### PR TITLE
update policyRule to check for standard SKU as basic does not include…

### DIFF
--- a/services/Network/publicIPAddresses/Deploy-PIP-VIPAvailability-Alert.json
+++ b/services/Network/publicIPAddresses/Deploy-PIP-VIPAvailability-Alert.json
@@ -126,6 +126,10 @@
             "equals": "Microsoft.Network/publicIPAddresses"
           },
           {
+            "field": "Microsoft.Network/publicIPAddresses/sku.name",
+            "equals": "Standard"
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisable'), ']')]",
             "notEquals": "true"
           }


### PR DESCRIPTION
… metric checks

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

"VipAvailability" metric is only available in Standard SKU of Public IP Address. This PR adds a requirement for SKU to be Standard in the policyRule

## This PR fixes/adds/changes/removes

1. Adds policyRule  If Allof check to ensure PIP standard SKU is required 



