### PR TITLE
AMBA Update deployment documentation with release tags

### DIFF
--- a/docs/content/patterns/alz/deploy/Deploy-only-Service-Health-Alerts.md
+++ b/docs/content/patterns/alz/deploy/Deploy-only-Service-Health-Alerts.md
@@ -185,7 +185,7 @@ The ```location``` variable refers to the deployment location. Deploying to mult
 Using your preferred command-line tool (Windows PowerShell, Cmd, Bash or other Unix shells), if you closed your previous session, navigate again to the root of the cloned repo and log on to Azure with an account with at least Resource Policy Contributor access at the root of the management group hierarchy where you will be creating the policies and Policy Set Definitions.
 
 ```bash
-az deployment mg create --template-uri https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/main/patterns/alz/alzArm.json --name "amba-GeneralDeployment" --location $location --management-group-id $pseudoRootManagementGroup --parameters .\patterns\alz\alzArm.param.json
+az deployment mg create --template-uri https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/2024-03-01/patterns/alz/alzArm.json --name "amba-GeneralDeployment" --location $location --management-group-id $pseudoRootManagementGroup --parameters .\patterns\alz\alzArm.param.json
 ```
 
 </br>

--- a/docs/content/patterns/alz/deploy/Deploy-with-Azure-CLI.md
+++ b/docs/content/patterns/alz/deploy/Deploy-with-Azure-CLI.md
@@ -42,7 +42,7 @@ If you customized the policies as documented at [How to modify individual polici
 {{< /hint >}}
 
 ```bash
-az deployment mg create --name "amba-GeneralDeployment" --template-uri https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/main/patterns/alz/alzArm.json --location $location --management-group-id $pseudoRootManagementGroup --parameters ".\patterns\alz\alzArm.param.json"
+az deployment mg create --name "amba-GeneralDeployment" --template-uri https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/2024-03-01/patterns/alz/alzArm.json --location $location --management-group-id $pseudoRootManagementGroup --parameters ".\patterns\alz\alzArm.param.json"
 ```
 
 ## Next steps

--- a/docs/content/patterns/alz/deploy/Deploy-with-Azure-PowerShell.md
+++ b/docs/content/patterns/alz/deploy/Deploy-with-Azure-PowerShell.md
@@ -50,7 +50,7 @@ If you customized the policies as documented at [How to modify individual polici
 {{< /hint >}}
 
 ```powershell
-New-AzManagementGroupDeployment -Name "amba-GeneralDeployment" -ManagementGroupId $pseudoRootManagementGroup -Location $location -TemplateUri "https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/main/patterns/alz/alzArm.json" -TemplateParameterFile ".\patterns\alz\alzArm.param.json"
+New-AzManagementGroupDeployment -Name "amba-GeneralDeployment" -ManagementGroupId $pseudoRootManagementGroup -Location $location -TemplateUri "https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/2024-03-01/patterns/alz/alzArm.json" -TemplateParameterFile ".\patterns\alz\alzArm.param.json"
 ```
 
 ## Next steps


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Update the deployment documentation and change the command to include the latest release. which currently is "2023-11-14" (new release planned for end of February)
This includes:
Powershell
CLI
GitHub workflows
ADO Pipelines

## This PR fixes/adds/changes/removes

1. Currently our deployment commands in the documentation point to main. We change this to the latest release that we've tested. Now that there is more activity and multiple patterns (with more coming) we should have some extra protection from changes to the policy defintion.


### Breaking Changes

1. No

## As part of this Pull Request I have

- [x ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x ] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [x ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [ x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x ] Ensured PR tests are passing
- [x ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
