### PR TITLE
Deploy to Azure buttons to use URLs to raw files in GitHub

### DIFF
--- a/docs/layouts/partials/templates/template-tabs.html
+++ b/docs/layouts/partials/templates/template-tabs.html
@@ -5,6 +5,9 @@
 {{ $filename := printf "%s.json" $alert_name | printf "%s"}}
 {{ $file := path.Join "services" $category $type "templates/arm" $filename }}
 {{ $file2 := path.Join "services" $category $type "templates/policy-arm" $filename }}
+{{ $urlprefix := "https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/refs/heads/main/services" }}
+{{ $fileURL := printf "%s/%s/%s/%s/%s" $urlprefix $category $type "templates/arm" $filename }}
+{{ $fileURL2 := printf "%s/%s/%s/%s/%s" $urlprefix $category $type "templates/policy-arm" $filename }}
 <div class="gdoc-tabs">
   <input
     type="radio"
@@ -16,10 +19,10 @@
   <label for="{{ anchorize .alert.name }}-0" class="gdoc-tabs__label">Deploy Alert</label>
   <div class="gdoc-markdown--nested gdoc-tabs__content">
     <p>
-      <a href="https://portal.azure.com/#create/Microsoft.Template/uri/{{ absURL $file }}" target="_blank">
+      <a href="https://portal.azure.com/#create/Microsoft.Template/uri/{{ absURL $fileURL }}" target="_blank">
         <img src="https://aka.ms/deploytoazurebutton"/>
       </a>
-      <a href="https://portal.azure.us/#create/Microsoft.Template/uri/{{ absURL $file }}" target="_blank">
+      <a href="https://portal.azure.us/#create/Microsoft.Template/uri/{{ absURL $fileURL }}" target="_blank">
         <img src="https://aka.ms/deploytoazuregovbutton"/>
       </a>
     </p>
@@ -33,10 +36,10 @@
   <label for="{{ anchorize .alert.name }}-1" class="gdoc-tabs__label">Deploy Policy</label>
   <div class="gdoc-markdown--nested gdoc-tabs__content">
     <p>
-      <a href="https://portal.azure.com/#create/Microsoft.Template/uri/{{ absURL $file2 }}" target="_blank">
+      <a href="https://portal.azure.com/#create/Microsoft.Template/uri/{{ absURL $fileURL2 }}" target="_blank">
         <img src="https://aka.ms/deploytoazurebutton"/>
       </a>
-      <a href="https://portal.azure.us/#create/Microsoft.Template/uri/{{ absURL $file2 }}" target="_blank">
+      <a href="https://portal.azure.us/#create/Microsoft.Template/uri/{{ absURL $fileURL2 }}" target="_blank">
         <img src="https://aka.ms/deploytoazuregovbutton"/>
       </a>
     </p>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Deploy to Azure buttons in the Resources section will now use URLs to the raw files in GitHub.  This avoids issues with Azure downloading the template files.  For example, "There was an error downloading the template ... Ensure that the template is publicly accessible and that the publisher has enabled CORS policy on the endpoint."

## This PR fixes/adds/changes/removes

1. *Replace me*
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
