### PR TITLE
SAP Disk AMBA review by PM Alec Becker

### DIFF
--- a/docs/content/patterns/specialized/sap/_index.md
+++ b/docs/content/patterns/specialized/sap/_index.md
@@ -26,10 +26,9 @@ Table below shows the Alerts configured after the deployment.
 | VmAvailabilityMetric < 1                                   | < 1 (0)                                    | Metric Alerts           | 5 min     | Default        |
 | OS Disk Bandwidth Consumed Percentage >= 95                | 95 (0)                                     | Metric Alerts           | 5 min     | Default        |
 | OS Disk Bandwidth Consumed Percentage >= 90                | 90 (1)                                     | Metric Alerts           | 5 min     | Default        |
-| Available Memory Bytes < 500000000                         | < 500000000 (1)                            | Metric Alerts           | 5 min     | Default        |
-| Data Disk IOPS Consumed Percentage > 95                    | \>95 (3)                                   | Metric Alerts           | 5 min     | Default        |
-| OS Disk Bandwidth Consumed Percentage >= 90                | \>=90 (0)                                  | Metric Alerts           | 5 min     | Default        |
 | OS Disk Bandwidth Consumed Percentage >= 80                | \>= 80 (2)                                 | Metric Alerts           | 5 min     | Default        |
+| Available Memory Bytes < 500000000                         | < 500000000 (1)                            | Metric Alerts           | 5 min     | Default        |
+| Data Disk IOPS Consumed Percentage > 90                    | \>90 (3)                                   | Metric Alerts           | 5 min     | Default        |
 | VolumeConsumedSizePercentage >= 95                         | \>=95 (0)                                  | Metric Alerts           | 5 min     | Default        |
 | VolumeConsumedSizePercentage >= 90                         | \>=90 (2)                                  | Metric Alerts           | 5 min     | Default        |
 | UnhealthyHostCount >=1                                     | \>=1 (0)                                   | Metric Alerts           | 5 min     | Default        |


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

I've asked Disk Metrics PM Alec Becker to review Disk related AMBA.

## This PR fixes/adds/changes/removes

1. Remove "OS Disk Bandwidth Consumed Percentage >= 90" since it's duplicated.
2. Change "Data Disk IOPS Consumed Percentage > 95" to be threshold 90.
3. In progress: < Not yet applied> Remove static number alerts, customer should use the percentage ones. E.g. "Available Memory Bytes < 500000000", "Linux OS High memory usage MB > 5000", "Linux OS High Disk Read MB per Sec > 10"
4. Remove Latency related 

### Breaking Changes

N/A

## As part of this Pull Request I have

- [X] Read the Contribution Guide and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [X] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
