### PR TITLE
Fix operator in SNATPortUtilization AzureFirewall alert

### DIFF
--- a/services/Network/azureFirewalls/alerts.yaml
+++ b/services/Network/azureFirewalls/alerts.yaml
@@ -70,7 +70,7 @@
     windowSize: PT5M
     evaluationFrequency: PT1M
     timeAggregation: Average
-    operator: LessThan
+    operator: GreaterThan
     threshold: 80
     criterionType: StaticThresholdCriterion
     autoMitigate: false


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

The `alerts.yaml` file for AzureFirewall contains a wrong operator. For the alert `SNATPortUtilization` it is set to `LessThan`, but should be `GreaterThan`.

## This PR fixes/adds/changes/removes

1. Changes `operator` for `SNATPortUtilization` in Services/Network/AzureFirewall/alerts.yaml

### Breaking Changes

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
