### PR TITLE
JCore-FixAVD_Deployment_Failure

### DIFF
--- a/patterns/avd/avdArm.json
+++ b/patterns/avd/avdArm.json
@@ -11,7 +11,7 @@
   "parameters": {
     "_ArtifactsLocation": {
       "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/main/patterns/alz/scripts/",
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/main/patterns/avd/scripts/",
       "metadata": {
         "description": "Location of needed scripts to deploy solution."
       }

--- a/patterns/avd/templates/deploy.bicep
+++ b/patterns/avd/templates/deploy.bicep
@@ -6,8 +6,7 @@ param SetEnabled bool = false
  */
 
 @description('Location of needed scripts to deploy solution.')
-param _ArtifactsLocation string = 'https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/main/patterns/alz/scripts/'
-// https://raw.githubusercontent.com/Azure/avdaccelerator/main/workload/scripts/alerts/  OLD from AVD Accelerator Repo
+param _ArtifactsLocation string = 'https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/main/patterns/avd/scripts/'
 
 @description('SaS token if needed for script location.')
 @secure()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

The deployment was failing due to the path for the Script files for the Automation Account being incorrect. 

## This PR fixes/adds/changes/removes

1. _ArtifactsLocation parameter default location was incorrect and contained 'alz' in the path versus the newer location with 'avd' 
https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/main/patterns/avd/scripts/

### Breaking Changes

1. N/A

## As part of this Pull Request I have

- [X] Read the Contribution Guide and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [X] Ensured PR tests are passing
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
