### PR TITLE
Add requirement for sku.name in policyRule

### DIFF
--- a/services/Network/publicIPAddresses/Deploy-PIP-VIPAvailability-Alert.json
+++ b/services/Network/publicIPAddresses/Deploy-PIP-VIPAvailability-Alert.json
@@ -126,6 +126,10 @@
             "equals": "Microsoft.Network/publicIPAddresses"
           },
           {
+            "field": "Microsoft.Network/publicIPAddresses/sku.name",
+            "equals": "Standard"
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisable'), ']')]",
             "notEquals": "true"
           }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

"VipAvailability" metric is only available in Standard SKU of Public IP Address. This PR adds a requirement for SKU to be Standard in the policyRule(#80)

## This PR fixes/adds/changes/removes

1. *Add policyRule requirement for Standard SKU*

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
