### PR TITLE
Update alert description for ProbeAgentCurrentEndpointStateByProfileResourceId to remove quotes around "Enabled"

### DIFF
--- a/services/Network/trafficmanagerprofiles/alerts.yaml
+++ b/services/Network/trafficmanagerprofiles/alerts.yaml
@@ -1,5 +1,5 @@
 - name: ProbeAgentCurrentEndpointStateByProfileResourceId
-  description: 1 if an endpoint's probe status is "Enabled", 0 otherwise.
+  description: 1 if an endpoint's probe status is Enabled, 0 otherwise.
   type: Metric
   verified: false
   visible: true


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Update alert description for ProbeAgentCurrentEndpointStateByProfileResourceId to remove quotes around "Enabled"

## This PR fixes/adds/changes/removes

1. Update alert description for ProbeAgentCurrentEndpointStateByProfileResourceId to remove quotes around "Enabled"

### Breaking Changes

## As part of this Pull Request I have

- [X] Read the Contribution Guide and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [X] Ensured PR tests are passing
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
