### PR TITLE
AVD Alerts v2.2.0 update - docs, sub opt for LAW, bug fixes #315 and #457

### DIFF
--- a/docs/content/patterns/specialized/avd/Known-Issues.md
+++ b/docs/content/patterns/specialized/avd/Known-Issues.md
@@ -4,9 +4,17 @@ geekdocCollapseSection: true
 weight: 100
 ---
 
-## Host Pool Capacity Remaining not reporting
+## VM in Separate Resource Group option fails deployment (Issue #457)
+Updated the custom UI definition to no longer hide the AVD Resource Resource Group selection when selecting option for VMs in seperate resource group(s). This will ensure the value is passed into the ARM template for processing verses the previously noted place holder value of 'Resource Group' with brackets.
+(Fixed on 12/18/24 - v2.1.8)
+
+## Action Group in subsequent deployment fails (Issue #315)
+Action Group creation now gets appended with a unique 13 character value based on the hash of the Subscription Name and current time. This will allow for subsequent deployments to ensure the action group name is unique across subscriptions.
+(Fixed on 12/18/24 - v2.1.8)
+
+## Host Pool Capacity Remaining not reporting (Issue #288)
 After 3/21/24 there was a permission missing that did not allow the automation account to gather the information.
-(Fixed on: 12/10/2024)
+(Fixed on: 12/10/2024 - v2.1.7)
 
 Fix without Redeploying:
 Simply assigning the identity tied to the Automation Account the Virtual Desktop Reader role on the Resource Group that houses the Host Pools.

--- a/docs/content/patterns/specialized/avd/Whats-New.md
+++ b/docs/content/patterns/specialized/avd/Whats-New.md
@@ -8,6 +8,10 @@ For information on what's new please refer to the [Releases](https://github.com/
 
 To update your current deployment with the content from the latest release, please refer to the [Update to new release](Update-to-new-Release.md) page.
 
+## 2024-12-18
+Bug fixes [(See Known Issues Section)](Known-Issues.md)
+Added option to select alternate subscription for Log Analytics and an initial prerequisites note on the first screen.
+
 ## 2024-12-10
 ### After 3/21/2024 Host Pool Capacity Alert Rule would not fire
 An issue was discovered where the Automation Account Identity was not being assigned the Virtual Desktop Reader role on the Resource Group hosting all the AVD Resources. Thus, the output of the script was null which yielded no alerts, regardless of what the host pool capacity currently was. There was a condition on the role assignment that was adjusted so that it will be added at deployment.

--- a/docs/content/patterns/specialized/avd/_index.md
+++ b/docs/content/patterns/specialized/avd/_index.md
@@ -8,7 +8,7 @@ geekdocCollapseSection: true
 This solution provides a baseline of alerts for AVD that are disabled by default and for ensuring administrators and staff get meaningful and timely alerts when there are problems related to an AVD deployment. The deployment has been tested in Azure Global and Azure US Government and will incorporate storage alerts for either or both Azure Files and/or Azure Netapp Files.  This solution initially was part of the Azure Virtual Desktop Solution Accelerator as a brownfield and moved to this location.
 
 **Current Version:**
-v2.1.7 (Dec 10, 2024)
+v2.1.8 (Dec 17, 2024)
 
 ## Alerts Table
 

--- a/patterns/avd/avdArm.json
+++ b/patterns/avd/avdArm.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.31.92.45157",
-      "templateHash": "17094575244347820739"
+      "templateHash": "6799636428937761449"
     }
   },
   "parameters": {
@@ -153,8 +153,8 @@
         "input": "[split(parameters('StorageAccountResourceIds')[copyIndex('StorAcctRGsAll')], '/')[4]]"
       }
     ],
-    "ActionGroupName": "[format('ag-avdmetrics-{0}-{1}', parameters('Environment'), parameters('Location'))]",
-    "AlertDescriptionHeader": "Automated AVD Alert Deployment Solution (v2.1.7)\n",
+    "ActionGroupName": "[format('ag-avdmetrics-{0}-{1}-{2}', parameters('Environment'), parameters('Location'), uniqueString(subscription().displayName, parameters('time')))]",
+    "AlertDescriptionHeader": "Automated AVD Alert Deployment Solution (v2.1.8)\n",
     "AutomationAccountName": "[format('aa-avdmetrics-{0}-{1}-{2}', parameters('Environment'), parameters('Location'), parameters('AlertNamePrefix'))]",
     "CloudEnvironment": "[environment().name]",
     "ResourceGroupCreate": "[if(equals(parameters('ResourceGroupStatus'), 'New'), true(), false())]",

--- a/patterns/avd/avdCustomUi.json
+++ b/patterns/avd/avdCustomUi.json
@@ -20,6 +20,15 @@
 							}
 						},
 						{
+							"name": "infoMessagePrereqs",
+							"type": "Microsoft.Common.InfoBox",
+							"visible": true,
+							"options": {
+								"text": "This page is for the Subscription and region to deploy the Alerts Solution in. The next page will prompt for alternate subscriptions for Log Analytics if it is NOT within this subscription. You will need to ensure you are deploying with an Account that has full Owner over the Resource Group with this resource to allow the proper role assignments for the Automation Account!",
+								"style": "Warning"
+							}
+						},
+						{
 							"name": "HostPoolsApi",
 							"type": "Microsoft.Solutions.ArmApiControl",
 							"request": {
@@ -41,14 +50,6 @@
 							"request": {
 								"method": "GET",
 								"path": "[concat(steps('basics').resourceScope.subscription.id, '/providers/Microsoft.Storage/storageAccounts?api-version=2022-09-01')]"
-							}
-						},
-						{
-							"name": "LogAnalyticsApi",
-							"type": "Microsoft.Solutions.ArmApiControl",
-							"request": {
-								"method": "GET",
-								"path": "[concat(steps('basics').resourceScope.subscription.id, '/providers/microsoft.operationalinsights/workspaces?api-version=2021-06-01')]"
 							}
 						}
 					]
@@ -250,16 +251,58 @@
 							"visible": true
 						},
 						{
-							"name": "LogAnalyticsWorkspaceResource",
-							"type": "Microsoft.Solutions.ResourceSelector",
-							"label": "Insights Log Analytics Workspace",
-							"toolTip": "Log Analytics Workspace in which AVD Insigts and diagnostics data resides in.",
-							"resourceType": "Microsoft.OperationalInsights/workspaces",
-							"constraints": {
-								"required": true
-							},
-							"infoMessages": [],
-							"visible": true
+							"name": "LAWSection",
+							"type": "Microsoft.Common.Section",
+							"label": "Log Analytics Selection",
+							"elements": [
+								{
+									"type": "Microsoft.Common.SubscriptionSelector",
+									"name": "LAWsubscription",
+									"label": "Log Analytics Subscription",
+									"resourceProviders": [
+										"Microsoft.OperationalInsights"
+									]
+								},
+								{
+									"name": "LogAnalyticsApi",
+									"type": "Microsoft.Solutions.ArmApiControl",
+									"request": {
+										"method": "GET",
+										"path": "[concat('/subscriptions/', steps('AlertsConfig').LAWSection.LAWsubscription.subscriptionId, '/providers/microsoft.operationalinsights/workspaces?api-version=2021-06-01')]",
+										"transforms": {
+											"list": "value[*].{label:name, value:id, description:location}"
+										}
+									}
+								},
+								{
+									"name": "LogAnalyticsWorkspaceResource",
+									"type": "Microsoft.Common.DropDown",
+									"label": "Insights Log Analytics Workspace NEW",
+									"toolTip": "Log Analytics Workspace in which AVD Insigts and diagnostics data resides in.",
+									"placeholder": "",
+									"defaultValue": "",
+									"multiselect": false,
+									"selectAll": false,
+									"filter": true,
+									"filterPlaceholder": "Filter items ...",
+									"multiLine": true,
+									"defaultDescription": "A value for selection",
+									"constraints": {
+										"allowedValues": "[steps('AlertsConfig').LAWSection.LogAnalyticsApi.transformed.list]",
+										"required": true
+									},
+									"visible": true
+								},
+								{
+									"name": "infoMessageLogAnalytics",
+									"type": "Microsoft.Common.InfoBox",
+									"visible": true,
+									"options": {
+										"text": "The Log Analytics Workspace in which AVD Insights and diagnostics data resides in.",
+										"style": "Info"
+									}
+								}
+							]
 						},
 						{
 							"name": "optionVMMetrics",
@@ -283,9 +326,9 @@
 							"defaultDescription": "A value for selection",
 							"constraints": {
 								"allowedValues": "[map(steps('basics').ResGroupsApi.value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.id, '\"}')))]",
-								"required": "[if(steps('AlertsConfig').optionVMMetrics, false, true)]"
+								"required": true
 							},
-							"visible": "[if(steps('AlertsConfig').optionVMMetrics, false, true)]"
+							"visible": true
 						},
 						{
 							"name": "HostPools",
@@ -468,7 +511,7 @@
 				"Environment": "[steps('AlertsConfig').Environment]",
 				"HostPoolInfo": "[steps('AlertsConfig').hostPoolInfo]",
 				"HostPools": "[steps('AlertsConfig').HostPools]",
-				"LogAnalyticsWorkspaceResourceId": "[steps('AlertsConfig').LogAnalyticsWorkspaceResource.id]",
+				"LogAnalyticsWorkspaceResourceId": "[steps('AlertsConfig').LAWSection.LogAnalyticsWorkspaceResource]",
 				"ResourceGroupName": "[if(equals(steps('AlertsConfig').ResourceGroupStatus, 'New'), steps('AlertsConfig').resourceGroupNameNew, last(split(steps('AlertsConfig').resourceGroupNameExisting, '/')))]",
 				"ResourceGroupStatus": "[steps('AlertsConfig').ResourceGroupStatus]",
 				"StorageAccountResourceIds": "[steps('AlertsConfig').AzFilesStorageSection.StorageAccountResourceIds]",

--- a/patterns/avd/templates/deploy.bicep
+++ b/patterns/avd/templates/deploy.bicep
@@ -72,8 +72,8 @@ param ANFVolumeResourceIds array = []
 
 param Tags object = {}
 
-var ActionGroupName = 'ag-avdmetrics-${Environment}-${Location}'
-var AlertDescriptionHeader = 'Automated AVD Alert Deployment Solution (v2.1.7)\n' // DESCRIPTION HEADER AND VERSION <-----------------------------
+var ActionGroupName = 'ag-avdmetrics-${Environment}-${Location}-${uniqueString(subscription().displayName, time)}'
+var AlertDescriptionHeader = 'Automated AVD Alert Deployment Solution (v2.1.8)\n' // DESCRIPTION HEADER AND VERSION <-----------------------------
 var AutomationAccountName = 'aa-avdmetrics-${Environment}-${Location}-${AlertNamePrefix}'
 var CloudEnvironment = environment().name
 var ResourceGroupCreate = ResourceGroupStatus == 'New' ? true : false


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Update to v2.2.0 includes documentation updates and bug fixes for issues #315  and #457 as well as a feature update to allow alternate subscription selection for Log Analytics resource.

## This PR fixes/adds/changes/removes

1. Issue #315 resolved by appending the Action Group name with a random unique 13 characters to allow for subsequent deployments to not fail due to an existing Action Group with the same name.
2. Issue #457 resolved by ensuring UI Definition does not hide the AVD Resources Resource Group Selection when checking the option for VMs in separate Resource Groups.
3. Added Warning text on first deployment page outlining the prerequisite permissions required.
4. Additional Subscription selector for Log Analytics Workspace and Azure Files selection and created titled section for Log Analytics in UI

### Breaking Changes

1. N/A

## As part of this Pull Request I have

- [X] Read the Contribution Guide and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [X] Ensured PR tests are passing
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
