### PR TITLE
Update alert rules for Cosmos DB

### DIFF
--- a/services/DocumentDB/databaseAccounts/alerts.yaml
+++ b/services/DocumentDB/databaseAccounts/alerts.yaml
@@ -16,12 +16,15 @@
     timeAggregation: Count
     operator: GreaterThan
     criterionType: DynamicThresholdCriterion
+    failingPeriods:
+      numberOfEvaluationPeriods: 4
+      minFailingPeriodsToAlert: 4
+    alertSensitivity: Low
     dimensions:
     - operator: include
       name: statuscode
       values:
       - '429'
-    threshold: 0.0
     enabled: true
   references:
   - name: Monitor Azure Cosmos DB
@@ -258,7 +261,10 @@
     timeAggregation: Average
     operator: GreaterThan
     criterionType: DynamicThresholdCriterion
-    threshold: 0.0
+    failingPeriods:
+      numberOfEvaluationPeriods: 4
+      minFailingPeriodsToAlert: 4
+    alertSensitivity: Low
     enabled: true
   guid: 0914c189-0adc-45d6-8704-d2ae73b9b7b6
 - name: MongoRequests
@@ -279,7 +285,10 @@
     timeAggregation: Count
     operator: GreaterThan
     criterionType: DynamicThresholdCriterion
-    threshold: 0.0
+    failingPeriods:
+      numberOfEvaluationPeriods: 4
+      minFailingPeriodsToAlert: 4
+    alertSensitivity: Low
     enabled: true
   references:
   - name: Monitor Azure Cosmos DB

--- a/services/DocumentDB/databaseAccounts/alerts.yaml
+++ b/services/DocumentDB/databaseAccounts/alerts.yaml
@@ -21,8 +21,7 @@
       name: statuscode
       values:
       - '429'
-    threshold:
-    thresholdSensitivity: low
+    threshold: 0.0
     enabled: true
   references:
   - name: Monitor Azure Cosmos DB
@@ -259,8 +258,7 @@
     timeAggregation: Average
     operator: GreaterThan
     criterionType: DynamicThresholdCriterion
-    threshold:
-    thresholdSensitivity: low
+    threshold: 0.0
     enabled: true
   guid: 0914c189-0adc-45d6-8704-d2ae73b9b7b6
 - name: MongoRequests
@@ -281,8 +279,7 @@
     timeAggregation: Count
     operator: GreaterThan
     criterionType: DynamicThresholdCriterion
-    threshold: 
-    thresholdSensitivity: low
+    threshold: 0.0
     enabled: true
   references:
   - name: Monitor Azure Cosmos DB

--- a/services/DocumentDB/databaseAccounts/alerts.yaml
+++ b/services/DocumentDB/databaseAccounts/alerts.yaml
@@ -14,7 +14,7 @@
     windowSize: PT5M
     evaluationFrequency: PT1M
     timeAggregation: Count
-    operator: GreaterThan
+    operator: GreaterThanOrLessThan
     criterionType: DynamicThresholdCriterion
     failingPeriods:
       numberOfEvaluationPeriods: 4
@@ -226,7 +226,7 @@
     windowSize: PT5M
     evaluationFrequency: PT5M
     timeAggregation: Count
-    operator: GreaterThanOrEqual
+    operator: GreaterThan
     criterionType: StaticThresholdCriterion
     dimensions:
     - operator: include
@@ -256,10 +256,10 @@
     metricName: DataUsage
     metricNamespace: Microsoft.DocumentDB/databaseAccounts
     severity: 3
-    windowSize: PT1M
+    windowSize: PT1H
     evaluationFrequency: PT15M
     timeAggregation: Average
-    operator: GreaterThan
+    operator: GreaterThanOrLessThan
     criterionType: DynamicThresholdCriterion
     failingPeriods:
       numberOfEvaluationPeriods: 4
@@ -283,7 +283,7 @@
     windowSize: PT5M
     evaluationFrequency: PT1M
     timeAggregation: Count
-    operator: GreaterThan
+    operator: GreaterThanOrLessThan
     criterionType: DynamicThresholdCriterion
     failingPeriods:
       numberOfEvaluationPeriods: 4
@@ -337,7 +337,7 @@
   properties:
     metricName: ReplicationLatency
     metricNamespace: Microsoft.DocumentDB/databaseAccounts
-    severity: 2
+    severity: 3
     windowSize: PT15M
     evaluationFrequency: PT5M
     timeAggregation: Average
@@ -423,7 +423,7 @@
   description: Throttled requests for Cosmos DB request rate too large (429) exceptions. Most workloads can tolerate 1-5% of throttled requests.
   type: Metric
   verified: true
-  visible: true
+  visible: false
   tags:
   - rag
   properties:
@@ -441,7 +441,7 @@
       values:
       - '429'
     threshold: 50.0
-    enabled: true
+    enabled: false
   references:
   - name: Diagnose and troubleshoot Azure Cosmos DB request rate too large (429) exceptions
     url: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/troubleshoot-request-rate-too-large?tabs=resource-specific#recommended-solution

--- a/services/DocumentDB/databaseAccounts/alerts.yaml
+++ b/services/DocumentDB/databaseAccounts/alerts.yaml
@@ -67,7 +67,7 @@
 - name: ServiceAvailability
   description: Account requests availability at one hour, day or month granularity
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -187,7 +187,7 @@
 - name: RegionFailover
   description: Region Failed Over
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -213,7 +213,7 @@
 - name: UpdateAccountKeys
   description: Account Keys Updated
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -246,7 +246,7 @@
 - name: DataUsage
   description: Total data usage reported at 5 minutes granularity
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -270,7 +270,7 @@
 - name: MongoRequests
   description: Number of Mongo Requests Made
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -328,7 +328,7 @@
   description: P99 Replication Latency across source and target regions for geo-enabled
     account
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -420,12 +420,11 @@
     url: https://learn.microsoft.com/azure/cosmos-db/create-alerts
   guid: a7958120-a386-46d0-9790-e80bfa72fb22
 - name: ThrottledRequests
-  description: Most workloads can tolerate 1-5% of throttled requests.
+  description: Throttled requests for Cosmos DB request rate too large (429) exceptions. Most workloads can tolerate 1-5% of throttled requests.
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
-  - auto-generated
   - rag
   properties:
     metricName: ThrottledRequests

--- a/services/DocumentDB/databaseAccounts/alerts.yaml
+++ b/services/DocumentDB/databaseAccounts/alerts.yaml
@@ -417,7 +417,7 @@
   visible: true
   tags:
   - auto-generated
-  - rag 
+  - rag
   properties:
     metricName: ThrottledRequests
     metricNamespace: Microsoft.DocumentDB/databaseAccounts

--- a/services/DocumentDB/databaseAccounts/alerts.yaml
+++ b/services/DocumentDB/databaseAccounts/alerts.yaml
@@ -15,13 +15,14 @@
     evaluationFrequency: PT1M
     timeAggregation: Count
     operator: GreaterThan
-    criterionType: StaticThresholdCriterion
+    criterionType: DynamicThresholdCriterion
     dimensions:
     - operator: include
       name: statuscode
       values:
       - '429'
-    threshold: 5.0
+    threshold:
+    thresholdSensitivity: low
     enabled: true
   references:
   - name: Monitor Azure Cosmos DB
@@ -73,9 +74,9 @@
   properties:
     metricName: ServiceAvailability
     metricNamespace: Microsoft.DocumentDB/databaseAccounts
-    severity: 1
+    severity: 2
     windowSize: PT1H
-    evaluationFrequency: PT5M
+    evaluationFrequency: PT1M
     timeAggregation: Average
     operator: LessThan
     criterionType: StaticThresholdCriterion
@@ -193,7 +194,7 @@
   properties:
     metricName: RegionFailover
     metricNamespace: Microsoft.DocumentDB/databaseAccounts
-    severity: 3
+    severity: 2
     windowSize: PT5M
     evaluationFrequency: PT1M
     timeAggregation: Count
@@ -230,7 +231,7 @@
       name: keytype
       values:
       - '*'
-    threshold: 1.0
+    threshold: 0.0
     enabled: true
   references:
   - name: Monitor Azure Cosmos DB
@@ -255,10 +256,11 @@
     severity: 3
     windowSize: PT5M
     evaluationFrequency: PT1M
-    timeAggregation: Total
+    timeAggregation: Average
     operator: GreaterThan
-    criterionType: StaticThresholdCriterion
-    threshold: 2147483648.0
+    criterionType: DynamicThresholdCriterion
+    threshold:
+    thresholdSensitivity: low
     enabled: true
   guid: 0914c189-0adc-45d6-8704-d2ae73b9b7b6
 - name: MongoRequests
@@ -278,8 +280,9 @@
     evaluationFrequency: PT1M
     timeAggregation: Count
     operator: GreaterThan
-    criterionType: StaticThresholdCriterion
-    threshold: 9.0
+    criterionType: DynamicThresholdCriterion
+    threshold: 
+    thresholdSensitivity: low
     enabled: true
   references:
   - name: Monitor Azure Cosmos DB
@@ -328,7 +331,7 @@
   properties:
     metricName: ReplicationLatency
     metricNamespace: Microsoft.DocumentDB/databaseAccounts
-    severity: 3
+    severity: 2
     windowSize: PT15M
     evaluationFrequency: PT5M
     timeAggregation: Average
@@ -410,3 +413,31 @@
   - name: Create alerts for Azure Cosmos DB using Azure Monitor
     url: https://learn.microsoft.com/azure/cosmos-db/create-alerts
   guid: a7958120-a386-46d0-9790-e80bfa72fb22
+- name: ThrottledRequests
+  description: Most workloads can tolerate 1-5% of throttled requests.
+  type: Metric
+  verified: false
+  visible: true
+  tags:
+  - auto-generated
+  - rag 
+  properties:
+    metricName: ThrottledRequests
+    metricNamespace: Microsoft.DocumentDB/databaseAccounts
+    severity: 2
+    windowSize: PT5M
+    evaluationFrequency: PT1M
+    timeAggregation: Count
+    operator: GreaterThan
+    criterionType: StaticThresholdCriterion
+    dimensions:
+    - operator: include
+      name: statuscode
+      values:
+      - '429'
+    threshold: 50.0
+    enabled: true
+  references:
+  - name: Diagnose and troubleshoot Azure Cosmos DB request rate too large (429) exceptions
+    url: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/troubleshoot-request-rate-too-large?tabs=resource-specific#recommended-solution
+  guid: fc8db431-f429-40ee-a51a-de1858198e19

--- a/services/DocumentDB/databaseAccounts/alerts.yaml
+++ b/services/DocumentDB/databaseAccounts/alerts.yaml
@@ -256,8 +256,8 @@
     metricName: DataUsage
     metricNamespace: Microsoft.DocumentDB/databaseAccounts
     severity: 3
-    windowSize: PT5M
-    evaluationFrequency: PT1M
+    windowSize: PT1M
+    evaluationFrequency: PT15M
     timeAggregation: Average
     operator: GreaterThan
     criterionType: DynamicThresholdCriterion


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Updating cosmos DB alert rules with PG signed off alerts. Many Cosmos DB alerts are now PG verified and properties/thresholds are updated, including severity levels, evaluation frequencies, time aggregation, threshold type. New ThrottledRequests alert is added, and for PG verified alerts, verification property is set to true for alert definitions.


## This PR fixes/adds/changes/removes

1. *Updates existing alert rules with new signed off thresholds*
2. *Adds new "Throttled Request" alert for Cosmos DB*
3. *Sets PG verified alerts as true to show verified status*

### Breaking Changes

1. *Replace me*
2. *Replace me*

### Testing evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

Tested extensively to make sure failing check errors are fixed

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
