### PR TITLE
Add workflow and tests

### DIFF
--- a/.github/actions-pester/Test-ArmTemplates.Tests.ps1
+++ b/.github/actions-pester/Test-ArmTemplates.Tests.ps1
@@ -1,0 +1,73 @@
+<# Script to validate ARM templates using the Test-AzTemplate cmdlet #>
+
+# Define a function to get the list of changed files in a pull request
+function Get-ChangedFiles {
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        # Parameter to filter files by path
+        [Parameter()]
+        [String]$pathFilter,
+
+        # Parameter to filter files by extension
+        [Parameter()]
+        [String]$extensionFilter,
+
+        # Parameter to specify the pull request branch, defaulting to the GitHub head reference
+        [Parameter()]
+        [String]$PRBranch = "$($env:GITHUB_HEAD_REF)"
+    )
+    
+    # Get the list of changed files between the main branch and the pull request branch
+    $changedFiles = git diff --name-only origin/main origin/$PRBranch
+    
+    # Create a regex pattern to filter files based on the provided path and extension
+    $regex = "$pathFilter.*\.$extensionFilter"
+    
+    # Filter the changed files using the regex pattern
+    $resultFiles = $changedFiles | Where-Object { $PSItem -match $regex }
+
+    # Return the filtered files
+    $resultFiles | ForEach-Object {
+        return $_
+    }
+}
+
+# Get the list of modified ARM template files
+$ModifiedFiles = @(Get-ChangedFiles -pathFilter 'templates/arm' -extensionFilter 'json')
+
+# Check if there are any modified ARM template files
+if ($null -ne $ModifiedFiles) {
+    Write-Output "These are the modified ARM templates: $($ModifiedFiles)"
+} else {
+    Write-Output "There are no modified ARM templates"
+}
+
+# Initialize a counter for the number of failed tests
+$NumberOfFailedTests = 0
+
+# Iterate over each modified ARM template file
+$ModifiedFiles | ForEach-Object {
+    $TemplatePath = $PSItem
+    Write-Output "Test $TemplatePath"
+    
+    # Run the Test-AzTemplate cmdlet to test the ARM template
+    $testResults = Test-AzTemplate -TemplatePath $TemplatePath -Test deploymentTemplate -ErrorAction Continue
+    
+    # Filter the test results to find any failed tests
+    $failedTests = $testResults | Where-Object { $PSItem.Passed -ne $True }
+    
+    # If there are failed tests, log a warning and increment the failed tests counter
+    if ($failedTests -ne $null) {
+        $failedTests | ForEach-Object {
+            Write-Warning "$($PSItem | Out-String)"
+            $NumberOfFailedTests++
+        }
+    }
+}
+
+# If there are any failed tests, log an error and exit with a non-zero status
+If ($NumberOfFailedTests -gt 0) {
+    Write-Error "There are $NumberOfFailedTests failed tests"
+    exit 1
+}
+

--- a/.github/actions-pester/Test-ArmTemplates.Tests.ps1
+++ b/.github/actions-pester/Test-ArmTemplates.Tests.ps1
@@ -1,7 +1,7 @@
 <# Script to validate ARM templates using the Test-AzTemplate cmdlet #>
 
 # Define a function to get the list of changed files in a pull request
-function Get-ChangedFiles {
+function Get-ChangedFile {
     [CmdletBinding(SupportsShouldProcess)]
     param (
         # Parameter to filter files by path
@@ -32,7 +32,7 @@ function Get-ChangedFiles {
 }
 
 # Get the list of modified ARM template files
-$ModifiedFiles = @(Get-ChangedFiles -pathFilter 'templates/arm' -extensionFilter 'json')
+$ModifiedFiles = @(Get-ChangedFile -pathFilter 'templates/arm' -extensionFilter 'json')
 
 # Check if there are any modified ARM template files
 if ($null -ne $ModifiedFiles) {

--- a/.github/actions-pester/Test-ArmTemplates.Tests.ps1
+++ b/.github/actions-pester/Test-ArmTemplates.Tests.ps1
@@ -16,13 +16,12 @@ function Get-ChangedFiles {
         [Parameter()]
         [String]$PRBranch = "$($env:GITHUB_HEAD_REF)"
     )
-    
     # Get the list of changed files between the main branch and the pull request branch
     $changedFiles = git diff --name-only origin/main origin/$PRBranch
-    
+
     # Create a regex pattern to filter files based on the provided path and extension
     $regex = "$pathFilter.*\.$extensionFilter"
-    
+
     # Filter the changed files using the regex pattern
     $resultFiles = $changedFiles | Where-Object { $PSItem -match $regex }
 
@@ -49,13 +48,13 @@ $NumberOfFailedTests = 0
 $ModifiedFiles | ForEach-Object {
     $TemplatePath = $PSItem
     Write-Output "Test $TemplatePath"
-    
+
     # Run the Test-AzTemplate cmdlet to test the ARM template
     $testResults = Test-AzTemplate -TemplatePath $TemplatePath -Test deploymentTemplate -ErrorAction Continue
-    
+
     # Filter the test results to find any failed tests
     $failedTests = $testResults | Where-Object { $PSItem.Passed -ne $True }
-    
+
     # If there are failed tests, log a warning and increment the failed tests counter
     if ($failedTests -ne $null) {
         $failedTests | ForEach-Object {

--- a/.github/workflows/unit-test-arm-templates.yml
+++ b/.github/workflows/unit-test-arm-templates.yml
@@ -1,3 +1,4 @@
+---
 name: Unit Test ARM templates with arm-ttk
 
 ##########################################
@@ -14,7 +15,7 @@ on:
       - ready_for_review
     paths:
       - "services/**/**/templates/arm/**.json"
-  workflow_dispatch: {}
+  workflow_dispatch: { }
 
 permissions:
   id-token: write

--- a/.github/workflows/unit-test-arm-templates.yml
+++ b/.github/workflows/unit-test-arm-templates.yml
@@ -1,0 +1,42 @@
+name: Unit Test ARM templates with arm-ttk
+
+##########################################
+# Start the job on PR for all branches #
+#########################################
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    paths:
+      - "services/**/**/templates/arm/**.json"
+  workflow_dispatch: {}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  validate-arm-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+      - name: Clone ARM-TTK repo
+        uses: GuillaumeFalourd/clone-github-repo-action@v3
+        with:
+          owner: 'Azure'
+          repository: 'arm-ttk'
+      - name: Test Modified ARM templates
+        shell: pwsh
+        run: |
+            Import-Module ./arm-ttk/arm-ttk/arm-ttk.psd1
+            ./.github/actions-pester/Test-ArmTemplates.Tests.ps1


### PR DESCRIPTION
# Overview/Summary

Add workflow and test scripts to verify ARM templates updated based on https://github.com/Azure/arm-ttk. Described in https://dev.azure.com/CSUSolEng/Guidance%20-%20Observability/_workitems/edit/37410

## This PR fixes/adds/changes/removes

1. Add .github/workflows/unit-test-arm-templates.yml to run whenever a PR is made updating one or more ARM templates
2. Add .github/actions/Test-Armtemplates.Tests.ps1 which does the actual testing. 


### Breaking Changes

No breaking changes.

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
