### PR TITLE
Update alzMetricAlerts.html - Fixed spelling of Resources

### DIFF
--- a/docs/layouts/shortcodes/alzMetricAlerts.html
+++ b/docs/layouts/shortcodes/alzMetricAlerts.html
@@ -10,7 +10,7 @@
     <th>Frequency</th>
     <th>Severity</th>
     <th>Scope</th>
-    <th>Support for Multiple Resoruces</th>
+    <th>Support for Multiple Resources</th>
     <th>Verified</th>
     <th>References</th>
   </tr>


### PR DESCRIPTION
# Overview/Summary

Update alzMetricAlerts.html - Fixed spelling of Resources, on the Alerts Detail array.

## This PR fixes/adds/changes/removes

1. Replaced: <html>
Support for Multiple Resoruces
to:
Support for Multiple Resources

### Breaking Changes

N/A

## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
