### PR TITLE
Add name policy attribute for metric alerts both static and dynamic

### DIFF
--- a/tooling/generate-templates/policy/metric-dynamic-full-arm.json
+++ b/tooling/generate-templates/policy/metric-dynamic-full-arm.json
@@ -196,6 +196,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
+              "name": "[[concat(field('name'), '-##METRIC_NAME##')]",
               "existenceCondition": {
                 "allOf": [
                   {

--- a/tooling/generate-templates/policy/metric-dynamic.json
+++ b/tooling/generate-templates/policy/metric-dynamic.json
@@ -157,6 +157,7 @@
             "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
           ],
           "type": "Microsoft.Insights/metricAlerts",
+          "name": "[[concat(field('name'), '-##METRIC_NAME##')]",
           "existenceCondition": {
             "allOf": [
               {

--- a/tooling/generate-templates/policy/metric-static-full-arm.json
+++ b/tooling/generate-templates/policy/metric-static-full-arm.json
@@ -191,6 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
+              "name": "[[concat(field('name'), '-##METRIC_NAME##')]",
               "existenceCondition": {
                 "allOf": [
                   {

--- a/tooling/generate-templates/policy/metric-static.json
+++ b/tooling/generate-templates/policy/metric-static.json
@@ -152,6 +152,7 @@
             "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
           ],
           "type": "Microsoft.Insights/metricAlerts",
+          "name": "[[concat(field('name'), '-##METRIC_NAME##')]",
           "existenceCondition": {
             "allOf": [
               {


### PR DESCRIPTION
# Overview/Summary
Fix for compliance calculation when multiple alerts are in the same RG.
With 2 or more alerts compliancy calculation will always be done on the last alert returned, and not on itself.
To fix this one needs to use the name attribute to target the individual alerts for the existenceCondition to run on.

https://learn.microsoft.com/en-us/azure/governance/policy/concepts/effect-deploy-if-not-exists

Not to familiar with this codebase, so best guess from my side where the change needed to occur.
Please advice if I have not correctly understood the code structure.

## This PR fixes/adds/changes/removes

1. Adds name attribute with logic to: tooling/generate-templates/policy/metric-dynamic-full-arm.json
2. Adds name attribute with logic to: tooling/generate-templates/policy/metric-dynamic.json
3. Adds name attribute with logic to: tooling/generate-templates/policy/metric-static-full-arm.json
4. Adds name attribute with logic to: tooling/generate-templates/policy/metric-static.json

### Breaking Changes

1. All policies needs to be regenerated to include name attribute in alert policies

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
