### PR TITLE
fix: evaluationPeriods naming

### DIFF
--- a/patterns/alz/policyDefinitions/policies-Network.json
+++ b/patterns/alz/policyDefinitions/policies-Network.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.32.4.45862",
-      "templateHash": "12111942939098873329"
+      "templateHash": "18121271080586088518"
     }
   },
   "parameters": {
@@ -185,7 +185,7 @@
         "displayName": "Deploy Azure Monitor Baseline Alerts for Connectivity",
         "description": "This initiative deploys Azure Monitor Baseline Alerts to monitor Network components such as Azure Firewalls, ExpressRoute, VPN, and Private DNS Zones.",
         "metadata": {
-          "version": "1.3.1",
+          "version": "1.3.2",
           "category": "Monitoring",
           "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
           "alzCloudEnvironments": [
@@ -3841,7 +3841,7 @@
               "failingPeriods": {
                 "value": "[[[parameters('ERCIRQoSDropBitsinPerSecFailingPeriods')]"
               },
-              "evaluationperiods": {
+              "evaluationPeriods": {
                 "value": "[[[parameters('ERCIRQoSDropBitsinPerSecEvaluationPeriods')]"
               },
               "MonitorDisableTagName": {
@@ -5320,7 +5320,7 @@
         "displayName": "Deploy Azure Monitor Baseline Alerts for Load Balancing",
         "description": "This initiative deploys Azure Monitor Baseline Alerts to monitor Load Balancing Services such as Load Balancer, Application Gateway, Traffic Manager, and Azure Front Door.",
         "metadata": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "category": "Monitoring",
           "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
           "alzCloudEnvironments": [
@@ -7363,7 +7363,7 @@
               "failingPeriods": {
                 "value": "[[[parameters('AGWApplicationGatewayTotalTimeFailingPeriods')]"
               },
-              "evaluationperiods": {
+              "evaluationPeriods": {
                 "value": "[[[parameters('AGWApplicationGatewayTotalTimeEvaluationPeriods')]"
               },
               "MonitorDisableTagName": {
@@ -7399,7 +7399,7 @@
               "failingPeriods": {
                 "value": "[[[parameters('AGWBackendLastByteResponseTimeFailingPeriods')]"
               },
-              "evaluationperiods": {
+              "evaluationPeriods": {
                 "value": "[[[parameters('AGWBackendLastByteResponseTimeEvaluationPeriods')]"
               },
               "MonitorDisableTagName": {
@@ -7516,7 +7516,7 @@
               "failingPeriods": {
                 "value": "[[[parameters('AGWFailedRequestsFailingPeriods')]"
               },
-              "evaluationperiods": {
+              "evaluationPeriods": {
                 "value": "[[[parameters('AGWFailedRequestsEvaluationPeriods')]"
               },
               "MonitorDisableTagName": {
@@ -7552,7 +7552,7 @@
               "failingPeriods": {
                 "value": "[[[parameters('AGWResponseStatusFailingPeriods')]"
               },
-              "evaluationperiods": {
+              "evaluationPeriods": {
                 "value": "[[[parameters('AGWResponseStatusEvaluationPeriods')]"
               },
               "MonitorDisableTagName": {
@@ -7747,7 +7747,7 @@
               "failingPeriods": {
                 "value": "[[[parameters('CDNPOriginLatencyFailingPeriods')]"
               },
-              "evaluationperiods": {
+              "evaluationPeriods": {
                 "value": "[[[parameters('CDNPOriginLatencyEvaluationPeriods')]"
               },
               "MonitorDisableTagName": {
@@ -7780,7 +7780,7 @@
               "failingPeriods": {
                 "value": "[[[parameters('CDNPPercentage4XXFailingPeriods')]"
               },
-              "evaluationperiods": {
+              "evaluationPeriods": {
                 "value": "[[[parameters('CDNPPercentage4XXEvaluationPeriods')]"
               },
               "MonitorDisableTagName": {
@@ -7813,7 +7813,7 @@
               "failingPeriods": {
                 "value": "[[[parameters('CDNPPercentage5XXFailingPeriods')]"
               },
-              "evaluationperiods": {
+              "evaluationPeriods": {
                 "value": "[[[parameters('CDNPPercentage5XXEvaluationPeriods')]"
               },
               "MonitorDisableTagName": {

--- a/patterns/alz/policySetDefinitions/Deploy-Connectivity-Alerts.json
+++ b/patterns/alz/policySetDefinitions/Deploy-Connectivity-Alerts.json
@@ -6,7 +6,7 @@
     "displayName": "Deploy Azure Monitor Baseline Alerts for Connectivity",
     "description": "This initiative deploys Azure Monitor Baseline Alerts to monitor Network components such as Azure Firewalls, ExpressRoute, VPN, and Private DNS Zones.",
     "metadata": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "category": "Monitoring",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
       "alzCloudEnvironments": [
@@ -3662,7 +3662,7 @@
           "failingPeriods": {
             "value": "[[parameters('ERCIRQoSDropBitsinPerSecFailingPeriods')]"
           },
-          "evaluationperiods": {
+          "evaluationPeriods": {
             "value": "[[parameters('ERCIRQoSDropBitsinPerSecEvaluationPeriods')]"
           },
           "MonitorDisableTagName": {

--- a/patterns/alz/policySetDefinitions/Deploy-LoadBalancing-Alerts.json
+++ b/patterns/alz/policySetDefinitions/Deploy-LoadBalancing-Alerts.json
@@ -6,7 +6,7 @@
     "displayName": "Deploy Azure Monitor Baseline Alerts for Load Balancing",
     "description": "This initiative deploys Azure Monitor Baseline Alerts to monitor Load Balancing Services such as Load Balancer, Application Gateway, Traffic Manager, and Azure Front Door.",
     "metadata": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "category": "Monitoring",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
       "alzCloudEnvironments": [
@@ -2049,7 +2049,7 @@
           "failingPeriods": {
             "value": "[[parameters('AGWApplicationGatewayTotalTimeFailingPeriods')]"
           },
-          "evaluationperiods": {
+          "evaluationPeriods": {
             "value": "[[parameters('AGWApplicationGatewayTotalTimeEvaluationPeriods')]"
           },
           "MonitorDisableTagName": {
@@ -2085,7 +2085,7 @@
           "failingPeriods": {
             "value": "[[parameters('AGWBackendLastByteResponseTimeFailingPeriods')]"
           },
-          "evaluationperiods": {
+          "evaluationPeriods": {
             "value": "[[parameters('AGWBackendLastByteResponseTimeEvaluationPeriods')]"
           },
           "MonitorDisableTagName": {
@@ -2202,7 +2202,7 @@
           "failingPeriods": {
             "value": "[[parameters('AGWFailedRequestsFailingPeriods')]"
           },
-          "evaluationperiods": {
+          "evaluationPeriods": {
             "value": "[[parameters('AGWFailedRequestsEvaluationPeriods')]"
           },
           "MonitorDisableTagName": {
@@ -2238,7 +2238,7 @@
           "failingPeriods": {
             "value": "[[parameters('AGWResponseStatusFailingPeriods')]"
           },
-          "evaluationperiods": {
+          "evaluationPeriods": {
             "value": "[[parameters('AGWResponseStatusEvaluationPeriods')]"
           },
           "MonitorDisableTagName": {
@@ -2433,7 +2433,7 @@
           "failingPeriods": {
             "value": "[[parameters('CDNPOriginLatencyFailingPeriods')]"
           },
-          "evaluationperiods": {
+          "evaluationPeriods": {
             "value": "[[parameters('CDNPOriginLatencyEvaluationPeriods')]"
           },
           "MonitorDisableTagName": {
@@ -2466,7 +2466,7 @@
           "failingPeriods": {
             "value": "[[parameters('CDNPPercentage4XXFailingPeriods')]"
           },
-          "evaluationperiods": {
+          "evaluationPeriods": {
             "value": "[[parameters('CDNPPercentage4XXEvaluationPeriods')]"
           },
           "MonitorDisableTagName": {
@@ -2499,7 +2499,7 @@
           "failingPeriods": {
             "value": "[[parameters('CDNPPercentage5XXFailingPeriods')]"
           },
-          "evaluationperiods": {
+          "evaluationPeriods": {
             "value": "[[parameters('CDNPPercentage5XXEvaluationPeriods')]"
           },
           "MonitorDisableTagName": {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

alzlibtool flagged naming inconsistencies of `evaluationPeriods` 

![image](https://github.com/user-attachments/assets/226579cf-2583-4054-8d41-69d15af16a80)

## This PR fixes/adds/changes/removes

1. Fix casing of `evaluationPeriods` 

### Breaking Changes

None

### Evidence

Deployment:

![image](https://github.com/user-attachments/assets/ab18c25c-350b-45e5-955d-9e488c4e8815)

Policy:

![image](https://github.com/user-attachments/assets/972ac696-fbbe-4acf-b325-4d6c3ecd8e11)

Fixing the casing of `evaluationPeriods` in the library fixed the error

![image](https://github.com/user-attachments/assets/eff01f21-e274-4bfe-bb7c-4b7fa5cb1d66)


## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
