### PR TITLE
Fixing VSCode error with policies.json file

### DIFF
--- a/patterns/alz/alzArm.json
+++ b/patterns/alz/alzArm.json
@@ -152,7 +152,7 @@
         "policyAssignmentParametersLandingZone": "[union(parameters('policyAssignmentParametersCommon'), parameters('policyAssignmentParametersLandingZone'))]",
         "policyAssignmentParametersManagement": "[union(parameters('policyAssignmentParametersCommon'), parameters('policyAssignmentParametersManagement'))]",
         "policyAssignmentParametersServiceHealth": "[union(parameters('policyAssignmentParametersCommon'), parameters('policyAssignmentParametersServiceHealth'))]",
-        
+
         // Declaring all required deployment uri's used for deployments of composite ARM templates for ESLZ
         "deploymentUris": {
             "policyDefinitionsAMBA": "[uri(deployment().properties.templateLink.uri, 'policyDefinitions/policies.json')]",
@@ -162,7 +162,7 @@
             "AMBAManagementInitiative": "[uri(deployment().properties.templateLink.uri, 'policyAssignments/DINE-ManagementAssignment.json')]",
             "AMBAServiceHealthInitiative": "[uri(deployment().properties.templateLink.uri, 'policyAssignments/DINE-ServiceHealthAssignment.json')]"
         },
-        
+
         // Declaring deterministic deployment names
         "deploymentSuffix": "[concat('-', deployment().location, '-', guid(parameters('enterpriseScaleCompanyPrefix'), parameters('currentDateTimeUtcNow')))]",
         "deploymentNames": {
@@ -193,7 +193,7 @@
         {
             // Deploying AMBA custom policies. Note: all policies should eventually be moved to built-in policies and codebase will be reduced
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2019-10-01",
+            "apiVersion": "2020-10-01",
             "name": "[variables('deploymentNames').AMBAPolicyDeploymentName]",
             "location": "[deployment().location]",
             "scope": "[concat('Microsoft.Management/managementGroups/', parameters('enterpriseScaleCompanyPrefix'))]",

--- a/patterns/alz/policyDefinitions/policies.json
+++ b/patterns/alz/policyDefinitions/policies.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.19.5.34762",
-      "templateHash": "10767426305168551574"
+      "templateHash": "17811804002211668395"
     }
   },
   "parameters": {
@@ -3612,7 +3612,7 @@
         "policyDefinitions": [
           {
             "policyDefinitionReferenceId": "ALZ_ERCIRQoSDropBitsinPerSec",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_QosDropBitsInPerSecond_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_QosDropBitsInPerSecond_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('ERCIRQoSDropBitsinPerSecAlertSeverity')]"
@@ -3633,7 +3633,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_ERCIRQoSDropBitsoutPerSec",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_QosDropBitsOutPerSecond_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_QosDropBitsOutPerSecond_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('ERCIRQoSDropBitsoutPerSecAlertSeverity')]"
@@ -3654,7 +3654,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VPNGwBGPPeerStatus",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_BGPPeerStatus_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_BGPPeerStatus_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VPNGwBGPPeerStatusAlertSeverity')]"
@@ -3678,7 +3678,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VnetGwERCpuUtil",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_ExpressRouteCpuUtil_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_ExpressRouteCpuUtil_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VnetGwERCpuUtilAlertSeverity')]"
@@ -3702,7 +3702,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VnetGwTunnelBW",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelBandwidth_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelBandwidth_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VnetGwTunnelBWAlertSeverity')]"
@@ -3726,7 +3726,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VnetGwTunnelEgress",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelEgress_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelEgress_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VnetGwTunnelEgressAlertSeverity')]"
@@ -3750,7 +3750,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VnetGwTunnelIngress",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelIngress_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelIngress_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VnetGwTunnelIngressAlertSeverity')]"
@@ -3774,7 +3774,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VPNGWBandWidthUtil",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_BandwidthUtil_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_BandwidthUtil_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VPNGWBandWidthUtilAlertSeverity')]"
@@ -3798,7 +3798,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VPNGWEgress",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_Egress_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_Egress_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VPNGWEgressAlertSeverity')]"
@@ -3822,7 +3822,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VPNGWTunnelEgressPacketDropCount",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelEgressPacketDropCount_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelEgressPacketDropCount_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VPNGWTunnelEgressPacketDropCountAlertSeverity')]"
@@ -3843,7 +3843,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VPNGWTunnelEgressPacketDropMismatch",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelEgressPacketDropMismatch_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelEgressPacketDropMismatch_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VPNGWTunnelEgressPacketDropMismatchAlertSeverity')]"
@@ -3864,7 +3864,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VPNGWIngress",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_Ingress_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_Ingress_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VPNGWIngressAlertSeverity')]"
@@ -3891,7 +3891,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VPNGWTunnelIngressPacketDropCount",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelIngressPacketDropCount_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelIngressPacketDropCount_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VPNGWTunnelIngressPacketDropCountAlertSeverity')]"
@@ -3912,7 +3912,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VPNGWTunnelIngressPacketDropMismatch",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelIngressPacketDropMismatch_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelIngressPacketDropMismatch_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VPNGWTunnelIngressPacketDropMismatchAlertSeverity')]"
@@ -3933,7 +3933,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_PDNSZCapacityUtil",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PDNSZ_CapacityUtil_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PDNSZ_CapacityUtil_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('PDNSZCapacityUtilAlertSeverity')]"
@@ -3957,7 +3957,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_PDNSZQueryVolume",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PDNSZ_QueryVolume_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PDNSZ_QueryVolume_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('PDNSZQueryVolumeAlertSeverity')]"
@@ -3981,7 +3981,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_PDNSZRecordSetCapacity",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PDNSZ_RecordSetCapacity_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PDNSZ_RecordSetCapacity_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('PDNSZRecordSetCapacityAlertSeverity')]"
@@ -4005,7 +4005,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_PDNSZRegistrationCapacityUtil",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_DNSZ_RegistrationCapacityUtil_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_DNSZ_RegistrationCapacityUtil_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('PDNSZRegistrationCapacityUtilAlertSeverity')]"
@@ -4029,7 +4029,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_ERGwExpressRouteBitsIn",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERGw_ExpressRouteBitsIn_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERGw_ExpressRouteBitsIn_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('ERGwExpressRouteBitsInAlertSeverity')]"
@@ -4053,7 +4053,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_ERGwExpressRouteBitsOut",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERGw_ExpressRouteBitsOut_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERGw_ExpressRouteBitsOut_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('ERGwExpressRouteBitsOutAlertSeverity')]"
@@ -4077,7 +4077,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_ERGwExpressRouteCpuUtil",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERGw_ExpressRouteCpuUtil_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERGw_ExpressRouteCpuUtil_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('ERGwExpressRouteCpuUtilAlertSeverity')]"
@@ -4101,7 +4101,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VnetGwTunnelEgressPacketDropCount",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelEgressPacketDropCount_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelEgressPacketDropCount_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VnetGwTunnelEgressPacketDropCountAlertSeverity')]"
@@ -4122,7 +4122,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VnetGwTunnelEgressPacketDropMismatch",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelEgressPacketDropMismatch_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelEgressPacketDropMismatch_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VnetGwTunnelEgressPacketDropMismatchAlertSeverity')]"
@@ -4143,7 +4143,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VnetGwExpressRouteBitsPerSecond",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_ExpressRouteBitsPerSecond_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_ExpressRouteBitsPerSecond_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VnetGwExpressRouteBitsPerSecondAlertSeverity')]"
@@ -4167,7 +4167,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VnetGwTunnelIngressPacketDropMismatchWindowSize",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelIngressPacketDropMismatch_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelIngressPacketDropMismatch_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VnetGwTunnelIngressPacketDropMismatchAlertSeverity')]"
@@ -4188,7 +4188,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VnetGwTunnelIngressPacketDropCountWindowSize",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelIngressPacketDropCount_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelIngressPacketDropCount_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VnetGwTunnelIngressPacketDropCountAlertSeverity')]"
@@ -4209,7 +4209,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_ERCIRBgpAvailability",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_BgpAvailability_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_BgpAvailability_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('ERCIRBgpAvailabilityAlertSeverity')]"
@@ -4233,7 +4233,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_ERCIRArpAvailability",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_ArpAvailability_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_ArpAvailability_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('ERCIRArpAvailabilityAlertSeverity')]"
@@ -4257,7 +4257,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_AFWSNATPortUtilization",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AFW_SNATPortUtilization_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AFW_SNATPortUtilization_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('AFWSNATPortUtilizationAlertSeverity')]"
@@ -4281,7 +4281,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_PIPBytesInDDoSEvaluationFrequency",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_BytesInDDoSAttack_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_BytesInDDoSAttack_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('PIPBytesInDDoSAlertSeverity')]"
@@ -4305,7 +4305,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_PIPDDoSAttack",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_DDoSAttack_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_DDoSAttack_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('PIPDDoSAttackAlertSeverity')]"
@@ -4329,7 +4329,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_PIPPacketsInDDoS",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_PacketsInDDoSAttack_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_PacketsInDDoSAttack_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('PIPPacketsInDDoSAlertSeverity')]"
@@ -4353,7 +4353,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_PIPVIPAvailability",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_VIPAvailability_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_VIPAvailability_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('PIPVIPAvailabilityAlertSeverity')]"
@@ -4377,7 +4377,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VNETDDOSAttack",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VNET_DDoSAttack_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VNET_DDoSAttack_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VNETDDOSAttackAlertSeverity')]"
@@ -4401,7 +4401,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_FirewallHealth",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AFW_FirewallHealth_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AFW_FirewallHealth_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('FirewallHealthAlertSeverity')]"
@@ -4425,7 +4425,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_activityFWDelete",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_Firewall_Delete')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_Firewall_Delete')]",
             "parameters": {
               "enabled": {
                 "value": "[[[parameters('activityFWDeleteAlertState')]"
@@ -4443,7 +4443,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_activityNSGDelete",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_NSG_Delete')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_NSG_Delete')]",
             "parameters": {
               "enabled": {
                 "value": "[[[parameters('activityNSGDeleteAlertState')]"
@@ -4461,7 +4461,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_activityUDRUpdate",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_RouteTable_Update')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_RouteTable_Update')]",
             "parameters": {
               "enabled": {
                 "value": "[[[parameters('activityUDRUpdateAlertState')]"
@@ -4479,7 +4479,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_activityVPNGWDelete",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_VPNGateway_Delete')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_VPNGateway_Delete')]",
             "parameters": {
               "enabled": {
                 "value": "[[[parameters('activityVPNGWDeleteAlertState')]"
@@ -4497,7 +4497,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_LBDataPathAvailability",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_DataPathAvailability_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_DataPathAvailability_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('LBDataPathAvailabilityAlertSeverity')]"
@@ -4518,7 +4518,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_LBGlobalBackendAvailability",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_GlobalBackendAvailability_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_GlobalBackendAvailability_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('LBGlobalBackendAvailabilityAlertSeverity')]"
@@ -4539,7 +4539,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_LBHealthProbeStatus",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_HealthProbeStatus_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_HealthProbeStatus_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('LBHealthProbeStatusAlertSeverity')]"
@@ -4560,7 +4560,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_LBUsedSNATPorts",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_UsedSNATPorts_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_UsedSNATPorts_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('LBUsedSNATPortsAlertSeverity')]"
@@ -4581,7 +4581,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_ERPBitsInPerSecond",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRouteBitsIn_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRouteBitsIn_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('ERPBitsInPerSecondAlertSeverity')]"
@@ -4602,7 +4602,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_ERPBitsOutPerSecond",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRouteBitsOut_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRouteBitsOut_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('ERPBitsOutPerSecondAlertSeverity')]"
@@ -4623,7 +4623,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_ERPLineProtocol",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutLineProtocol_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutLineProtocol_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('ERPLineProtocolAlertSeverity')]"
@@ -4644,7 +4644,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_ERPRxLightLevelHigh",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutRxLightLevell_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutRxLightLevell_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('ERPRxLightLevelHighAlertSeverity')]"
@@ -4665,7 +4665,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_ERPRxLightLevelLow",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutRxLightLevellow_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutRxLightLevellow_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('ERPRxLightLevelLowAlertSeverity')]"
@@ -4686,7 +4686,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_ERPTxLightLevelHigh",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutTxLightLevell_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutTxLightLevell_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('ERPTxLightLevelHighAlertSeverity')]"
@@ -4707,7 +4707,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_ERPTxLightLevelLow",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutTxLightLevellow_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutTxLightLevellow_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('ERPTxLightLevelLowAlertSeverity')]"
@@ -4731,7 +4731,7 @@
         "policyDefinitionGroups": null
       }
     },
-    "$fxv#88": "{\r\n  \"type\": \"Microsoft.Authorization/policySetDefinitions\",\r\n  \"apiVersion\": \"2021-06-01\",\r\n  \"name\": \"Alerting-Identity\",\r\n  \"properties\": {\r\n    \"displayName\": \"Deploy Azure Monitor Baseline Alerts for Identity\",\r\n    \"description\": \"Initiative to deploy AMBA alerts relevant to the ALZ Identity management group\",\r\n    \"metadata\": {\r\n      \"version\": \"1.0.2\",\r\n      \"category\": \"Monitoring\",\r\n      \"source\": \"https://github.com/Azure/azure-monitor-baseline-alerts/\",\r\n      \"alzCloudEnvironments\": [\r\n        \"AzureCloud\"\r\n      ],\r\n      \"_deployed_by_amba\": true\r\n    },\r\n    \"parameters\": {\r\n      \"ALZMonitorResourceGroupName\": {\r\n        \"type\": \"String\",\r\n        \"defaultValue\": \"ALZ-Monitoring-RG\",\r\n        \"metadata\": {\r\n          \"displayName\": \"ALZ Monitor Resource Group Name\",\r\n          \"description\": \"Name of the resource group where the alerting resources will be deployed\"\r\n        }\r\n      },\r\n      \"ALZMonitorResourceGroupTags\": {\r\n        \"type\": \"Object\",\r\n        \"defaultValue\": {\r\n          \"_deployed_by_alz_monitor\": true\r\n        },\r\n        \"metadata\": {\r\n          \"displayName\": \"ALZ Monitor Resource Group Tags\",\r\n          \"description\": \"Tags for the resource group where the alerting resources will be deployed\"\r\n        }\r\n      },\r\n      \"ALZMonitorResourceGroupLocation\": {\r\n        \"type\": \"String\",\r\n        \"defaultValue\": \"centralus\",\r\n        \"metadata\": {\r\n          \"displayName\": \"ALZ Monitor Resource Group Location\",\r\n          \"description\": \"Location of the resource group where the alerting resources will be deployed\"\r\n        }\r\n      },\r\n      \"KVRequestAlertSeverity\": {\r\n        \"type\": \"String\",\r\n        \"defaultValue\": \"2\",\r\n        \"allowedValues\": [\r\n          \"0\",\r\n          \"1\",\r\n          \"2\",\r\n          \"3\",\r\n          \"4\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Request Alert Severity\",\r\n          \"description\": \"Severity of the alert\"\r\n        }\r\n      },\r\n      \"KVRequestWindowSize\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"PT5M\",\r\n        \"allowedValues\": [\r\n          \"PT1M\",\r\n          \"PT5M\",\r\n          \"PT15M\",\r\n          \"PT30M\",\r\n          \"PT1H\",\r\n          \"PT6H\",\r\n          \"PT12H\",\r\n          \"P1D\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Request Alert Window Size\",\r\n          \"description\": \"Window size for the alert\"\r\n        }\r\n      },\r\n      \"KVRequestEvaluationFrequency\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"PT5M\",\r\n        \"allowedValues\": [\r\n          \"PT1M\",\r\n          \"PT5M\",\r\n          \"PT15M\",\r\n          \"PT30M\",\r\n          \"PT1H\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Request Alert Evaluation Frequency\",\r\n          \"description\": \"Evaluation frequency for the alert\"\r\n        }\r\n      },\r\n      \"KVRequestPolicyEffect\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"disabled\",\r\n        \"allowedValues\": [\r\n          \"deployIfNotExists\",\r\n          \"disabled\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Request Alert Policy Effect\",\r\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist, disabled will not deploy the alert\"\r\n        }\r\n      },\r\n      \"KVRequestAlertState\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"true\",\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Request Alert State\",\r\n          \"description\": \"State of the alert, true will enable the alert, false will disable the alert\"\r\n        }\r\n      },\r\n      \"KvAvailabilityAlertSeverity\": {\r\n        \"type\": \"String\",\r\n        \"defaultValue\": \"1\",\r\n        \"allowedValues\": [\r\n          \"0\",\r\n          \"1\",\r\n          \"2\",\r\n          \"3\",\r\n          \"4\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Availability Alert Severity\",\r\n          \"description\": \"Severity of the alert\"\r\n        }\r\n      },\r\n      \"KvAvailabilityWindowSize\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"PT1M\",\r\n        \"allowedValues\": [\r\n          \"PT1M\",\r\n          \"PT5M\",\r\n          \"PT15M\",\r\n          \"PT30M\",\r\n          \"PT1H\",\r\n          \"PT6H\",\r\n          \"PT12H\",\r\n          \"P1D\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Availability Alert Window Size\",\r\n          \"description\": \"Window size for the alert\"\r\n        }\r\n      },\r\n      \"KvAvailabilityEvaluationFrequency\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"PT1M\",\r\n        \"allowedValues\": [\r\n          \"PT1M\",\r\n          \"PT5M\",\r\n          \"PT15M\",\r\n          \"PT30M\",\r\n          \"PT1H\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Availability Alert Evaluation Frequency\",\r\n          \"description\": \"Evaluation frequency for the alert\"\r\n        }\r\n      },\r\n      \"KvAvailabilityPolicyEffect\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"disabled\",\r\n        \"allowedValues\": [\r\n          \"deployIfNotExists\",\r\n          \"disabled\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Availability Alert Policy Effect\",\r\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist, disabled will not deploy the alert\"\r\n        }\r\n      },\r\n      \"KvAvailabilityAlertState\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"true\",\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Availability Alert State\",\r\n          \"description\": \"State of the alert, true will enable the alert, false will disable the alert\"\r\n        }\r\n      },\r\n      \"KVAvailabilityThreshold\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"20\",\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Availability Alert Threshold\",\r\n          \"description\": \"Threshold for the alert\"\r\n        }\r\n      },\r\n      \"KvLatencyAvailabilityAlertSeverity\": {\r\n        \"type\": \"String\",\r\n        \"defaultValue\": \"3\",\r\n        \"allowedValues\": [\r\n          \"0\",\r\n          \"1\",\r\n          \"2\",\r\n          \"3\",\r\n          \"4\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Latency Alert Severity\",\r\n          \"description\": \"Severity of the alert\"\r\n        }\r\n      },\r\n      \"KvLatencyAvailabilityWindowSize\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"PT5M\",\r\n        \"allowedValues\": [\r\n          \"PT1M\",\r\n          \"PT5M\",\r\n          \"PT15M\",\r\n          \"PT30M\",\r\n          \"PT1H\",\r\n          \"PT6H\",\r\n          \"PT12H\",\r\n          \"P1D\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Latency Alert Window Size\",\r\n          \"description\": \"Window size for the alert\"\r\n        }\r\n      },\r\n      \"KvLatencyAvailabilityEvaluationFrequency\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"PT5M\",\r\n        \"allowedValues\": [\r\n          \"PT1M\",\r\n          \"PT5M\",\r\n          \"PT15M\",\r\n          \"PT30M\",\r\n          \"PT1H\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Latency Alert Evaluation Frequency\",\r\n          \"description\": \"Evaluation frequency for the alert\"\r\n        }\r\n      },\r\n      \"KvLatencyAvailabilityPolicyEffect\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"disabled\",\r\n        \"allowedValues\": [\r\n          \"deployIfNotExists\",\r\n          \"disabled\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Latency Alert Policy Effect\",\r\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist, disabled will not deploy the alert\"\r\n        }\r\n      },\r\n      \"KvLatencyAvailabilityAlertState\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"true\",\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Latency Alert State\",\r\n          \"description\": \"State of the alert, true will enable the alert, false will disable the alert\"\r\n        }\r\n      },\r\n      \"KvLatencyAvailabilityThreshold\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"1000\",\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Latency Alert Threshold\",\r\n          \"description\": \"Threshold for the alert\"\r\n        }\r\n      },\r\n      \"KVCapacityAlertSeverity\": {\r\n        \"type\": \"String\",\r\n        \"defaultValue\": \"1\",\r\n        \"allowedValues\": [\r\n          \"0\",\r\n          \"1\",\r\n          \"2\",\r\n          \"3\",\r\n          \"4\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Capacity Alert Severity\",\r\n          \"description\": \"Severity of the alert\"\r\n        }\r\n      },\r\n      \"KVCapacityWindowSize\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"PT5M\",\r\n        \"allowedValues\": [\r\n          \"PT1M\",\r\n          \"PT5M\",\r\n          \"PT15M\",\r\n          \"PT30M\",\r\n          \"PT1H\",\r\n          \"PT6H\",\r\n          \"PT12H\",\r\n          \"P1D\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Capacity Alert Window Size\",\r\n          \"description\": \"Window size for the alert\"\r\n        }\r\n      },\r\n      \"KVCapacityEvaluationFrequency\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"PT1M\",\r\n        \"allowedValues\": [\r\n          \"PT1M\",\r\n          \"PT5M\",\r\n          \"PT15M\",\r\n          \"PT30M\",\r\n          \"PT1H\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Capacity Alert Evaluation Frequency\",\r\n          \"description\": \"Evaluation frequency for the alert\"\r\n        }\r\n      },\r\n      \"KVCapacityPolicyEffect\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"disabled\",\r\n        \"allowedValues\": [\r\n          \"deployIfNotExists\",\r\n          \"disabled\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Capacity Alert Policy Effect\",\r\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist, disabled will not deploy the alert\"\r\n        }\r\n      },\r\n      \"KVCapacityAlertState\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"true\",\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Capacity Alert State\",\r\n          \"description\": \"State of the alert, true will enable the alert, false will disable the alert\"\r\n        }\r\n      },\r\n      \"KVCapacityThreshold\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"75\",\r\n        \"metadata\": {\r\n          \"displayName\": \"KeyVault Capacity Alert Threshold\",\r\n          \"description\": \"Threshold for the alert\"\r\n        }\r\n      },\r\n      \"activityKVDeleteAlertState\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"true\",\r\n        \"metadata\": {\r\n          \"displayName\": \"Activity Log KeyVault Delete Alert State\",\r\n          \"description\": \"State of the alert, true will enable the alert, false will disable the alert\"\r\n        }\r\n      }\r\n    },\r\n    \"policyDefinitions\": [\r\n      {\r\n        \"policyDefinitionReferenceId\": \"ALZ_KVRequest\",\r\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Requests_Alert')]\",\r\n        \"parameters\": {\r\n          \"severity\": {\r\n            \"value\": \"[[parameters('KVRequestAlertSeverity')]\"\r\n          },\r\n          \"windowSize\": {\r\n            \"value\": \"[[parameters('KVRequestWindowSize')]\"\r\n          },\r\n          \"evaluationFrequency\": {\r\n            \"value\": \"[[parameters('KVRequestEvaluationFrequency')]\"\r\n          },\r\n          \"effect\": {\r\n            \"value\": \"[[parameters('KVRequestPolicyEffect')]\"\r\n          },\r\n          \"enabled\": {\r\n            \"value\": \"[[parameters('KVRequestAlertState')]\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"policyDefinitionReferenceId\": \"ALZ_KvAvailability\",\r\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Availability_Alert')]\",\r\n        \"parameters\": {\r\n          \"severity\": {\r\n            \"value\": \"[[parameters('KvAvailabilityAlertSeverity')]\"\r\n          },\r\n          \"windowSize\": {\r\n            \"value\": \"[[parameters('KvAvailabilityWindowSize')]\"\r\n          },\r\n          \"evaluationFrequency\": {\r\n            \"value\": \"[[parameters('KvAvailabilityEvaluationFrequency')]\"\r\n          },\r\n          \"effect\": {\r\n            \"value\": \"[[parameters('KvAvailabilityPolicyEffect')]\"\r\n          },\r\n          \"enabled\": {\r\n            \"value\": \"[[parameters('KvAvailabilityAlertState')]\"\r\n          },\r\n          \"threshold\": {\r\n            \"value\": \"[[parameters('KVAvailabilityThreshold')]\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"policyDefinitionReferenceId\": \"ALZ_KvLatencyAvailability\",\r\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Latency_Alert')]\",\r\n        \"parameters\": {\r\n          \"severity\": {\r\n            \"value\": \"[[parameters('KvLatencyAvailabilityAlertSeverity')]\"\r\n          },\r\n          \"windowSize\": {\r\n            \"value\": \"[[parameters('KvLatencyAvailabilityWindowSize')]\"\r\n          },\r\n          \"evaluationFrequency\": {\r\n            \"value\": \"[[parameters('KvLatencyAvailabilityEvaluationFrequency')]\"\r\n          },\r\n          \"effect\": {\r\n            \"value\": \"[[parameters('KvLatencyAvailabilityPolicyEffect')]\"\r\n          },\r\n          \"enabled\": {\r\n            \"value\": \"[[parameters('KvLatencyAvailabilityAlertState')]\"\r\n          },\r\n          \"threshold\": {\r\n            \"value\": \"[[parameters('KvLatencyAvailabilityThreshold')]\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"policyDefinitionReferenceId\": \"ALZ_KVCapacity\",\r\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Capacity_Alert')]\",\r\n        \"parameters\": {\r\n          \"severity\": {\r\n            \"value\": \"[[parameters('KVCapacityAlertSeverity')]\"\r\n          },\r\n          \"windowSize\": {\r\n            \"value\": \"[[parameters('KVCapacityWindowSize')]\"\r\n          },\r\n          \"evaluationFrequency\": {\r\n            \"value\": \"[[parameters('KVCapacityEvaluationFrequency')]\"\r\n          },\r\n          \"effect\": {\r\n            \"value\": \"[[parameters('KVCapacityPolicyEffect')]\"\r\n          },\r\n          \"enabled\": {\r\n            \"value\": \"[[parameters('KVCapacityAlertState')]\"\r\n          },\r\n          \"threshold\": {\r\n            \"value\": \"[[parameters('KVCapacityThreshold')]\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"policyDefinitionReferenceId\": \"ALZ_activityKVDelete\",\r\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_KeyVault_Delete')]\",\r\n        \"parameters\": {\r\n          \"enabled\": {\r\n            \"value\": \"[[parameters('activityKVDeleteAlertState')]\"\r\n          },\r\n          \"alertResourceGroupName\": {\r\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\r\n          },\r\n          \"alertResourceGroupTags\": {\r\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\r\n          },\r\n          \"alertResourceGroupLocation\": {\r\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"policyType\": \"Custom\",\r\n    \"policyDefinitionGroups\": null\r\n  }\r\n}\r\n",
+    "$fxv#88": "{\n  \"type\": \"Microsoft.Authorization/policySetDefinitions\",\n  \"apiVersion\": \"2021-06-01\",\n  \"name\": \"Alerting-Identity\",\n  \"properties\": {\n    \"displayName\": \"Deploy Azure Monitor Baseline Alerts for Identity\",\n    \"description\": \"Initiative to deploy AMBA alerts relevant to the ALZ Identity management group\",\n    \"metadata\": {\n      \"version\": \"1.0.2\",\n      \"category\": \"Monitoring\",\n      \"source\": \"https://github.com/Azure/azure-monitor-baseline-alerts/\",\n      \"alzCloudEnvironments\": [\n        \"AzureCloud\"\n      ],\n      \"_deployed_by_amba\": true\n    },\n    \"parameters\": {\n      \"ALZMonitorResourceGroupName\": {\n        \"type\": \"String\",\n        \"defaultValue\": \"ALZ-Monitoring-RG\",\n        \"metadata\": {\n          \"displayName\": \"ALZ Monitor Resource Group Name\",\n          \"description\": \"Name of the resource group where the alerting resources will be deployed\"\n        }\n      },\n      \"ALZMonitorResourceGroupTags\": {\n        \"type\": \"Object\",\n        \"defaultValue\": {\n          \"_deployed_by_alz_monitor\": true\n        },\n        \"metadata\": {\n          \"displayName\": \"ALZ Monitor Resource Group Tags\",\n          \"description\": \"Tags for the resource group where the alerting resources will be deployed\"\n        }\n      },\n      \"ALZMonitorResourceGroupLocation\": {\n        \"type\": \"String\",\n        \"defaultValue\": \"centralus\",\n        \"metadata\": {\n          \"displayName\": \"ALZ Monitor Resource Group Location\",\n          \"description\": \"Location of the resource group where the alerting resources will be deployed\"\n        }\n      },\n      \"KVRequestAlertSeverity\": {\n        \"type\": \"String\",\n        \"defaultValue\": \"2\",\n        \"allowedValues\": [\n          \"0\",\n          \"1\",\n          \"2\",\n          \"3\",\n          \"4\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Request Alert Severity\",\n          \"description\": \"Severity of the alert\"\n        }\n      },\n      \"KVRequestWindowSize\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"PT5M\",\n        \"allowedValues\": [\n          \"PT1M\",\n          \"PT5M\",\n          \"PT15M\",\n          \"PT30M\",\n          \"PT1H\",\n          \"PT6H\",\n          \"PT12H\",\n          \"P1D\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Request Alert Window Size\",\n          \"description\": \"Window size for the alert\"\n        }\n      },\n      \"KVRequestEvaluationFrequency\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"PT5M\",\n        \"allowedValues\": [\n          \"PT1M\",\n          \"PT5M\",\n          \"PT15M\",\n          \"PT30M\",\n          \"PT1H\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Request Alert Evaluation Frequency\",\n          \"description\": \"Evaluation frequency for the alert\"\n        }\n      },\n      \"KVRequestPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"disabled\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Request Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist, disabled will not deploy the alert\"\n        }\n      },\n      \"KVRequestAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"KeyVault Request Alert State\",\n          \"description\": \"State of the alert, true will enable the alert, false will disable the alert\"\n        }\n      },\n      \"KvAvailabilityAlertSeverity\": {\n        \"type\": \"String\",\n        \"defaultValue\": \"1\",\n        \"allowedValues\": [\n          \"0\",\n          \"1\",\n          \"2\",\n          \"3\",\n          \"4\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Availability Alert Severity\",\n          \"description\": \"Severity of the alert\"\n        }\n      },\n      \"KvAvailabilityWindowSize\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"PT1M\",\n        \"allowedValues\": [\n          \"PT1M\",\n          \"PT5M\",\n          \"PT15M\",\n          \"PT30M\",\n          \"PT1H\",\n          \"PT6H\",\n          \"PT12H\",\n          \"P1D\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Availability Alert Window Size\",\n          \"description\": \"Window size for the alert\"\n        }\n      },\n      \"KvAvailabilityEvaluationFrequency\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"PT1M\",\n        \"allowedValues\": [\n          \"PT1M\",\n          \"PT5M\",\n          \"PT15M\",\n          \"PT30M\",\n          \"PT1H\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Availability Alert Evaluation Frequency\",\n          \"description\": \"Evaluation frequency for the alert\"\n        }\n      },\n      \"KvAvailabilityPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"disabled\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Availability Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist, disabled will not deploy the alert\"\n        }\n      },\n      \"KvAvailabilityAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"KeyVault Availability Alert State\",\n          \"description\": \"State of the alert, true will enable the alert, false will disable the alert\"\n        }\n      },\n      \"KVAvailabilityThreshold\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"20\",\n        \"metadata\": {\n          \"displayName\": \"KeyVault Availability Alert Threshold\",\n          \"description\": \"Threshold for the alert\"\n        }\n      },\n      \"KvLatencyAvailabilityAlertSeverity\": {\n        \"type\": \"String\",\n        \"defaultValue\": \"3\",\n        \"allowedValues\": [\n          \"0\",\n          \"1\",\n          \"2\",\n          \"3\",\n          \"4\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Latency Alert Severity\",\n          \"description\": \"Severity of the alert\"\n        }\n      },\n      \"KvLatencyAvailabilityWindowSize\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"PT5M\",\n        \"allowedValues\": [\n          \"PT1M\",\n          \"PT5M\",\n          \"PT15M\",\n          \"PT30M\",\n          \"PT1H\",\n          \"PT6H\",\n          \"PT12H\",\n          \"P1D\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Latency Alert Window Size\",\n          \"description\": \"Window size for the alert\"\n        }\n      },\n      \"KvLatencyAvailabilityEvaluationFrequency\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"PT5M\",\n        \"allowedValues\": [\n          \"PT1M\",\n          \"PT5M\",\n          \"PT15M\",\n          \"PT30M\",\n          \"PT1H\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Latency Alert Evaluation Frequency\",\n          \"description\": \"Evaluation frequency for the alert\"\n        }\n      },\n      \"KvLatencyAvailabilityPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"disabled\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Latency Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist, disabled will not deploy the alert\"\n        }\n      },\n      \"KvLatencyAvailabilityAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"KeyVault Latency Alert State\",\n          \"description\": \"State of the alert, true will enable the alert, false will disable the alert\"\n        }\n      },\n      \"KvLatencyAvailabilityThreshold\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"1000\",\n        \"metadata\": {\n          \"displayName\": \"KeyVault Latency Alert Threshold\",\n          \"description\": \"Threshold for the alert\"\n        }\n      },\n      \"KVCapacityAlertSeverity\": {\n        \"type\": \"String\",\n        \"defaultValue\": \"1\",\n        \"allowedValues\": [\n          \"0\",\n          \"1\",\n          \"2\",\n          \"3\",\n          \"4\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Capacity Alert Severity\",\n          \"description\": \"Severity of the alert\"\n        }\n      },\n      \"KVCapacityWindowSize\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"PT5M\",\n        \"allowedValues\": [\n          \"PT1M\",\n          \"PT5M\",\n          \"PT15M\",\n          \"PT30M\",\n          \"PT1H\",\n          \"PT6H\",\n          \"PT12H\",\n          \"P1D\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Capacity Alert Window Size\",\n          \"description\": \"Window size for the alert\"\n        }\n      },\n      \"KVCapacityEvaluationFrequency\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"PT1M\",\n        \"allowedValues\": [\n          \"PT1M\",\n          \"PT5M\",\n          \"PT15M\",\n          \"PT30M\",\n          \"PT1H\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Capacity Alert Evaluation Frequency\",\n          \"description\": \"Evaluation frequency for the alert\"\n        }\n      },\n      \"KVCapacityPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"disabled\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"KeyVault Capacity Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist, disabled will not deploy the alert\"\n        }\n      },\n      \"KVCapacityAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"KeyVault Capacity Alert State\",\n          \"description\": \"State of the alert, true will enable the alert, false will disable the alert\"\n        }\n      },\n      \"KVCapacityThreshold\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"75\",\n        \"metadata\": {\n          \"displayName\": \"KeyVault Capacity Alert Threshold\",\n          \"description\": \"Threshold for the alert\"\n        }\n      },\n      \"activityKVDeleteAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"Activity Log KeyVault Delete Alert State\",\n          \"description\": \"State of the alert, true will enable the alert, false will disable the alert\"\n        }\n      }\n    },\n    \"policyDefinitions\": [\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_KVRequest\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Requests_Alert')]\",\n        \"parameters\": {\n          \"severity\": {\n            \"value\": \"[[parameters('KVRequestAlertSeverity')]\"\n          },\n          \"windowSize\": {\n            \"value\": \"[[parameters('KVRequestWindowSize')]\"\n          },\n          \"evaluationFrequency\": {\n            \"value\": \"[[parameters('KVRequestEvaluationFrequency')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('KVRequestPolicyEffect')]\"\n          },\n          \"enabled\": {\n            \"value\": \"[[parameters('KVRequestAlertState')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_KvAvailability\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Availability_Alert')]\",\n        \"parameters\": {\n          \"severity\": {\n            \"value\": \"[[parameters('KvAvailabilityAlertSeverity')]\"\n          },\n          \"windowSize\": {\n            \"value\": \"[[parameters('KvAvailabilityWindowSize')]\"\n          },\n          \"evaluationFrequency\": {\n            \"value\": \"[[parameters('KvAvailabilityEvaluationFrequency')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('KvAvailabilityPolicyEffect')]\"\n          },\n          \"enabled\": {\n            \"value\": \"[[parameters('KvAvailabilityAlertState')]\"\n          },\n          \"threshold\": {\n            \"value\": \"[[parameters('KVAvailabilityThreshold')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_KvLatencyAvailability\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Latency_Alert')]\",\n        \"parameters\": {\n          \"severity\": {\n            \"value\": \"[[parameters('KvLatencyAvailabilityAlertSeverity')]\"\n          },\n          \"windowSize\": {\n            \"value\": \"[[parameters('KvLatencyAvailabilityWindowSize')]\"\n          },\n          \"evaluationFrequency\": {\n            \"value\": \"[[parameters('KvLatencyAvailabilityEvaluationFrequency')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('KvLatencyAvailabilityPolicyEffect')]\"\n          },\n          \"enabled\": {\n            \"value\": \"[[parameters('KvLatencyAvailabilityAlertState')]\"\n          },\n          \"threshold\": {\n            \"value\": \"[[parameters('KvLatencyAvailabilityThreshold')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_KVCapacity\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Capacity_Alert')]\",\n        \"parameters\": {\n          \"severity\": {\n            \"value\": \"[[parameters('KVCapacityAlertSeverity')]\"\n          },\n          \"windowSize\": {\n            \"value\": \"[[parameters('KVCapacityWindowSize')]\"\n          },\n          \"evaluationFrequency\": {\n            \"value\": \"[[parameters('KVCapacityEvaluationFrequency')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('KVCapacityPolicyEffect')]\"\n          },\n          \"enabled\": {\n            \"value\": \"[[parameters('KVCapacityAlertState')]\"\n          },\n          \"threshold\": {\n            \"value\": \"[[parameters('KVCapacityThreshold')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_activityKVDelete\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_KeyVault_Delete')]\",\n        \"parameters\": {\n          \"enabled\": {\n            \"value\": \"[[parameters('activityKVDeleteAlertState')]\"\n          },\n          \"alertResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"alertResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"alertResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          }\n        }\n      }\n    ],\n    \"policyType\": \"Custom\",\n    \"policyDefinitionGroups\": null\n  }\n}\n",
     "$fxv#89": {
       "type": "Microsoft.Authorization/policySetDefinitions",
       "apiVersion": "2021-06-01",
@@ -8095,7 +8095,7 @@
         "policyDefinitions": [
           {
             "policyDefinitionReferenceId": "ALZ_KVRequest",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Requests_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Requests_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('KVRequestAlertSeverity')]"
@@ -8116,7 +8116,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_KvAvailability",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Availability_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Availability_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('KvAvailabilityAlertSeverity')]"
@@ -8140,7 +8140,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_KvLatencyAvailability",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Latency_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Latency_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('KvLatencyAvailabilityAlertSeverity')]"
@@ -8164,7 +8164,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_KVCapacity",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Capacity_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Capacity_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('KVCapacityAlertSeverity')]"
@@ -8188,7 +8188,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_activityKVDelete",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_KeyVault_Delete')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_KeyVault_Delete')]",
             "parameters": {
               "enabled": {
                 "value": "[[[parameters('activityKVDeleteAlertState')]"
@@ -8206,7 +8206,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_StorageAccountAvailability",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_StorageAccount_Availability_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_StorageAccount_Availability_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('StorageAccountAvailabilityAlertSeverity')]"
@@ -8230,7 +8230,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_PIPBytesInDDoS",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_BytesInDDoSAttack_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_BytesInDDoSAttack_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('PIPBytesInDDoSAlertSeverity')]"
@@ -8254,7 +8254,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_PIPDDoSAttack",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_DDoSAttack_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_DDoSAttack_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('PIPDDoSAttackAlertSeverity')]"
@@ -8278,7 +8278,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_PIPPacketsInDDoS",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_PacketsInDDoSAttack_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_PacketsInDDoSAttack_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('PIPPacketsInDDoSAlertSeverity')]"
@@ -8302,7 +8302,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_PIPVIPAvailability",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_VIPAvailability_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_VIPAvailability_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('PIPVIPAvailabilityAlertSeverity')]"
@@ -8326,7 +8326,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_activityNSGDelete",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_NSG_Delete')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_NSG_Delete')]",
             "parameters": {
               "enabled": {
                 "value": "[[[parameters('activityNSGDeleteAlertState')]"
@@ -8344,7 +8344,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_activityUDRUpdate",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_RouteTable_Update')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_RouteTable_Update')]",
             "parameters": {
               "enabled": {
                 "value": "[[[parameters('activityUDRUpdateAlertState')]"
@@ -8362,7 +8362,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_RVBackupHealthMonitor",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_RecoveryVault_BackupHealthMonitor_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_RecoveryVault_BackupHealthMonitor_Alert')]",
             "parameters": {
               "effect": {
                 "value": "[[[parameters('RVBackupHealthMonitorPolicyEffect')]"
@@ -8371,7 +8371,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VNETDDOSAttack",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VNET_DDoSAttack_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VNET_DDoSAttack_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VNETDDOSAttackAlertSeverity')]"
@@ -8395,7 +8395,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VMHeartBeatRG",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_HeartBeat_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_HeartBeat_Alert')]",
             "parameters": {
               "alertResourceGroupName": {
                 "value": "[[[parameters('ALZMonitorResourceGroupName')]"
@@ -8443,7 +8443,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VMNetworkIn",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_NetworkIn_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_NetworkIn_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VMNetworkInAlertSeverity')]"
@@ -8503,7 +8503,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VMNetworkOut",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_NetworkOut_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_NetworkOut_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VMNetworkOutAlertSeverity')]"
@@ -8563,7 +8563,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VMOSDiskReadLatency",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_OSDiskreadLatency_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_OSDiskreadLatency_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VMOSDiskReadLatencyAlertSeverity')]"
@@ -8623,7 +8623,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VMOSDiskWriteLatency",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_OSDiskwriteLatency_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_OSDiskwriteLatency_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VMOSDiskWriteLatencyAlertSeverity')]"
@@ -8683,7 +8683,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VMOSDiskSpace",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_OSDiskSpace_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_OSDiskSpace_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VMOSDiskSpaceAlertSeverity')]"
@@ -8743,7 +8743,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VMPercentCPU",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_CPU_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_CPU_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VMPercentCPUAlertSeverity')]"
@@ -8791,7 +8791,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VMPercentMemory",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_Memory_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_Memory_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VMPercentMemoryAlertSeverity')]"
@@ -8839,7 +8839,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VMDataDiskSpace",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_dataDiskSpace_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_dataDiskSpace_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VMDataDiskSpaceAlertSeverity')]"
@@ -8896,7 +8896,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VMDataDiskReadLatency",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_dataDiskReadLatency_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_dataDiskReadLatency_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VMDataDiskReadLatencyAlertSeverity')]"
@@ -8956,7 +8956,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_VMDataDiskWriteLatency",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_dataDiskWriteLatency_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_dataDiskWriteLatency_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('VMDataDiskWriteLatencyAlertSeverity')]"
@@ -9016,7 +9016,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_AGWTotalTime",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_ApplicationGatewayTotalTime_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_ApplicationGatewayTotalTime_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('AGWApplicationGatewayTotalTimeAlertSeverity')]"
@@ -9037,7 +9037,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_AGWBackendLastByteResponseTime",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_BackendLastByteResponseTime_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_BackendLastByteResponseTime_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('AGWBackendLastByteResponseTimeAlertSeverity')]"
@@ -9058,7 +9058,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_AGWCapacityUnits",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_CapacityUnits_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_CapacityUnits_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('AGWCapacityUnitsAlertSeverity')]"
@@ -9079,7 +9079,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_AGWComputeUnits",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_ComputeUnits_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_ComputeUnits_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('AGWComputeUnitsAlertSeverity')]"
@@ -9100,7 +9100,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_AGWCPUUtilization",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_CPUUtilization_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_CPUUtilization_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('AGWCPUUtilAlertSeverity')]"
@@ -9121,7 +9121,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_AGWFailedRequests",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_FailedRequests_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_FailedRequests_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('AGWFailedRequestsAlertSeverity')]"
@@ -9142,7 +9142,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_AGWResponseStatus",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_ResponseStatus_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_ResponseStatus_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('AGWResponseStatusAlertSeverity')]"
@@ -9163,7 +9163,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_AGWUnhealthyHostCount",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_UnhealthyHostCount_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_UnhealthyHostCount_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('AGWUnhealthyHostCountAlertSeverity')]"
@@ -9184,7 +9184,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_LBDataPathAvailability",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_DataPathAvailability_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_DataPathAvailability_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('LBDataPathAvailabilityAlertSeverity')]"
@@ -9205,7 +9205,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_LBGlobalBackendAvailability",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_GlobalBackendAvailability_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_GlobalBackendAvailability_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('LBGlobalBackendAvailabilityAlertSeverity')]"
@@ -9226,7 +9226,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_LBHealthProbeStatus",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_HealthProbeStatus_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_HealthProbeStatus_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('LBHealthProbeStatusAlertSeverity')]"
@@ -9247,7 +9247,7 @@
           },
           {
             "policyDefinitionReferenceId": "ALZ_LBUsedSNATPorts",
-            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_UsedSNATPorts_Alert')]",
+            "policyDefinitionId": "[[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_UsedSNATPorts_Alert')]",
             "parameters": {
               "severity": {
                 "value": "[[[parameters('LBUsedSNATPortsAlertSeverity')]"
@@ -9272,8 +9272,8 @@
       }
     },
     "$fxv#9": "{\n  \"type\": \"Microsoft.Authorization/policyDefinitions\",\n  \"apiVersion\": \"2021-06-01\",\n  \"name\": \"Deploy_activitylog_ServiceHealth_Incident\",\n  \"properties\": {\n    \"policyType\": \"Custom\",\n    \"mode\": \"All\",\n    \"displayName\": \"Deploy Service Health Incident Alert\",\n    \"description\": \"Policy to Deploy Service Health Incident Alert\",\n    \"metadata\": {\n      \"version\": \"1.1.2\",\n      \"category\": \"Monitoring\",\n      \"source\": \"https://github.com/Azure/azure-monitor-baseline-alerts/\",\n      \"alzCloudEnvironments\": [\n        \"AzureCloud\"\n      ],\n      \"_deployed_by_amba\": \"True\"\n    },\n    \"parameters\": {\n      \"enabled\": {\n        \"type\": \"String\",\n        \"metadata\": {\n          \"displayName\": \"Alert State\",\n          \"description\": \"Alert state for the alert\"\n        },\n        \"allowedValues\": [\n          \"true\",\n          \"false\"\n        ],\n        \"defaultValue\": \"true\"\n      },\n      \"alertResourceGroupName\": {\n        \"type\": \"String\",\n        \"metadata\": {\n          \"displayName\": \"Resource Group Name\",\n          \"description\": \"Resource group the alert is placed in\"\n        },\n        \"defaultValue\": \"rg-amba-monitoring-001\"\n      },\n      \"alertResourceGroupTags\": {\n        \"type\": \"Object\",\n        \"metadata\": {\n          \"displayName\": \"Resource Group Tags\",\n          \"description\": \"Tags on the Resource group the alert is placed in\"\n        },\n        \"defaultValue\": {\n          \"_deployed_by_amba\": true\n        }\n      },\n      \"alertResourceGroupLocation\": {\n        \"type\": \"String\",\n        \"metadata\": {\n          \"displayName\": \"Resource Group Location\",\n          \"description\": \"Location of the Resource group the alert is placed in\"\n        },\n        \"defaultValue\": \"centralus\"\n      },\n      \"ALZMonitorActionGroupEmail\": {\n        \"type\": \"String\",\n        \"metadata\": {\n          \"displayName\": \"Action Group Email\",\n          \"description\": \"Email address to send alerts to\"\n        },\n        \"defaultValue\": \"action@mail.com\"\n      },\n      \"effect\": {\n        \"type\": \"String\",\n        \"metadata\": {\n          \"displayName\": \"Effect\",\n          \"description\": \"Effect of the policy\"\n        },\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"defaultValue\": \"disabled\"\n      },\n      \"MonitorDisable\": {\n        \"type\": \"String\",\n        \"metadata\": {\n          \"displayName\": \"Effect\",\n          \"description\": \"Tag name to disable monitoring  Subscription level alerts. Set to true if monitoring should be disabled\"\n        },\n        \"defaultValue\": \"MonitorDisable\"\n      }\n    },\n    \"policyRule\": {\n      \"if\": {\n        \"allOf\": [\n          {\n            \"field\": \"type\",\n            \"equals\": \"Microsoft.Resources/subscriptions\"\n          },\n          {\n            \"field\": \"[[concat('tags[', parameters('MonitorDisable'), ']')]\",\n            \"notEquals\": \"true\"\n          }\n        ]\n      },\n      \"then\": {\n        \"effect\": \"[[parameters('effect')]\",\n        \"details\": {\n          \"roleDefinitionIds\": [\n            \"/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c\"\n          ],\n          \"type\": \"Microsoft.Insights/activityLogAlerts\",\n          \"existenceScope\": \"resourcegroup\",\n          \"resourceGroupName\": \"[[parameters('alertResourceGroupName')]\",\n          \"deploymentScope\": \"subscription\",\n          \"existenceCondition\": {\n            \"allOf\": [\n              {\n                \"field\": \"Microsoft.Insights/ActivityLogAlerts/enabled\",\n                \"equals\": \"[[parameters('enabled')]\"\n              },\n              {\n                \"count\": {\n                  \"field\": \"Microsoft.Insights/ActivityLogAlerts/condition.allOf[*]\",\n                  \"where\": {\n                    \"anyOf\": [\n                      {\n                        \"allOf\": [\n                          {\n                            \"field\": \"Microsoft.Insights/ActivityLogAlerts/condition.allOf[*].field\",\n                            \"equals\": \"category\"\n                          },\n                          {\n                            \"field\": \"Microsoft.Insights/ActivityLogAlerts/condition.allOf[*].equals\",\n                            \"equals\": \"ServiceHealth\"\n                          }\n                        ]\n                      },\n                      {\n                        \"allOf\": [\n                          {\n                            \"field\": \"microsoft.insights/activityLogAlerts/condition.allOf[*].field\",\n                            \"equals\": \"properties.incidentType\"\n                          },\n                          {\n                            \"field\": \"microsoft.insights/activityLogAlerts/condition.allOf[*].equals\",\n                            \"equals\": \"Incident\"\n                          }\n                        ]\n                      }\n                    ]\n                  }\n                },\n                \"equals\": 2\n              }\n            ]\n          },\n          \"deployment\": {\n            \"location\": \"northeurope\",\n            \"properties\": {\n              \"mode\": \"incremental\",\n              \"template\": {\n                \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                \"contentVersion\": \"1.0.0.0\",\n                \"parameters\": {\n                  \"alertResourceGroupName\": {\n                    \"type\": \"string\"\n                  },\n                  \"alertResourceGroupTags\": {\n                    \"type\": \"object\"\n                  },\n                  \"alertResourceGroupLocation\": {\n                    \"type\": \"string\"\n                  },\n                  \"ALZMonitorActionGroupEmail\": {\n                    \"type\": \"string\"\n                  },\n                  \"enabled\": {\n                    \"type\": \"string\"\n                  }\n                },\n                \"variables\": {\n                    \"varALZMonitorActionGroupEmail\": \"[[array(split(parameters('ALZMonitorActionGroupEmail'),','))]\"\n                },\n                \"resources\": [\n                  {\n                    \"type\": \"Microsoft.Resources/resourceGroups\",\n                    \"apiVersion\": \"2021-04-01\",\n                    \"name\": \"[[parameters('alertResourceGroupName')]\",\n                    \"location\": \"[[parameters('alertResourceGroupLocation')]\",\n                    \"tags\": \"[[parameters('alertResourceGroupTags')]\"\n                  },\n                  {\n                    \"type\": \"Microsoft.Resources/deployments\",\n                    \"apiVersion\": \"2019-10-01\",\n                    \"name\": \"ServiceHealthIncident\",\n                    \"resourceGroup\": \"[[parameters('alertResourceGroupName')]\",\n                    \"dependsOn\": [\n                      \"[[concat('Microsoft.Resources/resourceGroups/', parameters('alertResourceGroupName'))]\"\n                    ],\n                    \"properties\": {\n                      \"mode\": \"Incremental\",\n                      \"template\": {\n                        \"$schema\": \"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                        \"contentVersion\": \"1.0.0.0\",\n                        \"parameters\": {\n                          \"enabled\": {\n                            \"type\": \"string\"\n                          },\n                          \"alertResourceGroupName\": {\n                            \"type\": \"string\"\n                          },\n                          \"ALZMonitorActionGroupEmail\": {\n                            \"type\": \"string\"\n                          }\n                        },\n                        \"variables\": {},\n                        \"resources\": [\n                          {\n                            \"type\": \"microsoft.insights/activityLogAlerts\",\n                            \"apiVersion\": \"2020-10-01\",\n                            \"name\": \"ServiceHealthIncident\",\n                            \"location\": \"global\",\n                            \"dependsOn\": [\n                              \"[[concat(subscription().Id, '/resourceGroups/', parameters('alertResourceGroupName'), '/providers/Microsoft.Insights/actionGroups/AmbaActionGr')]\"\n                            ],\n                            \"tags\": {\n                              \"_deployed_by_amba\": true\n                            },\n                            \"properties\": {\n                              \"actions\": {\n                                \"actionGroups\": [\n                                  {\n                                    \"actionGroupId\": \"[[concat(subscription().Id, '/resourceGroups/', parameters('alertResourceGroupName'), '/providers/Microsoft.Insights/actionGroups/AmbaActionGr')]\"\n                                  }\n                                ]\n                              },\n                              \"description\": \"ServiceHealthIncidentAlert\",\n                              \"enabled\": \"[[parameters('enabled')]\",\n                              \"scopes\": [\n                                \"[[subscription().id]\"\n                              ],\n                              \"condition\": {\n                                \"allOf\": [\n                                  {\n                                    \"field\": \"category\",\n                                    \"equals\": \"ServiceHealth\"\n                                  },\n                                  {\n                                    \"field\": \"properties.incidentType\",\n                                    \"equals\": \"Incident\"\n                                  }\n                                ]\n                              },\n                              \"parameters\": {\n                                \"enabled\": {\n                                  \"value\": \"[[parameters('enabled')]\"\n                                }\n                              }\n                            }\n                          },\n                          {\n                            \"type\": \"Microsoft.Insights/actionGroups\",\n                            \"apiVersion\": \"2022-06-01\",\n                            \"name\": \"AmbaActionGr\",\n                            \"location\": \"global\",\n                            \"tags\": {\n                                \"_deployed_by_amba\": true\n                              },\n                            \"properties\": {\n                                \"groupShortName\": \"AmbaActionGr\",\n                                \"enabled\": true,\n                                \"copy\": [\n                                    {\n                                        \"name\": \"emailReceivers\",\n                                        \"count\": \"[[length(variables('varALZMonitorActionGroupEmail'))]\",\n                                        \"mode\": \"serial\",\n                                        \"input\": {\n                                            \"name\": \"[[concat('AlzMail-', indexOf(variables('varALZMonitorActionGroupEmail'), variables('varALZMonitorActionGroupEmail')[copyIndex('emailReceivers')]))]\",\n                                            \"emailAddress\": \"[[trim(variables('varALZMonitorActionGroupEmail')[copyIndex('emailReceivers')])]\",\n                                            \"useCommonSchema\": true\n                                        }\n                                    }\n                                ]\n                            }\n                          }\n                        ]\n                      },\n                      \"parameters\": {\n                        \"enabled\": {\n                          \"value\": \"[[parameters('enabled')]\"\n                        },\n                        \"alertResourceGroupName\": {\n                          \"value\": \"[[parameters('alertResourceGroupName')]\"\n                        },\n                        \"ALZMonitorActionGroupEmail\": {\n                          \"value\": \"[[parameters('ALZMonitorActionGroupEmail')]\"\n                        }\n                      }\n                    }\n                  }\n                ]\n              },\n              \"parameters\": {\n                \"enabled\": {\n                  \"value\": \"[[parameters('enabled')]\"\n                },\n                \"alertResourceGroupName\": {\n                  \"value\": \"[[parameters('alertResourceGroupName')]\"\n                },\n                \"alertResourceGroupTags\": {\n                  \"value\": \"[[parameters('alertResourceGroupTags')]\"\n                },\n                \"alertResourceGroupLocation\": {\n                  \"value\": \"[[parameters('alertResourceGroupLocation')]\"\n                },\n                \"ALZMonitorActionGroupEmail\": {\n                  \"value\": \"[[parameters('ALZMonitorActionGroupEmail')]\"\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n",
-    "$fxv#90": "{\r\n  \"type\": \"Microsoft.Authorization/policySetDefinitions\",\r\n  \"apiVersion\": \"2021-06-01\",\r\n  \"name\": \"Alerting-Management\",\r\n  \"properties\": {\r\n    \"displayName\": \"Deploy Azure Monitor Baseline Alerts for Management\",\r\n    \"description\": \"Initiative to deploy AMBA alerts relevant to the ALZ Management management group\",\r\n    \"metadata\": {\r\n      \"version\": \"1.0.2\",\r\n      \"category\": \"Monitoring\",\r\n      \"source\": \"https://github.com/Azure/azure-monitor-baseline-alerts/\",\r\n      \"alzCloudEnvironments\": [\r\n        \"AzureCloud\"\r\n      ],\r\n      \"_deployed_by_amba\": true\r\n    },\r\n    \"parameters\": {\r\n      \"ALZMonitorResourceGroupName\": {\r\n        \"type\": \"String\",\r\n        \"defaultValue\": \"ALZ-Monitoring-RG\",\r\n        \"metadata\": {\r\n          \"displayName\": \"ALZ Monitoring Resource Group Name\",\r\n          \"description\": \"Name of the resource group to deploy the ALZ monitoring resources to\"\r\n        }\r\n      },\r\n      \"ALZMonitorResourceGroupTags\": {\r\n        \"type\": \"Object\",\r\n        \"defaultValue\": {\r\n          \"_deployed_by_alz_monitor\": true\r\n        },\r\n        \"metadata\": {\r\n          \"displayName\": \"ALZ Monitoring Resource Group Tags\",\r\n          \"description\": \"Tags to apply to the resource group\"\r\n        }\r\n      },\r\n      \"ALZMonitorResourceGroupLocation\": {\r\n        \"type\": \"String\",\r\n        \"defaultValue\": \"centralus\",\r\n        \"metadata\": {\r\n          \"displayName\": \"ALZ Monitoring Resource Group Location\",\r\n          \"description\": \"Location of the resource group\"\r\n        }\r\n      },\r\n      \"AATotalJobAlertSeverity\": {\r\n        \"type\": \"String\",\r\n        \"defaultValue\": \"2\",\r\n        \"allowedValues\": [\r\n          \"0\",\r\n          \"1\",\r\n          \"2\",\r\n          \"3\",\r\n          \"4\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"AA Total Job Alert Severity\",\r\n          \"description\": \"Severity of the alert\"\r\n        }\r\n      },\r\n      \"AATotalJobAlertWindowSize\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"PT5M\",\r\n        \"allowedValues\": [\r\n          \"PT1M\",\r\n          \"PT5M\",\r\n          \"PT15M\",\r\n          \"PT30M\",\r\n          \"PT1H\",\r\n          \"PT6H\",\r\n          \"PT12H\",\r\n          \"P1D\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"AA Total Job Alert Window Size\",\r\n          \"description\": \"Window size for the alert\"\r\n        }\r\n      },\r\n      \"AATotalJobAlertEvaluationFrequency\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"PT1M\",\r\n        \"allowedValues\": [\r\n          \"PT1M\",\r\n          \"PT5M\",\r\n          \"PT15M\",\r\n          \"PT30M\",\r\n          \"PT1H\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"AA Total Job Alert Evaluation Frequency\",\r\n          \"description\": \"Evaluation frequency for the alert\"\r\n        }\r\n      },\r\n      \"AATotalJobAlertPolicyEffect\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"deployIfNotExists\",\r\n        \"allowedValues\": [\r\n          \"deployIfNotExists\",\r\n          \"disabled\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"AA Total Job Alert Policy Effect\",\r\n          \"description\": \"Policy effect for the alert\"\r\n        }\r\n      },\r\n      \"AATotalJobAlertAlertState\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"true\",\r\n        \"metadata\": {\r\n          \"displayName\": \"AA Total Job Alert State\",\r\n          \"description\": \"Alert state for the alert\"\r\n        }\r\n      },\r\n      \"AATotalJobAlertThreshold\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"20\",\r\n        \"metadata\": {\r\n          \"displayName\": \"AA Total Job Alert Threshold\",\r\n          \"description\": \"Threshold for the alert\"\r\n        }\r\n      },\r\n      \"RVBackupHealthMonitorPolicyEffect\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"modify\",\r\n        \"allowedValues\": [\r\n          \"modify\",\r\n          \"audit\",\r\n          \"disabled\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"RV Backup Health Monitor Policy Effect\",\r\n          \"description\": \"Policy effect for the alert, modify will create the alert if it does not exist and enable it on your Recovery Vaults, audit will only audit if alerting is enabled on Recovery Vaults, disabled will not create the alert on Recovery Vaults\"\r\n        }\r\n      },\r\n      \"StorageAccountAvailabilityAlertSeverity\": {\r\n        \"type\": \"String\",\r\n        \"defaultValue\": \"1\",\r\n        \"allowedValues\": [\r\n          \"0\",\r\n          \"1\",\r\n          \"2\",\r\n          \"3\",\r\n          \"4\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"Storage Account Availability Alert Severity\",\r\n          \"description\": \"Severity of the alert\"\r\n        }\r\n      },\r\n      \"StorageAccountAvailabilityWindowSize\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"PT5M\",\r\n        \"allowedValues\": [\r\n          \"PT1M\",\r\n          \"PT5M\",\r\n          \"PT15M\",\r\n          \"PT30M\",\r\n          \"PT1H\",\r\n          \"PT6H\",\r\n          \"PT12H\",\r\n          \"P1D\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"Storage Account Availability Alert Window Size\",\r\n          \"description\": \"Window size for the alert\"\r\n        }\r\n      },\r\n      \"StorageAccountAvailabilityFrequency\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"PT5M\",\r\n        \"allowedValues\": [\r\n          \"PT1M\",\r\n          \"PT5M\",\r\n          \"PT15M\",\r\n          \"PT30M\",\r\n          \"PT1H\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"Storage Account Availability Alert Evaluation Frequency\",\r\n          \"description\": \"Evaluation frequency for the alert\"\r\n        }\r\n      },\r\n      \"StorageAccountAvailabilityPolicyEffect\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"deployIfNotExists\",\r\n        \"allowedValues\": [\r\n          \"deployIfNotExists\",\r\n          \"disabled\"\r\n        ],\r\n        \"metadata\": {\r\n          \"displayName\": \"Storage Account Availability Alert Policy Effect\",\r\n          \"description\": \"Policy effect for the alert, deployIfNotExists will create the alert if it does not exist, disabled will not create the alert\"\r\n        }\r\n      },\r\n      \"StorageAccountAvailabilityAlertState\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"true\",\r\n        \"metadata\": {\r\n          \"displayName\": \"Storage Account Availability Alert State\",\r\n          \"description\": \"Alert state for the alert\"\r\n        }\r\n      },\r\n      \"StorageAccountAvailabilityThreshold\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"90\",\r\n        \"metadata\": {\r\n          \"displayName\": \"Storage Account Availability Alert Threshold\",\r\n          \"description\": \"Threshold for the alert\"\r\n        }\r\n      },\r\n      \"activityLAWDeleteAlertState\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"true\",\r\n        \"metadata\": {\r\n          \"displayName\": \"Activity Log Alert Delete Alert State\",\r\n          \"description\": \"Alert state for the alert\"\r\n        }\r\n      },\r\n      \"activityLAWKeyRegenAlertState\": {\r\n        \"type\": \"string\",\r\n        \"defaultValue\": \"true\",\r\n        \"metadata\": {\r\n          \"displayName\": \"Activity Log Alert Key Regen Alert State\",\r\n          \"description\": \"Alert state for the alert\"\r\n        }\r\n      }\r\n    },\r\n    \"policyDefinitions\": [\r\n      {\r\n        \"policyDefinitionReferenceId\": \"ALZ_activityLAWDelete\",\r\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_LAWorkspace_Delete')]\",\r\n        \"parameters\": {\r\n          \"enabled\": {\r\n            \"value\": \"[[parameters('activityLAWDeleteAlertState')]\"\r\n          },\r\n          \"alertResourceGroupName\": {\r\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\r\n          },\r\n          \"alertResourceGroupTags\": {\r\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\r\n          },\r\n          \"alertResourceGroupLocation\": {\r\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"policyDefinitionReferenceId\": \"ALZ_activityLAWKeyRegen\",\r\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_LAWorkspace_KeyRegen')]\",\r\n        \"parameters\": {\r\n          \"enabled\": {\r\n            \"value\": \"[[parameters('activityLAWKeyRegenAlertState')]\"\r\n          },\r\n          \"alertResourceGroupName\": {\r\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\r\n          },\r\n          \"alertResourceGroupTags\": {\r\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\r\n          },\r\n          \"alertResourceGroupLocation\": {\r\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"policyDefinitionReferenceId\": \"ALZ_AATotalJob\",\r\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AA_TotalJob_Alert')]\",\r\n        \"parameters\": {\r\n          \"severity\": {\r\n            \"value\": \"[[parameters('AATotalJobAlertSeverity')]\"\r\n          },\r\n          \"windowSize\": {\r\n            \"value\": \"[[parameters('AATotalJobAlertWindowSize')]\"\r\n          },\r\n          \"evaluationFrequency\": {\r\n            \"value\": \"[[parameters('AATotalJobAlertEvaluationFrequency')]\"\r\n          },\r\n          \"effect\": {\r\n            \"value\": \"[[parameters('AATotalJobAlertPolicyEffect')]\"\r\n          },\r\n          \"enabled\": {\r\n            \"value\": \"[[parameters('AATotalJobAlertAlertState')]\"\r\n          },\r\n          \"threshold\": {\r\n            \"value\": \"[[parameters('AATotalJobAlertThreshold')]\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"policyDefinitionReferenceId\": \"ALZ_RVBackupHealth\",\r\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_RecoveryVault_BackupHealthMonitor_Alert')]\",\r\n        \"parameters\": {\r\n          \"effect\": {\r\n            \"value\": \"[[parameters('RVBackupHealthMonitorPolicyEffect')]\"\r\n          }\r\n        }\r\n      },\r\n      {\r\n        \"policyDefinitionReferenceId\": \"ALZ_StorageAccountAvailability\",\r\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_StorageAccount_Availability_Alert')]\",\r\n        \"parameters\": {\r\n          \"severity\": {\r\n            \"value\": \"[[parameters('StorageAccountAvailabilityAlertSeverity')]\"\r\n          },\r\n          \"windowSize\": {\r\n            \"value\": \"[[parameters('StorageAccountAvailabilityWindowSize')]\"\r\n          },\r\n          \"evaluationFrequency\": {\r\n            \"value\": \"[[parameters('StorageAccountAvailabilityFrequency')]\"\r\n          },\r\n          \"effect\": {\r\n            \"value\": \"[[parameters('StorageAccountAvailabilityPolicyEffect')]\"\r\n          },\r\n          \"enabled\": {\r\n            \"value\": \"[[parameters('StorageAccountAvailabilityAlertState')]\"\r\n          },\r\n          \"threshold\": {\r\n            \"value\": \"[[parameters('StorageAccountAvailabilityThreshold')]\"\r\n          }\r\n        }\r\n      }\r\n    ],\r\n    \"policyType\": \"Custom\",\r\n    \"policyDefinitionGroups\": null\r\n  }\r\n}\r\n",
-    "$fxv#91": "{\n  \"type\": \"Microsoft.Authorization/policySetDefinitions\",\n  \"apiVersion\": \"2021-06-01\",\n  \"name\": \"Alerting-ServiceHealth\",\n  \"properties\": {\n    \"displayName\": \"Deploy Azure Monitor Baseline Alerts for Service Health\",\n    \"description\": \"Initiative to deploy AMBA Service Health alerts to Azure services\",\n    \"metadata\": {\n      \"version\": \"1.1.0\",\n      \"category\": \"Monitoring\",\n      \"source\": \"https://github.com/Azure/azure-monitor-baseline-alerts/\",\n      \"alzCloudEnvironments\": [\n        \"AzureCloud\"\n      ],\n      \"_deployed_by_amba\": true\n    },\n    \"parameters\": {\n      \"ALZMonitorResourceGroupName\": {\n        \"type\": \"String\",\n        \"defaultValue\": \"ALZ-Monitoring-RG\",\n        \"metadata\": {\n          \"displayName\": \"Resource Group Name\",\n          \"description\": \"Name of the resource group to deploy the alerts to\"\n        }\n      },\n      \"ALZMonitorResourceGroupTags\": {\n        \"type\": \"Object\",\n        \"defaultValue\": {\n          \"_deployed_by_alz_monitor\": true\n        },\n        \"metadata\": {\n          \"displayName\": \"Resource Group Tags\",\n          \"description\": \"Tags to apply to the resource group\"\n        }\n      },\n      \"ALZMonitorResourceGroupLocation\": {\n        \"type\": \"String\",\n        \"defaultValue\": \"centralus\",\n        \"metadata\": {\n          \"displayName\": \"Resource Group Location\",\n          \"description\": \"Location of the resource group\"\n        }\n      },\n      \"ResHlthUnhealthyAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"Resource Health Unhealthy Alert State\",\n          \"description\": \"State of the Resource Health Unhealthy alert\"\n        }\n      },\n      \"ResHlthUnhealthyPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"deployIfNotExists\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"Resource Health Unhealthy Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist\"\n        }\n      },\n      \"SvcHlthAdvisoryAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"Service Health Advisory Alert State\",\n          \"description\": \"State of the Service Health Advisory alert\"\n        }\n      },\n      \"serviceHealthAdvisoryPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"deployIfNotExists\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"Service Health Advisory Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist\"\n        }\n      },\n      \"SvcHlthIncidentAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"Service Health Incident Alert State\",\n          \"description\": \"State of the Service Health Incident alert\"\n        }\n      },\n      \"serviceHealthIncidentPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"deployIfNotExists\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"Service Health Incident Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist\"\n        }\n      },\n      \"SvcHlthMaintenanceAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"Service Health Maintenance Alert State\",\n          \"description\": \"State of the Service Health Maintenance alert\"\n        }\n      },\n      \"serviceHealthMaintenancePolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"deployIfNotExists\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"Service Health Maintenance Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist\"\n        }\n      },\n      \"svcHlthSecAdvisoryAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"Service Health Security Advisory Alert State\",\n          \"description\": \"State of the Service Health Security Advisory alert\"\n        }\n      },\n      \"serviceHealthSecurityPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"deployIfNotExists\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"Service Health Security Advisory Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist\"\n        }\n      },\n      \"ALZMonitorActionGroupEmail\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"action@mail.com\",\n        \"metadata\": {\n          \"displayName\": \"Action Group Email\",\n          \"description\": \"Email address to send alerts to\"\n        }\n      },\n      \"MonitorDisable\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"MonitorDisable\",\n        \"metadata\": {\n          \"displayName\": \"Monitor Disable\",\n          \"description\": \"Disable the Monitor\"\n        }\n      }\n    },\n    \"policyDefinitions\": [\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_ResHlthUnhealthy\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ResourceHealth_Unhealthy_Alert')]\",\n        \"parameters\": {\n          \"enabled\": {\n            \"value\": \"[[parameters('ResHlthUnhealthyAlertState')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('ResHlthUnhealthyPolicyEffect')]\"\n          },\n          \"alertResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"alertResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"alertResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_SvcHlthAdvisory\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_HealthAdvisory')]\",\n        \"parameters\": {\n          \"enabled\": {\n            \"value\": \"[[parameters('SvcHlthAdvisoryAlertState')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('serviceHealthAdvisoryPolicyEffect')]\"\n          },\n          \"alertResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"alertResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"alertResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          },\n          \"ALZMonitorActionGroupEmail\": {\n            \"value\": \"[[parameters('ALZMonitorActionGroupEmail')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_SvcHlthIncident\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_Incident')]\",\n        \"parameters\": {\n          \"enabled\": {\n            \"value\": \"[[parameters('SvcHlthIncidentAlertState')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('serviceHealthIncidentPolicyEffect')]\"\n          },\n          \"alertResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"alertResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"alertResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          },\n          \"ALZMonitorActionGroupEmail\": {\n            \"value\": \"[[parameters('ALZMonitorActionGroupEmail')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_SvcHlthMaintenance\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_Maintenance')]\",\n        \"parameters\": {\n          \"enabled\": {\n            \"value\": \"[[parameters('SvcHlthMaintenanceAlertState')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('serviceHealthMaintenancePolicyEffect')]\"\n          },\n          \"alertResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"alertResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"alertResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          },\n          \"ALZMonitorActionGroupEmail\": {\n            \"value\": \"[[parameters('ALZMonitorActionGroupEmail')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_svcHlthSecAdvisory\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_SecurityAdvisory')]\",\n        \"parameters\": {\n          \"enabled\": {\n            \"value\": \"[[parameters('svcHlthSecAdvisoryAlertState')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('serviceHealthSecurityPolicyEffect')]\"\n          },\n          \"alertResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"alertResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"alertResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          },\n          \"ALZMonitorActionGroupEmail\": {\n            \"value\": \"[[parameters('ALZMonitorActionGroupEmail')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_AlertProcessing_Rule\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AlertProcessing_Rule')]\",\n        \"parameters\": {\n          \"ALZMonitorResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"ALZMonitorResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"ALZMonitorResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          },\n          \"ALZMonitorActionGroupEmail\": {\n            \"value\": \"[[parameters('ALZMonitorActionGroupEmail')]\"\n          },\n          \"MonitorDisable\": {\n            \"value\": \"[[parameters('MonitorDisable')]\"\n          }\n        }\n      }\n    ],\n    \"policyType\": \"Custom\",\n    \"policyDefinitionGroups\": null\n  }\n}\n",
+    "$fxv#90": "{\n  \"type\": \"Microsoft.Authorization/policySetDefinitions\",\n  \"apiVersion\": \"2021-06-01\",\n  \"name\": \"Alerting-Management\",\n  \"properties\": {\n    \"displayName\": \"Deploy Azure Monitor Baseline Alerts for Management\",\n    \"description\": \"Initiative to deploy AMBA alerts relevant to the ALZ Management management group\",\n    \"metadata\": {\n      \"version\": \"1.0.2\",\n      \"category\": \"Monitoring\",\n      \"source\": \"https://github.com/Azure/azure-monitor-baseline-alerts/\",\n      \"alzCloudEnvironments\": [\n        \"AzureCloud\"\n      ],\n      \"_deployed_by_amba\": true\n    },\n    \"parameters\": {\n      \"ALZMonitorResourceGroupName\": {\n        \"type\": \"String\",\n        \"defaultValue\": \"ALZ-Monitoring-RG\",\n        \"metadata\": {\n          \"displayName\": \"ALZ Monitoring Resource Group Name\",\n          \"description\": \"Name of the resource group to deploy the ALZ monitoring resources to\"\n        }\n      },\n      \"ALZMonitorResourceGroupTags\": {\n        \"type\": \"Object\",\n        \"defaultValue\": {\n          \"_deployed_by_alz_monitor\": true\n        },\n        \"metadata\": {\n          \"displayName\": \"ALZ Monitoring Resource Group Tags\",\n          \"description\": \"Tags to apply to the resource group\"\n        }\n      },\n      \"ALZMonitorResourceGroupLocation\": {\n        \"type\": \"String\",\n        \"defaultValue\": \"centralus\",\n        \"metadata\": {\n          \"displayName\": \"ALZ Monitoring Resource Group Location\",\n          \"description\": \"Location of the resource group\"\n        }\n      },\n      \"AATotalJobAlertSeverity\": {\n        \"type\": \"String\",\n        \"defaultValue\": \"2\",\n        \"allowedValues\": [\n          \"0\",\n          \"1\",\n          \"2\",\n          \"3\",\n          \"4\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"AA Total Job Alert Severity\",\n          \"description\": \"Severity of the alert\"\n        }\n      },\n      \"AATotalJobAlertWindowSize\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"PT5M\",\n        \"allowedValues\": [\n          \"PT1M\",\n          \"PT5M\",\n          \"PT15M\",\n          \"PT30M\",\n          \"PT1H\",\n          \"PT6H\",\n          \"PT12H\",\n          \"P1D\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"AA Total Job Alert Window Size\",\n          \"description\": \"Window size for the alert\"\n        }\n      },\n      \"AATotalJobAlertEvaluationFrequency\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"PT1M\",\n        \"allowedValues\": [\n          \"PT1M\",\n          \"PT5M\",\n          \"PT15M\",\n          \"PT30M\",\n          \"PT1H\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"AA Total Job Alert Evaluation Frequency\",\n          \"description\": \"Evaluation frequency for the alert\"\n        }\n      },\n      \"AATotalJobAlertPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"deployIfNotExists\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"AA Total Job Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert\"\n        }\n      },\n      \"AATotalJobAlertAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"AA Total Job Alert State\",\n          \"description\": \"Alert state for the alert\"\n        }\n      },\n      \"AATotalJobAlertThreshold\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"20\",\n        \"metadata\": {\n          \"displayName\": \"AA Total Job Alert Threshold\",\n          \"description\": \"Threshold for the alert\"\n        }\n      },\n      \"RVBackupHealthMonitorPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"modify\",\n        \"allowedValues\": [\n          \"modify\",\n          \"audit\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"RV Backup Health Monitor Policy Effect\",\n          \"description\": \"Policy effect for the alert, modify will create the alert if it does not exist and enable it on your Recovery Vaults, audit will only audit if alerting is enabled on Recovery Vaults, disabled will not create the alert on Recovery Vaults\"\n        }\n      },\n      \"StorageAccountAvailabilityAlertSeverity\": {\n        \"type\": \"String\",\n        \"defaultValue\": \"1\",\n        \"allowedValues\": [\n          \"0\",\n          \"1\",\n          \"2\",\n          \"3\",\n          \"4\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"Storage Account Availability Alert Severity\",\n          \"description\": \"Severity of the alert\"\n        }\n      },\n      \"StorageAccountAvailabilityWindowSize\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"PT5M\",\n        \"allowedValues\": [\n          \"PT1M\",\n          \"PT5M\",\n          \"PT15M\",\n          \"PT30M\",\n          \"PT1H\",\n          \"PT6H\",\n          \"PT12H\",\n          \"P1D\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"Storage Account Availability Alert Window Size\",\n          \"description\": \"Window size for the alert\"\n        }\n      },\n      \"StorageAccountAvailabilityFrequency\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"PT5M\",\n        \"allowedValues\": [\n          \"PT1M\",\n          \"PT5M\",\n          \"PT15M\",\n          \"PT30M\",\n          \"PT1H\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"Storage Account Availability Alert Evaluation Frequency\",\n          \"description\": \"Evaluation frequency for the alert\"\n        }\n      },\n      \"StorageAccountAvailabilityPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"deployIfNotExists\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"Storage Account Availability Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will create the alert if it does not exist, disabled will not create the alert\"\n        }\n      },\n      \"StorageAccountAvailabilityAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"Storage Account Availability Alert State\",\n          \"description\": \"Alert state for the alert\"\n        }\n      },\n      \"StorageAccountAvailabilityThreshold\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"90\",\n        \"metadata\": {\n          \"displayName\": \"Storage Account Availability Alert Threshold\",\n          \"description\": \"Threshold for the alert\"\n        }\n      },\n      \"activityLAWDeleteAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"Activity Log Alert Delete Alert State\",\n          \"description\": \"Alert state for the alert\"\n        }\n      },\n      \"activityLAWKeyRegenAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"Activity Log Alert Key Regen Alert State\",\n          \"description\": \"Alert state for the alert\"\n        }\n      }\n    },\n    \"policyDefinitions\": [\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_activityLAWDelete\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_LAWorkspace_Delete')]\",\n        \"parameters\": {\n          \"enabled\": {\n            \"value\": \"[[parameters('activityLAWDeleteAlertState')]\"\n          },\n          \"alertResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"alertResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"alertResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_activityLAWKeyRegen\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_LAWorkspace_KeyRegen')]\",\n        \"parameters\": {\n          \"enabled\": {\n            \"value\": \"[[parameters('activityLAWKeyRegenAlertState')]\"\n          },\n          \"alertResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"alertResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"alertResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_AATotalJob\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AA_TotalJob_Alert')]\",\n        \"parameters\": {\n          \"severity\": {\n            \"value\": \"[[parameters('AATotalJobAlertSeverity')]\"\n          },\n          \"windowSize\": {\n            \"value\": \"[[parameters('AATotalJobAlertWindowSize')]\"\n          },\n          \"evaluationFrequency\": {\n            \"value\": \"[[parameters('AATotalJobAlertEvaluationFrequency')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('AATotalJobAlertPolicyEffect')]\"\n          },\n          \"enabled\": {\n            \"value\": \"[[parameters('AATotalJobAlertAlertState')]\"\n          },\n          \"threshold\": {\n            \"value\": \"[[parameters('AATotalJobAlertThreshold')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_RVBackupHealth\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_RecoveryVault_BackupHealthMonitor_Alert')]\",\n        \"parameters\": {\n          \"effect\": {\n            \"value\": \"[[parameters('RVBackupHealthMonitorPolicyEffect')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_StorageAccountAvailability\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_StorageAccount_Availability_Alert')]\",\n        \"parameters\": {\n          \"severity\": {\n            \"value\": \"[[parameters('StorageAccountAvailabilityAlertSeverity')]\"\n          },\n          \"windowSize\": {\n            \"value\": \"[[parameters('StorageAccountAvailabilityWindowSize')]\"\n          },\n          \"evaluationFrequency\": {\n            \"value\": \"[[parameters('StorageAccountAvailabilityFrequency')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('StorageAccountAvailabilityPolicyEffect')]\"\n          },\n          \"enabled\": {\n            \"value\": \"[[parameters('StorageAccountAvailabilityAlertState')]\"\n          },\n          \"threshold\": {\n            \"value\": \"[[parameters('StorageAccountAvailabilityThreshold')]\"\n          }\n        }\n      }\n    ],\n    \"policyType\": \"Custom\",\n    \"policyDefinitionGroups\": null\n  }\n}\n",
+    "$fxv#91": "{\n  \"type\": \"Microsoft.Authorization/policySetDefinitions\",\n  \"apiVersion\": \"2021-06-01\",\n  \"name\": \"Alerting-ServiceHealth\",\n  \"properties\": {\n    \"displayName\": \"Deploy Azure Monitor Baseline Alerts for Service Health\",\n    \"description\": \"Initiative to deploy AMBA Service Health alerts to Azure services\",\n    \"metadata\": {\n      \"version\": \"1.1.0\",\n      \"category\": \"Monitoring\",\n      \"source\": \"https://github.com/Azure/azure-monitor-baseline-alerts/\",\n      \"alzCloudEnvironments\": [\n        \"AzureCloud\"\n      ],\n      \"_deployed_by_amba\": true\n    },\n    \"parameters\": {\n      \"ALZMonitorResourceGroupName\": {\n        \"type\": \"String\",\n        \"defaultValue\": \"ALZ-Monitoring-RG\",\n        \"metadata\": {\n          \"displayName\": \"Resource Group Name\",\n          \"description\": \"Name of the resource group to deploy the alerts to\"\n        }\n      },\n      \"ALZMonitorResourceGroupTags\": {\n        \"type\": \"Object\",\n        \"defaultValue\": {\n          \"_deployed_by_alz_monitor\": true\n        },\n        \"metadata\": {\n          \"displayName\": \"Resource Group Tags\",\n          \"description\": \"Tags to apply to the resource group\"\n        }\n      },\n      \"ALZMonitorResourceGroupLocation\": {\n        \"type\": \"String\",\n        \"defaultValue\": \"centralus\",\n        \"metadata\": {\n          \"displayName\": \"Resource Group Location\",\n          \"description\": \"Location of the resource group\"\n        }\n      },\n      \"ResHlthUnhealthyAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"Resource Health Unhealthy Alert State\",\n          \"description\": \"State of the Resource Health Unhealthy alert\"\n        }\n      },\n      \"ResHlthUnhealthyPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"deployIfNotExists\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"Resource Health Unhealthy Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist\"\n        }\n      },\n      \"SvcHlthAdvisoryAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"Service Health Advisory Alert State\",\n          \"description\": \"State of the Service Health Advisory alert\"\n        }\n      },\n      \"serviceHealthAdvisoryPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"deployIfNotExists\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"Service Health Advisory Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist\"\n        }\n      },\n      \"SvcHlthIncidentAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"Service Health Incident Alert State\",\n          \"description\": \"State of the Service Health Incident alert\"\n        }\n      },\n      \"serviceHealthIncidentPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"deployIfNotExists\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"Service Health Incident Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist\"\n        }\n      },\n      \"SvcHlthMaintenanceAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"Service Health Maintenance Alert State\",\n          \"description\": \"State of the Service Health Maintenance alert\"\n        }\n      },\n      \"serviceHealthMaintenancePolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"deployIfNotExists\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"Service Health Maintenance Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist\"\n        }\n      },\n      \"svcHlthSecAdvisoryAlertState\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"true\",\n        \"metadata\": {\n          \"displayName\": \"Service Health Security Advisory Alert State\",\n          \"description\": \"State of the Service Health Security Advisory alert\"\n        }\n      },\n      \"serviceHealthSecurityPolicyEffect\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"deployIfNotExists\",\n        \"allowedValues\": [\n          \"deployIfNotExists\",\n          \"disabled\"\n        ],\n        \"metadata\": {\n          \"displayName\": \"Service Health Security Advisory Alert Policy Effect\",\n          \"description\": \"Policy effect for the alert, deployIfNotExists will deploy the alert if it does not exist\"\n        }\n      },\n      \"ALZMonitorActionGroupEmail\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"action@mail.com\",\n        \"metadata\": {\n          \"displayName\": \"Action Group Email\",\n          \"description\": \"Email address to send alerts to\"\n        }\n      },\n      \"MonitorDisable\": {\n        \"type\": \"string\",\n        \"defaultValue\": \"MonitorDisable\",\n        \"metadata\": {\n          \"displayName\": \"Monitor Disable\",\n          \"description\": \"Disable the Monitor\"\n        }\n      }\n    },\n    \"policyDefinitions\": [\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_ResHlthUnhealthy\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ResourceHealth_Unhealthy_Alert')]\",\n        \"parameters\": {\n          \"enabled\": {\n            \"value\": \"[[parameters('ResHlthUnhealthyAlertState')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('ResHlthUnhealthyPolicyEffect')]\"\n          },\n          \"alertResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"alertResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"alertResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_SvcHlthAdvisory\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_HealthAdvisory')]\",\n        \"parameters\": {\n          \"enabled\": {\n            \"value\": \"[[parameters('SvcHlthAdvisoryAlertState')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('serviceHealthAdvisoryPolicyEffect')]\"\n          },\n          \"alertResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"alertResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"alertResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          },\n          \"ALZMonitorActionGroupEmail\": {\n            \"value\": \"[[parameters('ALZMonitorActionGroupEmail')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_SvcHlthIncident\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_Incident')]\",\n        \"parameters\": {\n          \"enabled\": {\n            \"value\": \"[[parameters('SvcHlthIncidentAlertState')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('serviceHealthIncidentPolicyEffect')]\"\n          },\n          \"alertResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"alertResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"alertResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          },\n          \"ALZMonitorActionGroupEmail\": {\n            \"value\": \"[[parameters('ALZMonitorActionGroupEmail')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_SvcHlthMaintenance\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_Maintenance')]\",\n        \"parameters\": {\n          \"enabled\": {\n            \"value\": \"[[parameters('SvcHlthMaintenanceAlertState')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('serviceHealthMaintenancePolicyEffect')]\"\n          },\n          \"alertResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"alertResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"alertResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          },\n          \"ALZMonitorActionGroupEmail\": {\n            \"value\": \"[[parameters('ALZMonitorActionGroupEmail')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_svcHlthSecAdvisory\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_SecurityAdvisory')]\",\n        \"parameters\": {\n          \"enabled\": {\n            \"value\": \"[[parameters('svcHlthSecAdvisoryAlertState')]\"\n          },\n          \"effect\": {\n            \"value\": \"[[parameters('serviceHealthSecurityPolicyEffect')]\"\n          },\n          \"alertResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"alertResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"alertResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          },\n          \"ALZMonitorActionGroupEmail\": {\n            \"value\": \"[[parameters('ALZMonitorActionGroupEmail')]\"\n          }\n        }\n      },\n      {\n        \"policyDefinitionReferenceId\": \"ALZ_AlertProcessing_Rule\",\n        \"policyDefinitionId\": \"[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AlertProcessing_Rule')]\",\n        \"parameters\": {\n          \"ALZMonitorResourceGroupName\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupName')]\"\n          },\n          \"ALZMonitorResourceGroupTags\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupTags')]\"\n          },\n          \"ALZMonitorResourceGroupLocation\": {\n            \"value\": \"[[parameters('ALZMonitorResourceGroupLocation')]\"\n          },\n          \"ALZMonitorActionGroupEmail\": {\n            \"value\": \"[[parameters('ALZMonitorActionGroupEmail')]\"\n          },\n          \"MonitorDisable\": {\n            \"value\": \"[[parameters('MonitorDisable')]\"\n          }\n        }\n      }\n    ],\n    \"policyType\": \"Custom\",\n    \"policyDefinitionGroups\": null\n  }\n}\n",
     "cloudEnv": "[environment().name]",
     "defaultDeploymentLocationByCloudType": {
       "AzureCloud": "northeurope",

--- a/patterns/alz/policySetDefinitions/Deploy-Connectivity-Alerts.json
+++ b/patterns/alz/policySetDefinitions/Deploy-Connectivity-Alerts.json
@@ -3409,7 +3409,7 @@
     "policyDefinitions": [
       {
         "policyDefinitionReferenceId": "ALZ_ERCIRQoSDropBitsinPerSec",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_QosDropBitsInPerSecond_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_QosDropBitsInPerSecond_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('ERCIRQoSDropBitsinPerSecAlertSeverity')]"
@@ -3430,7 +3430,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_ERCIRQoSDropBitsoutPerSec",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_QosDropBitsOutPerSecond_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_QosDropBitsOutPerSecond_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('ERCIRQoSDropBitsoutPerSecAlertSeverity')]"
@@ -3451,7 +3451,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VPNGwBGPPeerStatus",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_BGPPeerStatus_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_BGPPeerStatus_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VPNGwBGPPeerStatusAlertSeverity')]"
@@ -3475,7 +3475,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VnetGwERCpuUtil",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_ExpressRouteCpuUtil_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_ExpressRouteCpuUtil_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VnetGwERCpuUtilAlertSeverity')]"
@@ -3499,7 +3499,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VnetGwTunnelBW",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelBandwidth_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelBandwidth_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VnetGwTunnelBWAlertSeverity')]"
@@ -3523,7 +3523,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VnetGwTunnelEgress",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelEgress_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelEgress_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VnetGwTunnelEgressAlertSeverity')]"
@@ -3547,7 +3547,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VnetGwTunnelIngress",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelIngress_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelIngress_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VnetGwTunnelIngressAlertSeverity')]"
@@ -3571,7 +3571,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VPNGWBandWidthUtil",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_BandwidthUtil_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_BandwidthUtil_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VPNGWBandWidthUtilAlertSeverity')]"
@@ -3595,7 +3595,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VPNGWEgress",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_Egress_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_Egress_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VPNGWEgressAlertSeverity')]"
@@ -3619,7 +3619,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VPNGWTunnelEgressPacketDropCount",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelEgressPacketDropCount_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelEgressPacketDropCount_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VPNGWTunnelEgressPacketDropCountAlertSeverity')]"
@@ -3640,7 +3640,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VPNGWTunnelEgressPacketDropMismatch",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelEgressPacketDropMismatch_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelEgressPacketDropMismatch_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VPNGWTunnelEgressPacketDropMismatchAlertSeverity')]"
@@ -3661,7 +3661,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VPNGWIngress",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_Ingress_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_Ingress_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VPNGWIngressAlertSeverity')]"
@@ -3688,7 +3688,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VPNGWTunnelIngressPacketDropCount",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelIngressPacketDropCount_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelIngressPacketDropCount_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VPNGWTunnelIngressPacketDropCountAlertSeverity')]"
@@ -3709,7 +3709,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VPNGWTunnelIngressPacketDropMismatch",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelIngressPacketDropMismatch_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VPNGw_TunnelIngressPacketDropMismatch_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VPNGWTunnelIngressPacketDropMismatchAlertSeverity')]"
@@ -3730,7 +3730,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_PDNSZCapacityUtil",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PDNSZ_CapacityUtil_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PDNSZ_CapacityUtil_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('PDNSZCapacityUtilAlertSeverity')]"
@@ -3754,7 +3754,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_PDNSZQueryVolume",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PDNSZ_QueryVolume_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PDNSZ_QueryVolume_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('PDNSZQueryVolumeAlertSeverity')]"
@@ -3778,7 +3778,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_PDNSZRecordSetCapacity",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PDNSZ_RecordSetCapacity_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PDNSZ_RecordSetCapacity_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('PDNSZRecordSetCapacityAlertSeverity')]"
@@ -3802,7 +3802,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_PDNSZRegistrationCapacityUtil",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_DNSZ_RegistrationCapacityUtil_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_DNSZ_RegistrationCapacityUtil_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('PDNSZRegistrationCapacityUtilAlertSeverity')]"
@@ -3826,7 +3826,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_ERGwExpressRouteBitsIn",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERGw_ExpressRouteBitsIn_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERGw_ExpressRouteBitsIn_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('ERGwExpressRouteBitsInAlertSeverity')]"
@@ -3850,7 +3850,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_ERGwExpressRouteBitsOut",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERGw_ExpressRouteBitsOut_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERGw_ExpressRouteBitsOut_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('ERGwExpressRouteBitsOutAlertSeverity')]"
@@ -3874,7 +3874,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_ERGwExpressRouteCpuUtil",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERGw_ExpressRouteCpuUtil_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERGw_ExpressRouteCpuUtil_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('ERGwExpressRouteCpuUtilAlertSeverity')]"
@@ -3898,7 +3898,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VnetGwTunnelEgressPacketDropCount",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelEgressPacketDropCount_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelEgressPacketDropCount_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VnetGwTunnelEgressPacketDropCountAlertSeverity')]"
@@ -3919,7 +3919,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VnetGwTunnelEgressPacketDropMismatch",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelEgressPacketDropMismatch_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelEgressPacketDropMismatch_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VnetGwTunnelEgressPacketDropMismatchAlertSeverity')]"
@@ -3940,7 +3940,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VnetGwExpressRouteBitsPerSecond",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_ExpressRouteBitsPerSecond_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_ExpressRouteBitsPerSecond_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VnetGwExpressRouteBitsPerSecondAlertSeverity')]"
@@ -3964,7 +3964,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VnetGwTunnelIngressPacketDropMismatchWindowSize",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelIngressPacketDropMismatch_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelIngressPacketDropMismatch_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VnetGwTunnelIngressPacketDropMismatchAlertSeverity')]"
@@ -3985,7 +3985,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VnetGwTunnelIngressPacketDropCountWindowSize",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelIngressPacketDropCount_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VnetGw_TunnelIngressPacketDropCount_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VnetGwTunnelIngressPacketDropCountAlertSeverity')]"
@@ -4006,7 +4006,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_ERCIRBgpAvailability",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_BgpAvailability_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_BgpAvailability_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('ERCIRBgpAvailabilityAlertSeverity')]"
@@ -4030,7 +4030,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_ERCIRArpAvailability",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_ArpAvailability_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERCIR_ArpAvailability_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('ERCIRArpAvailabilityAlertSeverity')]"
@@ -4054,7 +4054,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_AFWSNATPortUtilization",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AFW_SNATPortUtilization_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AFW_SNATPortUtilization_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('AFWSNATPortUtilizationAlertSeverity')]"
@@ -4078,7 +4078,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_PIPBytesInDDoSEvaluationFrequency",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_BytesInDDoSAttack_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_BytesInDDoSAttack_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('PIPBytesInDDoSAlertSeverity')]"
@@ -4102,7 +4102,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_PIPDDoSAttack",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_DDoSAttack_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_DDoSAttack_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('PIPDDoSAttackAlertSeverity')]"
@@ -4126,7 +4126,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_PIPPacketsInDDoS",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_PacketsInDDoSAttack_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_PacketsInDDoSAttack_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('PIPPacketsInDDoSAlertSeverity')]"
@@ -4150,7 +4150,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_PIPVIPAvailability",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_VIPAvailability_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_VIPAvailability_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('PIPVIPAvailabilityAlertSeverity')]"
@@ -4174,7 +4174,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VNETDDOSAttack",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VNET_DDoSAttack_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VNET_DDoSAttack_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VNETDDOSAttackAlertSeverity')]"
@@ -4198,7 +4198,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_FirewallHealth",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AFW_FirewallHealth_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AFW_FirewallHealth_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('FirewallHealthAlertSeverity')]"
@@ -4222,7 +4222,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_activityFWDelete",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_Firewall_Delete')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_Firewall_Delete')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('activityFWDeleteAlertState')]"
@@ -4240,7 +4240,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_activityNSGDelete",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_NSG_Delete')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_NSG_Delete')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('activityNSGDeleteAlertState')]"
@@ -4258,7 +4258,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_activityUDRUpdate",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_RouteTable_Update')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_RouteTable_Update')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('activityUDRUpdateAlertState')]"
@@ -4276,7 +4276,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_activityVPNGWDelete",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_VPNGateway_Delete')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_VPNGateway_Delete')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('activityVPNGWDeleteAlertState')]"
@@ -4294,7 +4294,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_LBDataPathAvailability",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_DataPathAvailability_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_DataPathAvailability_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('LBDataPathAvailabilityAlertSeverity')]"
@@ -4315,7 +4315,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_LBGlobalBackendAvailability",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_GlobalBackendAvailability_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_GlobalBackendAvailability_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('LBGlobalBackendAvailabilityAlertSeverity')]"
@@ -4336,7 +4336,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_LBHealthProbeStatus",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_HealthProbeStatus_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_HealthProbeStatus_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('LBHealthProbeStatusAlertSeverity')]"
@@ -4357,7 +4357,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_LBUsedSNATPorts",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_UsedSNATPorts_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_UsedSNATPorts_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('LBUsedSNATPortsAlertSeverity')]"
@@ -4378,7 +4378,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_ERPBitsInPerSecond",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRouteBitsIn_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRouteBitsIn_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('ERPBitsInPerSecondAlertSeverity')]"
@@ -4399,7 +4399,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_ERPBitsOutPerSecond",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRouteBitsOut_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRouteBitsOut_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('ERPBitsOutPerSecondAlertSeverity')]"
@@ -4420,7 +4420,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_ERPLineProtocol",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutLineProtocol_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutLineProtocol_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('ERPLineProtocolAlertSeverity')]"
@@ -4441,7 +4441,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_ERPRxLightLevelHigh",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutRxLightLevell_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutRxLightLevell_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('ERPRxLightLevelHighAlertSeverity')]"
@@ -4462,7 +4462,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_ERPRxLightLevelLow",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutRxLightLevellow_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutRxLightLevellow_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('ERPRxLightLevelLowAlertSeverity')]"
@@ -4483,7 +4483,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_ERPTxLightLevelHigh",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutTxLightLevell_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutTxLightLevell_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('ERPTxLightLevelHighAlertSeverity')]"
@@ -4504,7 +4504,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_ERPTxLightLevelLow",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutTxLightLevellow_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ERP_ExpressRoutTxLightLevellow_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('ERPTxLightLevelLowAlertSeverity')]"

--- a/patterns/alz/policySetDefinitions/Deploy-Identity-Alerts.json
+++ b/patterns/alz/policySetDefinitions/Deploy-Identity-Alerts.json
@@ -349,7 +349,7 @@
     "policyDefinitions": [
       {
         "policyDefinitionReferenceId": "ALZ_KVRequest",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Requests_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Requests_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('KVRequestAlertSeverity')]"
@@ -370,7 +370,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_KvAvailability",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Availability_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Availability_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('KvAvailabilityAlertSeverity')]"
@@ -394,7 +394,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_KvLatencyAvailability",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Latency_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Latency_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('KvLatencyAvailabilityAlertSeverity')]"
@@ -418,7 +418,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_KVCapacity",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Capacity_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Capacity_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('KVCapacityAlertSeverity')]"
@@ -442,7 +442,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_activityKVDelete",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_KeyVault_Delete')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_KeyVault_Delete')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('activityKVDeleteAlertState')]"

--- a/patterns/alz/policySetDefinitions/Deploy-LandingZone-Alerts.json
+++ b/patterns/alz/policySetDefinitions/Deploy-LandingZone-Alerts.json
@@ -3181,7 +3181,7 @@
     "policyDefinitions": [
       {
         "policyDefinitionReferenceId": "ALZ_KVRequest",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Requests_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Requests_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('KVRequestAlertSeverity')]"
@@ -3202,7 +3202,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_KvAvailability",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Availability_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Availability_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('KvAvailabilityAlertSeverity')]"
@@ -3226,7 +3226,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_KvLatencyAvailability",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Latency_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Latency_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('KvLatencyAvailabilityAlertSeverity')]"
@@ -3250,7 +3250,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_KVCapacity",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Capacity_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_KeyVault_Capacity_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('KVCapacityAlertSeverity')]"
@@ -3274,7 +3274,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_activityKVDelete",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_KeyVault_Delete')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_KeyVault_Delete')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('activityKVDeleteAlertState')]"
@@ -3292,7 +3292,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_StorageAccountAvailability",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_StorageAccount_Availability_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_StorageAccount_Availability_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('StorageAccountAvailabilityAlertSeverity')]"
@@ -3316,7 +3316,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_PIPBytesInDDoS",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_BytesInDDoSAttack_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_BytesInDDoSAttack_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('PIPBytesInDDoSAlertSeverity')]"
@@ -3340,7 +3340,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_PIPDDoSAttack",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_DDoSAttack_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_DDoSAttack_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('PIPDDoSAttackAlertSeverity')]"
@@ -3364,7 +3364,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_PIPPacketsInDDoS",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_PacketsInDDoSAttack_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_PacketsInDDoSAttack_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('PIPPacketsInDDoSAlertSeverity')]"
@@ -3388,7 +3388,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_PIPVIPAvailability",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_VIPAvailability_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_PublicIp_VIPAvailability_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('PIPVIPAvailabilityAlertSeverity')]"
@@ -3412,7 +3412,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_activityNSGDelete",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_NSG_Delete')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_NSG_Delete')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('activityNSGDeleteAlertState')]"
@@ -3430,7 +3430,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_activityUDRUpdate",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_RouteTable_Update')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_RouteTable_Update')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('activityUDRUpdateAlertState')]"
@@ -3448,7 +3448,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_RVBackupHealthMonitor",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_RecoveryVault_BackupHealthMonitor_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_RecoveryVault_BackupHealthMonitor_Alert')]",
         "parameters": {
           "effect": {
             "value": "[[parameters('RVBackupHealthMonitorPolicyEffect')]"
@@ -3457,7 +3457,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VNETDDOSAttack",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VNET_DDoSAttack_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VNET_DDoSAttack_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VNETDDOSAttackAlertSeverity')]"
@@ -3481,7 +3481,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VMHeartBeatRG",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_HeartBeat_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_HeartBeat_Alert')]",
         "parameters": {
           "alertResourceGroupName": {
             "value": "[[parameters('ALZMonitorResourceGroupName')]"
@@ -3529,7 +3529,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VMNetworkIn",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_NetworkIn_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_NetworkIn_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VMNetworkInAlertSeverity')]"
@@ -3589,7 +3589,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VMNetworkOut",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_NetworkOut_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_NetworkOut_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VMNetworkOutAlertSeverity')]"
@@ -3649,7 +3649,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VMOSDiskReadLatency",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_OSDiskreadLatency_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_OSDiskreadLatency_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VMOSDiskReadLatencyAlertSeverity')]"
@@ -3709,7 +3709,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VMOSDiskWriteLatency",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_OSDiskwriteLatency_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_OSDiskwriteLatency_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VMOSDiskWriteLatencyAlertSeverity')]"
@@ -3769,7 +3769,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VMOSDiskSpace",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_OSDiskSpace_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_OSDiskSpace_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VMOSDiskSpaceAlertSeverity')]"
@@ -3829,7 +3829,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VMPercentCPU",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_CPU_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_CPU_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VMPercentCPUAlertSeverity')]"
@@ -3877,7 +3877,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VMPercentMemory",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_Memory_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_Memory_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VMPercentMemoryAlertSeverity')]"
@@ -3925,7 +3925,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VMDataDiskSpace",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_dataDiskSpace_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_dataDiskSpace_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VMDataDiskSpaceAlertSeverity')]"
@@ -3982,7 +3982,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VMDataDiskReadLatency",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_dataDiskReadLatency_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_dataDiskReadLatency_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VMDataDiskReadLatencyAlertSeverity')]"
@@ -4042,7 +4042,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_VMDataDiskWriteLatency",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_dataDiskWriteLatency_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_VM_dataDiskWriteLatency_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('VMDataDiskWriteLatencyAlertSeverity')]"
@@ -4102,7 +4102,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_AGWTotalTime",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_ApplicationGatewayTotalTime_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_ApplicationGatewayTotalTime_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('AGWApplicationGatewayTotalTimeAlertSeverity')]"
@@ -4123,7 +4123,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_AGWBackendLastByteResponseTime",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_BackendLastByteResponseTime_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_BackendLastByteResponseTime_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('AGWBackendLastByteResponseTimeAlertSeverity')]"
@@ -4144,7 +4144,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_AGWCapacityUnits",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_CapacityUnits_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_CapacityUnits_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('AGWCapacityUnitsAlertSeverity')]"
@@ -4165,7 +4165,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_AGWComputeUnits",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_ComputeUnits_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_ComputeUnits_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('AGWComputeUnitsAlertSeverity')]"
@@ -4186,7 +4186,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_AGWCPUUtilization",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_CPUUtilization_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_CPUUtilization_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('AGWCPUUtilAlertSeverity')]"
@@ -4207,7 +4207,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_AGWFailedRequests",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_FailedRequests_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_FailedRequests_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('AGWFailedRequestsAlertSeverity')]"
@@ -4228,7 +4228,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_AGWResponseStatus",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_ResponseStatus_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_ResponseStatus_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('AGWResponseStatusAlertSeverity')]"
@@ -4249,7 +4249,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_AGWUnhealthyHostCount",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_UnhealthyHostCount_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AG_UnhealthyHostCount_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('AGWUnhealthyHostCountAlertSeverity')]"
@@ -4270,7 +4270,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_LBDataPathAvailability",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_DataPathAvailability_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_DataPathAvailability_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('LBDataPathAvailabilityAlertSeverity')]"
@@ -4291,7 +4291,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_LBGlobalBackendAvailability",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_GlobalBackendAvailability_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_GlobalBackendAvailability_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('LBGlobalBackendAvailabilityAlertSeverity')]"
@@ -4312,7 +4312,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_LBHealthProbeStatus",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_HealthProbeStatus_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_HealthProbeStatus_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('LBHealthProbeStatusAlertSeverity')]"
@@ -4333,7 +4333,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_LBUsedSNATPorts",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_UsedSNATPorts_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_ALB_UsedSNATPorts_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('LBUsedSNATPortsAlertSeverity')]"

--- a/patterns/alz/policySetDefinitions/Deploy-Management-Alerts.json
+++ b/patterns/alz/policySetDefinitions/Deploy-Management-Alerts.json
@@ -226,7 +226,7 @@
     "policyDefinitions": [
       {
         "policyDefinitionReferenceId": "ALZ_activityLAWDelete",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_LAWorkspace_Delete')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_LAWorkspace_Delete')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('activityLAWDeleteAlertState')]"
@@ -244,7 +244,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_activityLAWKeyRegen",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_LAWorkspace_KeyRegen')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_LAWorkspace_KeyRegen')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('activityLAWKeyRegenAlertState')]"
@@ -262,7 +262,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_AATotalJob",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AA_TotalJob_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AA_TotalJob_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('AATotalJobAlertSeverity')]"
@@ -286,7 +286,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_RVBackupHealth",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_RecoveryVault_BackupHealthMonitor_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_RecoveryVault_BackupHealthMonitor_Alert')]",
         "parameters": {
           "effect": {
             "value": "[[parameters('RVBackupHealthMonitorPolicyEffect')]"
@@ -295,7 +295,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_StorageAccountAvailability",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_StorageAccount_Availability_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_StorageAccount_Availability_Alert')]",
         "parameters": {
           "severity": {
             "value": "[[parameters('StorageAccountAvailabilityAlertSeverity')]"

--- a/patterns/alz/policySetDefinitions/Deploy-ServiceHealth-Alerts.json
+++ b/patterns/alz/policySetDefinitions/Deploy-ServiceHealth-Alerts.json
@@ -161,7 +161,7 @@
     "policyDefinitions": [
       {
         "policyDefinitionReferenceId": "ALZ_ResHlthUnhealthy",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ResourceHealth_Unhealthy_Alert')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ResourceHealth_Unhealthy_Alert')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('ResHlthUnhealthyAlertState')]"
@@ -182,7 +182,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_SvcHlthAdvisory",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_HealthAdvisory')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_HealthAdvisory')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('SvcHlthAdvisoryAlertState')]"
@@ -206,7 +206,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_SvcHlthIncident",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_Incident')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_Incident')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('SvcHlthIncidentAlertState')]"
@@ -230,7 +230,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_SvcHlthMaintenance",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_Maintenance')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_Maintenance')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('SvcHlthMaintenanceAlertState')]"
@@ -254,7 +254,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_svcHlthSecAdvisory",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_SecurityAdvisory')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_activitylog_ServiceHealth_SecurityAdvisory')]",
         "parameters": {
           "enabled": {
             "value": "[[parameters('svcHlthSecAdvisoryAlertState')]"
@@ -278,7 +278,7 @@
       },
       {
         "policyDefinitionReferenceId": "ALZ_AlertProcessing_Rule",
-        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AlertProcessing_Rule')]",
+        "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso', '/providers/Microsoft.Authorization/policyDefinitions/Deploy_AlertProcessing_Rule')]",
         "parameters": {
           "ALZMonitorResourceGroupName": {
             "value": "[[parameters('ALZMonitorResourceGroupName')]"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

1. Aligned API version used to deploy policy to a newer one.
2. Changed policyDefinitionId" value to not include the managementGroup().Name function which was creating template validation issue in VSCode as per GH Issue [Linked template validation failed #43](https://github.com/Azure/azure-monitor-baseline-alerts/issues/43). The change has been done on the following files:

- patterns\alz\policySteDefinitions\Deploy-Connectivity-Alerts.json
- patterns\alz\policySteDefinitions\Deploy-Identity-Alerts.json
- patterns\alz\policySteDefinitions\Deploy-LandinZone-Alerts.json
- patterns\alz\policySteDefinitions\Deploy-Management-Alerts.json
- patterns\alz\policySteDefinitions\Deploy-ServiceHealth-Alerts.json

This work is related to bug [GH Issue 43: Linked template validation failed](https://dev.azure.com/CSUSolEng/Azure%20Landing%20Zones/_workitems/edit/31540)

## This PR fixes/adds/changes/removes

1. Aligned the API version used in the template part where we do deploy policies from 2019-10-01 to 2020-10-01
2. lines where the managementGroup().name function was used from **_"policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name,_** to **_"policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/contoso',_**

### Breaking Changes

1. NONE

## As part of this Pull Request I have

- [X] Read the Contribution Guide and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [X] Ensured PR tests are passing
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
