### PR TITLE
fix: adjust syntax for amba-vm team reference

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,4 +14,4 @@ services/DBforPostgreSQL @Azure/amba-maintainers @Azure/amba-postgres
 services/Sql @Azure/amba-maintainers @Azure/amba-sql
 
 ## The amba-vm team is responsible for all VM related PRs
-services/Compute @Azure/amba-maintainers @Azure-amba-vm
+services/Compute @Azure/amba-maintainers @Azure/amba-vm


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This pull request includes a minor change to the `.github/CODEOWNERS` file. The change corrects the team assignment for the `services/Compute` files to ensure the proper team is assigned for ownership.

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L17-R17): Corrected the team assignment from `@Azure-amba-vm` to `@Azure/amba-vm` for the `services/Compute` files.

## This PR fixes/adds/changes/removes

1. Fix codeowners file

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
