### PR TITLE
Remove Template Should Not Contain Blanks test

### DIFF
--- a/services/CognitiveServices/accounts/templates/arm/ServerErrors_3c550d9c-8276-4a61-b0cf-ef437a55e299.json
+++ b/services/CognitiveServices/accounts/templates/arm/ServerErrors_3c550d9c-8276-4a61-b0cf-ef437a55e299.json
@@ -11,7 +11,7 @@
     },
     "alertDescription": {
       "type": "string",
-      "defaultValue": "Number of calls with service internal error (HTTP response code 5xx). ",
+      "defaultValue": "Number of calls with service internal error (HTTP response code 5xx).",
       "metadata": {
         "description": "Description of alert"
       }


### PR DESCRIPTION
# Overview/Summary

Removes the Template Should Not Contain Blanks test, as discussed with @judyer28 
## This PR fixes/adds/changes/removes

Changes the validate yaml schema workflow to remove unwanted test

### Breaking Changes

N/A

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
