### PR TITLE
Fixes bug in `dimensions` property for metric & log alerts generation for Bicep templates

### DIFF
--- a/tooling/generate-templates/generate-templates.py
+++ b/tooling/generate-templates/generate-templates.py
@@ -256,7 +256,7 @@ def main():
               values: [{",".join(values)}]
             }}""")
 
-            bicep_template = bicep_template.replace("##DIMENSIONS##", "".join(dimensions))
+            bicep_template = bicep_template.replace("##DIMENSIONS##", "[" + "".join(dimensions) + "]")
           else:
             arm_template = arm_template.replace("##DIMENSIONS##", "[]")
             bicep_template = bicep_template.replace("##DIMENSIONS##", "[]")

--- a/tooling/generate-templates/templates/bicep/log.bicep
+++ b/tooling/generate-templates/templates/bicep/log.bicep
@@ -134,7 +134,7 @@ resource alert 'Microsoft.Insights/scheduledQueryRules@2021-08-01' = {
           query: query
           metricMeasureColumn: metricMeasureColumn
           resourceIdColumn: resourceIdColumn
-          dimensions: [##DIMENSIONS##]
+          dimensions: ##DIMENSIONS##
           operator: operator
           threshold: threshold
           timeAggregation: timeAggregation

--- a/tooling/generate-templates/templates/bicep/metric-dynamic.bicep
+++ b/tooling/generate-templates/templates/bicep/metric-dynamic.bicep
@@ -116,7 +116,7 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
           criterionType: 'DynamicThresholdCriterion'
           name: '1st criterion'
           metricName: '##METRIC_NAME##'
-          dimensions: [##DIMENSIONS##]
+          dimensions: ##DIMENSIONS##
           operator: operator
           alertSensitivity: alertSensitivity
           failingPeriods: {

--- a/tooling/generate-templates/templates/bicep/metric-static.bicep
+++ b/tooling/generate-templates/templates/bicep/metric-static.bicep
@@ -107,7 +107,7 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
         {
           name: '1st criterion'
           metricName: '##METRIC_NAME##'
-          dimensions: [##DIMENSIONS##]
+          dimensions: ##DIMENSIONS##
           operator: operator
           threshold: threshold
           timeAggregation: timeAggregation


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary
Fixes #505


## This PR fixes/adds/changes/removes

* Fixes a bug in `generate-templates.py` and the related bicep base templates that is used for generating bicep `metricAlerts` & `scheduledQueryRules` templates that had the `dimensions` property being populated with an empty array inside already empty array `dimensions: [[]]`.
  * For VS Code Bicep Extension this gives the warning `The enclosing array expected an item of type "MetricDimension", but the provided item was of type "<empty array>".bicep[BCP034](https://aka.ms/bicep/core-diagnostics#BCP034)`
  
  ![image](https://github.com/user-attachments/assets/da58ec88-7c26-47d9-9dea-9e88b28eb4a2)

  * When trying to deploy the Bicep templates with this occurance you are met with the following **error**:
   ```
  "statusMessage": "{\"error\":{\"code\":\"InvalidTemplateDeployment\",\"message\":\"The template deployment '-20250123-122657' is not valid according to the validation procedure. The tracking id is '008e3888-6da0-4861-a9d9-06300c1630b8'. See inner errors for details.\",\"details\":[{\"code\":\"BadRequest\",\"target\":\"/subscriptions/<obfuscated>/resourceGroups/rg-amba-monitoring-sdc-testing/providers/Microsoft.Insights/metricAlerts/AvailableMemoryBytes\",\"message\":\"Cannot deserialize the current JSON array (e.g. [1,2,3]) into type 'AlertRP.Models.MetricAlerts.v20180301.MetricDimension' because the type requires a JSON object (e.g. {\\\"name\\\":\\\"value\\\"}) to deserialize correctly.\\r\\nTo fix this error either change the JSON to a JSON object (e.g. {\\\"name\\\":\\\"value\\\"}) or change the deserialized type to an array or a type that implements a collection interface (e.g. ICollection, IList) like List<T> that can be deserialized from a JSON array. JsonArrayAttribute can also be added to the type to force it to deserialize from a JSON array.\\r\\nPath 'dimensions[0]'.\"}]}}",
  ```

## Testing the fix
* I have tested the fix and ran the `generate-templates.py` from a branch from my fork which can be found here: https://github.com/feliasson/azure-monitor-baseline-alerts/commit/7999ff4ff85620a3e7bce87881e1259d0ab825b4 (I assume they should be updated by your regular CI/CD processes instead of in this PR)
* I have tested deploying all of the `metricAlerts` & `scheduledQueryRules` Bicep templates after the fix from my fork

## As part of this Pull Request I have

- [X] Read the Contribution Guide and ensured this PR is compliant with the guide
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [X] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
