### PR TITLE
docs: update Temporary disabling notifications page with filter limitations and example

### DIFF
--- a/docs/content/patterns/alz/Temporarily-disabling-notifications.md
+++ b/docs/content/patterns/alz/Temporarily-disabling-notifications.md
@@ -27,7 +27,7 @@ To configure the APR, do the following:
 
 2. Click on the ARP named ***apr-AMBA-<mark>subscription display name</mark>-002*** with rule type **Suppression**
 
-  ![Suppression aler processing rule](../media/SuppressionAlertProcessingRule.png)
+  ![Suppression alert processing rule](../media/SuppressionAlertProcessingRule.png)
 
 3. Click on ***Edit***
 
@@ -42,11 +42,13 @@ To configure the APR, do the following:
     ![Configure filter](../media/Filter-AlertProcessingRule.png)
 
   {{< hint type=Important >}}
-  Each filter can include up to **five** values. Should you need more than **5** resources, add more lines of filter.
+  Each filter can include up to **five** values. Should you need more than **5** resources, you will need to create a new Alert processing rule to suppress notifications, as each filter type can only be used once within an Alert processing rule.
   {{< /hint >}}
 
-5. Click on ***Review + save*** and then ***Save***
+1. Click on ***Review + save*** and then ***Save***
 
 {{< hint type=Note >}}
   It is possible to apply other types of filter. For a complete list of allowed scopes and filters, refer to the official [Scope and filters for alert processing rules](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-processing-rules?tabs=portal#scope-and-filters-for-alert-processing-rules) documentation.
+
+  For example, you could add the *Alert Rule name* as a filter to only suppress the *ResourceHealthUnhealthyAlert* for specific resources during maintenance instead of all resource-related alerts.
   {{< /hint >}}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR adds/changes/removes

1. Clarifies/corrects the documentation page [Temporarily disabling notifications](https://azure.github.io/azure-monitor-baseline-alerts/patterns/alz/Temporarily-disabling-notifications/) in regards to limits when using filter types in that you can only use a filter type once in an Alert processing rule.
2. Adds an example in combining filters in a suppression rule

### Breaking Changes

_NONE_

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
