### PR TITLE
Update visibility of metrics in alerts configuration to false for alerts that are not configured properly

### DIFF
--- a/services/Network/expressRouteCircuits/alerts.yaml
+++ b/services/Network/expressRouteCircuits/alerts.yaml
@@ -140,7 +140,7 @@
   description: null
   type: Metric
   verified: false
-  visible: true
+  visible: false
   tags:
   - auto-generated
   - agc-15
@@ -163,7 +163,7 @@
   description: null
   type: Metric
   verified: false
-  visible: true
+  visible: false
   tags:
   - auto-generated
   - agc-14
@@ -188,7 +188,7 @@
   verified: false
   visible: false
   tags:
-  - auto-generateD
+  - auto-generated
   - agc-13
   severity: null
   windowSize: null

--- a/services/Network/loadBalancers/alerts.yaml
+++ b/services/Network/loadBalancers/alerts.yaml
@@ -161,7 +161,7 @@
   description: Total number of bytes passing through load balancer
   type: Metric
   verified: false
-  visible: true
+  visible: false
   properties:
     metricName: Bytecount
     metricNamespace: Microsoft.Network/loadBalancers
@@ -176,7 +176,7 @@
   description: total number of packet passing through load balancer
   type: Metric
   verified: false
-  visible: true
+  visible: false
   properties:
     metricName: PacketCount
     metricNamespace: Microsoft.Network/loadBalancers
@@ -187,13 +187,13 @@
     criterionType: StaticThresholdCriterion
     autoMitigate: false
   guid: d766dc3e-42cc-42a7-ba4f-3c1d7fa295c5
-- name: AllocatedSnartPorts
+- name: AllocatedSnatPorts
   description: total number of port allocated for SNAT
   type: Metric
   verified: false
-  visible: true
+  visible: false
   properties:
-    metricName: AllocatedSnartPorts
+    metricName: AllocatedSnatPorts
     metricNamespace: Microsoft.Network/loadBalancers
     severity: 1
     windowSize: PT5M
@@ -206,7 +206,7 @@
   description: number of syn packet which represent an attempt to establish tcp connection.
   type: Metric
   verified: false
-  visible: true
+  visible: false
   properties:
     metricName: SYNCount
     metricNamespace: Microsoft.Network/loadBalancers


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Update visibility of metrics in alerts configuration to false for alerts that are not configured properly

## This PR fixes/adds/changes/removes

1. Update visibility of metrics in alerts configuration to false for alerts that are not configured properly

### Breaking Changes


## As part of this Pull Request I have

- [X] Read the Contribution Guide and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [X] Ensured PR tests are passing
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
