### PR TITLE
Github action to validate yml schemas

### DIFF
--- a/.github/workflows/validate-yml-schema.yml
+++ b/.github/workflows/validate-yml-schema.yml
@@ -1,0 +1,50 @@
+---
+  name: Validate yml schemas
+
+  ##########################################
+  # Start the job on PR for all branches #
+  #########################################
+
+  on:
+    pull_request:
+      types:
+        - opened
+        - reopened
+        - synchronize
+        - ready_for_review
+      paths:
+        - "services/**/**/**.yaml"
+    workflow_dispatch: { }
+
+  jobs:
+    validate-yaml-files:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+            ref: ${{github.event.pull_request.head.ref}}
+            repository: ${{github.event.pull_request.head.repo.full_name}}
+        - name: Get all changed yaml files
+          id: changed-yaml-files
+          uses: tj-actions/changed-files@v45
+          with:
+            files: |
+              services/**/**/**.yaml
+        - name: List all changed yaml files
+          if: steps.changed-yaml-files.outputs.any_changed == 'true'
+          env:
+            ALL_CHANGED_FILES: ${{ steps.changed-yaml-files.outputs.all_changed_files }}
+          run: |
+                for file in ${ALL_CHANGED_FILES}; do
+                echo "File changed: $file"
+                done
+        - name: validate yaml files
+          id: validate-yaml-files
+          if: steps.changed-yaml-files.outputs.any_changed == 'true'
+          run: |
+              python .github/yml-schemas/validate_yml.py "${{ steps.changed-yaml-files.outputs.all_changed_files }}"
+
+
+

--- a/.github/yml-schemas/defaultAdminActivityLog.json
+++ b/.github/yml-schemas/defaultAdminActivityLog.json
@@ -1,0 +1,167 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/Welcome",
+    "definitions": {
+        "Welcome": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "verified": {
+                    "type": "boolean"
+                },
+                "visible": {
+                    "type": "boolean"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "$ref": "#/definitions/WelcomeProperties"
+                },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Reference"
+                    }
+                },
+                "deployments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Deployment"
+                    }
+                },
+                "guid": {
+                    "type": "string",
+                    "format": "uuid"
+                }
+            },
+            "required": [
+                "deployments",
+                "description",
+                "guid",
+                "name",
+                "properties",
+                "references",
+                "tags",
+                "type",
+                "verified",
+                "visible"
+            ],
+            "title": "Welcome"
+        },
+        "Deployment": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "template": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "$ref": "#/definitions/DeploymentProperties"
+                }
+            },
+            "required": [
+                "name",
+                "properties",
+                "tags",
+                "template",
+                "type"
+            ],
+            "title": "Deployment"
+        },
+        "DeploymentProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scope": {
+                    "type": "string"
+                },
+                "policyScope": {
+                    "type": "string"
+                },
+                "documented": {
+                    "type": "boolean"
+                },
+                "alertName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alertName",
+                "documented",
+                "policyScope",
+                "scope"
+            ],
+            "title": "DeploymentProperties"
+        },
+        "WelcomeProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "operationName": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "category",
+                "operationName",
+                "status"
+            ],
+            "title": "WelcomeProperties"
+        },
+        "Reference": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "https"
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "url"
+            ],
+            "title": "Reference"
+        }
+    }
+}

--- a/.github/yml-schemas/defaultDynamicMetric.json
+++ b/.github/yml-schemas/defaultDynamicMetric.json
@@ -1,0 +1,233 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/Welcome",
+    "definitions": {
+        "Welcome": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "verified": {
+                    "type": "boolean"
+                },
+                "visible": {
+                    "type": "boolean"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "$ref": "#/definitions/Properties"
+                },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Reference"
+                    }
+                },
+                "deployments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Deployment"
+                    }
+                },
+                "guid": {
+                    "type": "string",
+                    "format": "uuid"
+                }
+            },
+            "required": [
+                "description",
+                "guid",
+                "name",
+                "properties",
+                "type",
+                "verified",
+                "visible"
+            ],
+            "title": "Welcome"
+        },
+        "Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "metricName": {
+                    "type": "string"
+                },
+                "metricNamespace": {
+                    "type": "string"
+                },
+                "severity": {
+                    "type": "integer"
+                },
+                "windowSize": {
+                    "type": "string"
+                },
+                "evaluationFrequency": {
+                    "type": "string"
+                },
+                "timeAggregation": {
+                    "type": "string"
+                },
+                "operator": {
+                    "type": "string"
+                },
+                "criterionType": {
+                    "type": "string"
+                },
+                "alertSensitivity": {
+                    "type": "string"
+                },
+                "failingPeriods": {
+                    "$ref": "#/definitions/FailingPeriods"
+                },
+                "dimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Dimension"
+                    }
+                },
+                "threshold": {
+                    "type": "number"
+                },
+                "autoMitigate": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "criterionType",
+                "evaluationFrequency",
+                "metricName",
+                "metricNamespace",
+                "operator",
+                "severity",
+                "timeAggregation",
+                "windowSize",
+                "failingPeriods"
+            ],
+            "title": "Properties"
+        },
+        "FailingPeriods": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "numberOfEvaluationPeriods": {
+                    "type": "integer"
+                },
+                "minFailingPeriodsToAlert": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "minFailingPeriodsToAlert",
+                "numberOfEvaluationPeriods"
+            ],
+            "title": "FailingPeriods"
+        },
+        "Dimension": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "operator": {
+                    "type": "string"
+                },
+                "values": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "operator",
+                "values"
+            ],
+            "title": "Dimension"
+        },
+        "Reference": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "https"
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "url"
+            ],
+            "title": "Reference"
+        },
+        "Deployment": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "template": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "$ref": "#/definitions/DeploymentProperties"
+                }
+            },
+            "required": [
+                "name",
+                "properties",
+                "tags",
+                "template",
+                "type"
+            ],
+            "title": "Deployment"
+        },
+        "DeploymentProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scope": {
+                    "type": "string"
+                },
+                "multiResource": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "multiResource",
+                "scope"
+            ],
+            "title": "DeploymentProperties"
+        }
+    }
+}

--- a/.github/yml-schemas/defaultLog.json
+++ b/.github/yml-schemas/defaultLog.json
@@ -1,0 +1,247 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "type": "object",
+    "items": {
+        "$ref": "#/definitions/WelcomeElement"
+    },
+    "definitions": {
+        "WelcomeElement": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "verified": {
+                    "type": "boolean"
+                },
+                "visible": {
+                    "type": "boolean"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "$ref": "#/definitions/WelcomeProperties"
+                },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Reference"
+                    }
+                },
+                "deployments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Deployment"
+                    }
+                },
+                "guid": {
+                    "type": "string",
+                    "format": "uuid"
+                }
+            },
+            "required": [
+                "deployments",
+                "description",
+                "guid",
+                "name",
+                "properties",
+                "references",
+                "tags",
+                "type",
+                "verified",
+                "visible"
+            ],
+            "title": "WelcomeElement"
+        },
+        "Deployment": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "template": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "$ref": "#/definitions/DeploymentProperties"
+                }
+            },
+            "required": [
+                "name",
+                "properties",
+                "tags",
+                "template",
+                "type"
+            ],
+            "title": "Deployment"
+        },
+        "DeploymentProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scope": {
+                    "type": "string"
+                },
+                "multiResource": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "multiResource",
+                "scope"
+            ],
+            "title": "DeploymentProperties"
+        },
+        "WelcomeProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "severity": {
+                    "type": "integer"
+                },
+                "operator": {
+                    "type": "string"
+                },
+                "timeAggregation": {
+                    "type": "string"
+                },
+                "windowSize": {
+                    "type": "string"
+                },
+                "evaluationFrequency": {
+                    "type": "string"
+                },
+                "threshold": {
+                    "type": "integer"
+                },
+                "metricMeasureColumn": {
+                    "type": "string"
+                },
+                "resouceIdColumn": {
+                    "type": "string"
+                },
+                "dimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Dimension"
+                    }
+                },
+                "failingPeriods": {
+                    "$ref": "#/definitions/FailingPeriods"
+                },
+                "query": {
+                    "type": "string"
+                },
+                "autoMitigate": {
+                    "type": "boolean"
+                },
+                "autoResolve": {
+                    "type": "boolean"
+                },
+                "autoResolveTime": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "autoMitigate",
+                "autoResolve",
+                "autoResolveTime",
+                "dimensions",
+                "evaluationFrequency",
+                "failingPeriods",
+                "metricMeasureColumn",
+                "operator",
+                "query",
+                "resouceIdColumn",
+                "severity",
+                "threshold",
+                "timeAggregation",
+                "windowSize"
+            ],
+            "title": "WelcomeProperties"
+        },
+        "Dimension": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "operator": {
+                    "type": "string"
+                },
+                "values": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "operator",
+                "values"
+            ],
+            "title": "Dimension"
+        },
+        "FailingPeriods": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "numberOfEvaluationPeriods": {
+                    "type": "integer"
+                },
+                "minFailingPeriodsToAlert": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "minFailingPeriodsToAlert",
+                "numberOfEvaluationPeriods"
+            ],
+            "title": "FailingPeriods"
+        },
+        "Reference": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "https"
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "url"
+            ],
+            "title": "Reference"
+        }
+    }
+}

--- a/.github/yml-schemas/defaultRHActivityLog.json
+++ b/.github/yml-schemas/defaultRHActivityLog.json
@@ -1,0 +1,170 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/Welcome",
+    "definitions": {
+        "Welcome": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "verified": {
+                    "type": "boolean"
+                },
+                "visible": {
+                    "type": "boolean"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "$ref": "#/definitions/WelcomeProperties"
+                },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Reference"
+                    }
+                },
+                "deployments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Deployment"
+                    }
+                },
+                "guid": {
+                    "type": "string",
+                    "format": "uuid"
+                }
+            },
+            "required": [
+                "deployments",
+                "description",
+                "guid",
+                "name",
+                "properties",
+                "references",
+                "tags",
+                "type",
+                "verified",
+                "visible"
+            ],
+            "title": "Welcome"
+        },
+        "Deployment": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "template": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "$ref": "#/definitions/DeploymentProperties"
+                }
+            },
+            "required": [
+                "name",
+                "properties",
+                "tags",
+                "template",
+                "type"
+            ],
+            "title": "Deployment"
+        },
+        "DeploymentProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scope": {
+                    "type": "string"
+                },
+                "policyScope": {
+                    "type": "string"
+                },
+                "documented": {
+                    "type": "boolean"
+                },
+                "alertName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alertName",
+                "documented",
+                "policyScope",
+                "scope"
+            ],
+            "title": "DeploymentProperties"
+        },
+        "WelcomeProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "causes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "currentHealthStatus": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "category",
+                "causes",
+                "currentHealthStatus"
+            ],
+            "title": "WelcomeProperties"
+        },
+        "Reference": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "https"
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "url"
+            ],
+            "title": "Reference"
+        }
+    }
+}

--- a/.github/yml-schemas/defaultSHActivityLog.json
+++ b/.github/yml-schemas/defaultSHActivityLog.json
@@ -128,7 +128,6 @@
                 "incidentType": {
                     "type": "string"
                 }
-                
             },
             "required": [
                 "category",

--- a/.github/yml-schemas/defaultSHActivityLog.json
+++ b/.github/yml-schemas/defaultSHActivityLog.json
@@ -1,0 +1,161 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/Welcome",
+    "definitions": {
+        "Welcome": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "verified": {
+                    "type": "boolean"
+                },
+                "visible": {
+                    "type": "boolean"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "$ref": "#/definitions/WelcomeProperties"
+                },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Reference"
+                    }
+                },
+                "deployments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Deployment"
+                    }
+                },
+                "guid": {
+                    "type": "string",
+                    "format": "uuid"
+                }
+            },
+            "required": [
+                "deployments",
+                "description",
+                "guid",
+                "name",
+                "properties",
+                "references",
+                "tags",
+                "type",
+                "verified",
+                "visible"
+            ],
+            "title": "Welcome"
+        },
+        "Deployment": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "template": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "$ref": "#/definitions/DeploymentProperties"
+                }
+            },
+            "required": [
+                "name",
+                "properties",
+                "tags",
+                "template",
+                "type"
+            ],
+            "title": "Deployment"
+        },
+        "DeploymentProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scope": {
+                    "type": "string"
+                },
+                "policyScope": {
+                    "type": "string"
+                },
+                "documented": {
+                    "type": "boolean"
+                },
+                "alertName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "alertName",
+                "documented",
+                "policyScope",
+                "scope"
+            ],
+            "title": "DeploymentProperties"
+        },
+        "WelcomeProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "incidentType": {
+                    "type": "string"
+                }
+                
+            },
+            "required": [
+                "category",
+                "incidentType"
+            ],
+            "title": "WelcomeProperties"
+        },
+        "Reference": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "https"
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "url"
+            ],
+            "title": "Reference"
+        }
+    }
+}

--- a/.github/yml-schemas/defaultStaticMetric.json
+++ b/.github/yml-schemas/defaultStaticMetric.json
@@ -1,0 +1,208 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/Welcome",
+    "definitions": {
+        "Welcome": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "verified": {
+                    "type": "boolean"
+                },
+                "visible": {
+                    "type": "boolean"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "$ref": "#/definitions/Properties"
+                },
+                "references": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Reference"
+                    }
+                },
+                "deployments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Deployment"
+                    }
+                },
+                "guid": {
+                    "type": "string",
+                    "format": "uuid"
+                }
+            },
+            "required": [
+                "description",
+                "guid",
+                "name",
+                "properties",
+                "type",
+                "verified",
+                "visible"
+            ],
+            "title": "Welcome"
+        },
+        "Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "metricName": {
+                    "type": "string"
+                },
+                "metricNamespace": {
+                    "type": "string"
+                },
+                "severity": {
+                    "type": "integer"
+                },
+                "windowSize": {
+                    "type": "string"
+                },
+                "evaluationFrequency": {
+                    "type": "string"
+                },
+                "timeAggregation": {
+                    "type": "string"
+                },
+                "operator": {
+                    "type": "string"
+                },
+                "criterionType": {
+                    "type": "string"
+                },
+                "dimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Dimension"
+                    }
+                },
+                "threshold": {
+                    "type": "number"
+                },
+                "autoMitigate": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "criterionType",
+                "evaluationFrequency",
+                "metricName",
+                "metricNamespace",
+                "severity",
+                "timeAggregation",
+                "windowSize"
+            ],
+            "title": "Properties"
+        },
+        "Dimension": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "operator": {
+                    "type": "string"
+                },
+                "values": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "operator",
+                "values"
+            ],
+            "title": "Dimension"
+        },
+        "Reference": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "https"
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "url"
+            ],
+            "title": "Reference"
+        },
+        "Deployment": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "template": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "$ref": "#/definitions/DeploymentProperties"
+                }
+            },
+            "required": [
+                "name",
+                "properties",
+                "tags",
+                "template",
+                "type"
+            ],
+            "title": "Deployment"
+        },
+        "DeploymentProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scope": {
+                    "type": "string"
+                },
+                "multiResource": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "multiResource",
+                "scope"
+            ],
+            "title": "DeploymentProperties"
+        }
+    }
+}

--- a/.github/yml-schemas/validate_yml.py
+++ b/.github/yml-schemas/validate_yml.py
@@ -62,8 +62,8 @@ for yaml_file_name in yaml_files:
     print(f"Validating {yaml_file_name}")
     # Validate each entity in the array
     for entity in data:
-        entity_type = entity.get("type").lower()  
-        entity_name = entity.get("name").lower()  
+        entity_type = entity.get("type").lower()
+        entity_name = entity.get("name").lower()
         # switch depending on entity_type
         if entity_type == "activitylog":
             # Get Category in properties

--- a/.github/yml-schemas/validate_yml.py
+++ b/.github/yml-schemas/validate_yml.py
@@ -1,0 +1,97 @@
+import yaml
+import json
+from jsonschema import Draft7Validator, exceptions
+import argparse
+import os
+
+# Set up argument parser
+parser = argparse.ArgumentParser(description='Validate YAML data against JSON schemas.')
+parser.add_argument('yaml_files', type=str, help='The YAML files to validate, separated by spaces')
+
+# Parse arguments
+args = parser.parse_args()
+yaml_files = args.yaml_files.split(' ')
+failed_validation = False
+
+class Colors:
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+
+# Default schema file names
+subschema1_file_name = '.github/yml-schemas/defaultLog.json'
+subschema2_file_name = '.github/yml-schemas/defaultStaticMetric.json'
+subschema3_file_name = '.github/yml-schemas/defaultAdminActivityLog.json'
+subschema4_file_name = '.github/yml-schemas/defaultRHActivityLog.json'
+subschema5_file_name = '.github/yml-schemas/defaultSHActivityLog.json'
+subschema6_file_name = '.github/yml-schemas/defaultDynamicMetric.json'
+
+# Load the subschemas from files
+with open(subschema1_file_name, 'r') as subschema1_file:
+    subschema1 = json.load(subschema1_file)
+
+with open(subschema2_file_name, 'r') as subschema2_file:
+    subschema2 = json.load(subschema2_file)
+
+with open(subschema3_file_name, 'r') as subschema3_file:
+    subschema3 = json.load(subschema3_file)
+
+with open(subschema4_file_name, 'r') as subschema4_file:
+    subschema4 = json.load(subschema4_file)
+
+with open(subschema5_file_name, 'r') as subschema5_file:
+    subschema5 = json.load(subschema5_file)
+
+with open(subschema6_file_name, 'r') as subschema6_file:
+    subschema6 = json.load(subschema6_file)
+
+# Define a mapping of types to schemas
+schemas = {
+    "log": subschema1,
+    "staticthresholdcriterion_metric": subschema2,
+    "administrative_activitylog": subschema3,
+    "resourcehealth_activitylog": subschema4,
+    "servicehealth_activitylog": subschema5,
+    "dynamicthresholdcriterion_metric": subschema6
+}
+
+for yaml_file_name in yaml_files:
+# Load the YAML data from a file
+    with open(yaml_file_name, 'r') as yaml_file:
+        data = yaml.safe_load(yaml_file)
+    print(f"Validating {yaml_file_name}")
+    # Validate each entity in the array
+    for entity in data:
+        entity_type = entity.get("type").lower()  
+        entity_name = entity.get("name").lower()  
+        # switch depending on entity_type
+        if entity_type == "activitylog":
+            # Get Category in properties
+            entity_category = entity.get("properties").get("category").lower()
+            selector = f"{entity_category}_{entity_type}"
+            schema = schemas.get(selector)
+        if entity_type == "metric":
+            entity_category = entity.get("properties").get("criterionType").lower()
+            selector = f"{entity_category}_{entity_type}"
+            schema = schemas.get(selector)
+        if entity_type == "log":
+            schema = schemas.get(entity_type)
+        if schema:
+            validator = Draft7Validator(schema)
+            errors = sorted(validator.iter_errors(entity), key=lambda e: e.path)
+            if errors:
+                print(f"{Colors.WARNING}Validation failed for entity: {entity}{Colors.ENDC}")
+                for error in errors:
+                    print(f"{Colors.WARNING}Error: {error.message}{Colors.ENDC}")
+                    failed_validation = True
+            else:
+                print(f"Validation passed for entity: {entity_name}")
+        else:
+            print(f"{Colors.WARNING}No schema found for entity type: {entity_name}{entity_type}{entity_category}{Colors.ENDC}")
+            failed_validation = True
+if failed_validation:
+    print("One or more validations failed.")
+    exit(1)
+
+
+

--- a/services/AnalysisServices/servers/alerts.yaml
+++ b/services/AnalysisServices/servers/alerts.yaml
@@ -9,7 +9,7 @@
   properties:
     metricName: qpu_metric
     metricNamespace: Microsoft.AnalysisServices/servers
-    severity: 3
+    severity: notConfigured
     windowSize: PT5M
     evaluationFrequency: PT1M
     timeAggregation: Average

--- a/services/AnalysisServices/servers/alerts.yaml
+++ b/services/AnalysisServices/servers/alerts.yaml
@@ -1,5 +1,5 @@
 - name: qpu_metric
-  description: QPU. Range 0-100 for S1, 0-200 for S2 and 0-400 for S4
+  description: QPU. Range 0-100 for S1, 1-200 for S2 and 0-400 for S4
   type: Metric
   verified: false
   visible: false

--- a/services/AnalysisServices/servers/alerts.yaml
+++ b/services/AnalysisServices/servers/alerts.yaml
@@ -1,5 +1,5 @@
 - name: qpu_metric
-  description: QPU. Range 0-100 for S1, 1-200 for S2 and 0-400 for S4
+  description: QPU. Range 0-100 for S1, 0-200 for S2 and 0-400 for S4
   type: Metric
   verified: false
   visible: false
@@ -9,7 +9,7 @@
   properties:
     metricName: qpu_metric
     metricNamespace: Microsoft.AnalysisServices/servers
-    severity: notConfigured
+    severity: 3
     windowSize: PT5M
     evaluationFrequency: PT1M
     timeAggregation: Average


### PR DESCRIPTION
# Overview/Summary

Add code to validate alert yaml schema on PR. Task is described in https://dev.azure.com/CSUSolEng/Guidance%20-%20Observability/_workitems/edit/37696

## This PR fixes/adds/changes/removes

1. Adds Github action .github/workflows/validate-yml-schema.yml, which will trigger on PR.
2. Adds .github/yml-schemas directory containing the default yml schemas for the various alert types.

### Breaking Changes

May cause previously accepted yml files to be rejected if changes are made since they are not meeting requirements.

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
