### PR TITLE
Update Deploy-only-Service-Health-Alerts.md

### DIFF
--- a/docs/content/patterns/alz/deploy/Deploy-only-Service-Health-Alerts.md
+++ b/docs/content/patterns/alz/deploy/Deploy-only-Service-Health-Alerts.md
@@ -215,7 +215,7 @@ Open the newly created Bicep file in your favorite text editor, such as Visual S
 {
 var loadPolicyDefinitions = {
   All: [
-    loadTextContent('../../../services/AlertsManagement/actionRules/Deploy-AlertProcessingRule-Deploy.json')
+    loadTextContent('../../../services/Resources/subscriptions/Deploy-ServiceHealth-ActionGroups.json')
     loadTextContent('../../../services/Resources/subscriptions/Deploy-ActivityLog-ResourceHealth-UnHealthly-Alert.json')
     loadTextContent('../../../services/Resources/subscriptions/Deploy-ActivityLog-ServiceHealth-Health.json')
     loadTextContent('../../../services/Resources/subscriptions/Deploy-ActivityLog-ServiceHealth-Incident.json')


### PR DESCRIPTION
This PR fixes AMBA Update deployment documentation Service Health
In Custom deployment step 2.
In load Policy Definitions: removed Alert processing rule.
included new action group policy