### PR TITLE
changed two AOAI alerts to visible with the proper thresholds

### DIFF
--- a/services/CognitiveServices/accounts/alerts.yaml
+++ b/services/CognitiveServices/accounts/alerts.yaml
@@ -343,18 +343,18 @@
   description: Utilization % for a provisoned-managed deployment, calculated as (PTUs consumed / PTUs deployed) x 100.
   type: Metric
   verified: false
-  visible: false
+  visible: true
   tags: manual-ck
   properties:
     metricName: AzureOpenAIProvisionedManagedUtilizationV2
     metricNamespace: Microsoft.CognitiveServices/accounts
-    severity: 0
+    severity: 2
     windowSize: PT5M
     evaluationFrequency: PT1M
     timeAggregation: Total
     operator: GreaterThan
     criterionType: StaticThresholdCriterion
-    threshold: 0.0
+    threshold: 80
   guid: 693a3b37-1e2a-42d1-aaed-b1f374276d1c
 - name: AzureOpenAIRequests
   description: Number of calls made to the Azure OpenAI API over a period of time.
@@ -377,18 +377,18 @@
   description: Recommended latency (responsiveness) measure for streaming requests.
   type: Metric
   verified: false
-  visible: false
+  visible: true
   tags: manual-ck
   properties:
     metricName: AzureOpenAITimeToResponse
     metricNamespace: Microsoft.CognitiveServices/accounts
-    severity: 0
+    severity: 2
     windowSize: PT5M
     evaluationFrequency: PT1M
     timeAggregation: Total
     operator: GreaterThan
     criterionType: StaticThresholdCriterion
-    threshold: 0.0
+    threshold: 200ms
   guid: 995cc12a-1887-4669-92c5-70a6ca8bfe70
 - name: BaselineEstimatorOverallReward
   description: Baseline Estimator Overall Reward.

--- a/services/CognitiveServices/accounts/alerts.yaml
+++ b/services/CognitiveServices/accounts/alerts.yaml
@@ -374,7 +374,7 @@
     threshold: 0.0
   guid: a1528d17-f288-46b1-b084-8b8fe3af90fa
 - name: AzureOpenAITimeToResponse
-  description: Recommended latency (responsiveness) measure for streaming requests.
+  description: Recommended latency (responsiveness) measure for streaming requests. Time in milliseconds.
   type: Metric
   verified: true
   visible: true
@@ -388,7 +388,7 @@
     timeAggregation: Total
     operator: GreaterThan
     criterionType: StaticThresholdCriterion
-    threshold: 200ms
+    threshold: 200
   guid: 995cc12a-1887-4669-92c5-70a6ca8bfe70
 - name: BaselineEstimatorOverallReward
   description: Baseline Estimator Overall Reward.

--- a/services/CognitiveServices/accounts/alerts.yaml
+++ b/services/CognitiveServices/accounts/alerts.yaml
@@ -308,19 +308,19 @@
 - name: AzureOpenAIContextTokensCacheMatchRate
   description: Percentage of the prompt tokens hit the cache, avaiable for PTU-managed.
   type: Metric
-  verified: false
-  visible: false
+  verified: true
+  visible: true
   tags: manual-ck
   properties:
     metricName: AzureOpenAIContextTokensCacheMatchRate
     metricNamespace: Microsoft.CognitiveServices/accounts
-    severity: 0
+    severity: 2
     windowSize: PT5M
     evaluationFrequency: PT1M
     timeAggregation: Total
     operator: GreaterThan
     criterionType: StaticThresholdCriterion
-    threshold: 0.0
+    threshold: 75
   guid: 81f8369c-65bf-4194-bfd2-ffdfa2470577
 - name: AzureOpenAIProvisionedManagedUtilization
   description: Utilization % for a provisoned-managed deployment, calculated as (PTUs consumed / PTUs deployed) x 100.
@@ -342,7 +342,7 @@
 - name: AzureOpenAIProvisionedManagedUtilizationV2
   description: Utilization % for a provisoned-managed deployment, calculated as (PTUs consumed / PTUs deployed) x 100.
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags: manual-ck
   properties:
@@ -376,7 +376,7 @@
 - name: AzureOpenAITimeToResponse
   description: Recommended latency (responsiveness) measure for streaming requests.
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags: manual-ck
   properties:


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. added threshold and severity for both AzureOpenAITimeToResponse and AzureOpenAIProvisionedManagedUtilizationV2
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
