### PR TITLE
Add missing '\' to the example commands in Start-AMBARemediation.ps1

### DIFF
--- a/patterns/alz/scripts/Start-AMBARemediation.ps1
+++ b/patterns/alz/scripts/Start-AMBARemediation.ps1
@@ -11,11 +11,11 @@ Examples:
   $connectivityManagementGroup = "The management group id for Connectivity"
   $LZManagementGroup="The management group id for Landing Zones"
   #Run the following commands to initiate remediation
-  .\patterns\alz\scriptsStart-AMBARemediation.ps1 -managementGroupName $managementManagementGroup -policyName Alerting-Management
-  .\patterns\alz\scriptsStart-AMBARemediation.ps1 -managementGroupName $connectivityManagementGroup -policyName Alerting-Connectivity
-  .\patterns\alz\scriptsStart-AMBARemediation.ps1 -managementGroupName $identityManagementGroup -policyName Alerting-Identity
-  .\patterns\alz\scriptsStart-AMBARemediation.ps1 -managementGroupName $LZManagementGroup -policyName Alerting-LandingZone
-  .\patterns\alz\scriptsStart-AMBARemediation.ps1 -managementGroupName $pseudoRootManagementGroup -policyName Alerting-ServiceHealth
+  .\patterns\alz\scripts\Start-AMBARemediation.ps1 -managementGroupName $managementManagementGroup -policyName Alerting-Management
+  .\patterns\alz\scripts\Start-AMBARemediation.ps1 -managementGroupName $connectivityManagementGroup -policyName Alerting-Connectivity
+  .\patterns\alz\scripts\Start-AMBARemediation.ps1 -managementGroupName $identityManagementGroup -policyName Alerting-Identity
+  .\patterns\alz\scripts\Start-AMBARemediation.ps1 -managementGroupName $LZManagementGroup -policyName Alerting-LandingZone
+  .\patterns\alz\scripts\Start-AMBARemediation.ps1 -managementGroupName $pseudoRootManagementGroup -policyName Alerting-ServiceHealth
 #>
 
 Param(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fix missing '\' in sample commands in Start-AMBARemediation.ps1 script.

## This PR fixes/adds/changes/removes

1. Start-AMBARemediation.ps1

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [ x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
