### PR TITLE
Fix dimensions for VM and HybridCompute Log Alerts 

### DIFF
--- a/services/Compute/virtualMachines/alerts.yaml
+++ b/services/Compute/virtualMachines/alerts.yaml
@@ -292,7 +292,7 @@
       operator: Include
       values:
       - '*'
-    - name: Disk
+    - name: NetworkInterface
       operator: Include
       values:
       - '*'
@@ -350,7 +350,7 @@
       operator: Include
       values:
       - '*'
-    - name: Disk
+    - name: NetworkInterface
       operator: Include
       values:
       - '*'

--- a/services/Compute/virtualMachines/templates/policy-arm/NetworkReadbytessec_b565e73f-71c8-4bb3-a792-903b67775497.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/NetworkReadbytessec_b565e73f-71c8-4bb3-a792-903b67775497.json
@@ -477,7 +477,7 @@
                                         "resourceIdColumn": "_ResourceId",
                                         "metricMeasureColumn": "AggregatedValue",
                                         "timeAggregation": "[[parameters('timeAggregation')]",
-                                        "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"Disk","operator":"Include","values":["*"]}],
+                                        "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"NetworkInterface","operator":"Include","values":["*"]}],
                                         "failingPeriods": {
                                           "numberOfEvaluationPeriods": "[[parameters('evaluationPeriods')]",
                                           "minFailingPeriodsToAlert": "[[parameters('failingPeriods')]"

--- a/services/Compute/virtualMachines/templates/policy-arm/NetworkWritebytessec_552ca1f1-d69d-4bc2-b044-19f81b225fd4.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/NetworkWritebytessec_552ca1f1-d69d-4bc2-b044-19f81b225fd4.json
@@ -477,7 +477,7 @@
                                         "resourceIdColumn": "_ResourceId",
                                         "metricMeasureColumn": "AggregatedValue",
                                         "timeAggregation": "[[parameters('timeAggregation')]",
-                                        "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"Disk","operator":"Include","values":["*"]}],
+                                        "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"NetworkInterface","operator":"Include","values":["*"]}],
                                         "failingPeriods": {
                                           "numberOfEvaluationPeriods": "[[parameters('evaluationPeriods')]",
                                           "minFailingPeriodsToAlert": "[[parameters('failingPeriods')]"

--- a/services/Compute/virtualMachines/templates/policy/NetworkReadbytessec_b565e73f-71c8-4bb3-a792-903b67775497.json
+++ b/services/Compute/virtualMachines/templates/policy/NetworkReadbytessec_b565e73f-71c8-4bb3-a792-903b67775497.json
@@ -435,7 +435,7 @@
                                     "resourceIdColumn": "_ResourceId",
                                     "metricMeasureColumn": "AggregatedValue",
                                     "timeAggregation": "[[parameters('timeAggregation')]",
-                                    "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"Disk","operator":"Include","values":["*"]}],
+                                    "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"NetworkInterface","operator":"Include","values":["*"]}],
                                     "failingPeriods": {
                                       "numberOfEvaluationPeriods": "[[parameters('evaluationPeriods')]",
                                       "minFailingPeriodsToAlert": "[[parameters('failingPeriods')]"

--- a/services/Compute/virtualMachines/templates/policy/NetworkWritebytessec_552ca1f1-d69d-4bc2-b044-19f81b225fd4.json
+++ b/services/Compute/virtualMachines/templates/policy/NetworkWritebytessec_552ca1f1-d69d-4bc2-b044-19f81b225fd4.json
@@ -435,7 +435,7 @@
                                     "resourceIdColumn": "_ResourceId",
                                     "metricMeasureColumn": "AggregatedValue",
                                     "timeAggregation": "[[parameters('timeAggregation')]",
-                                    "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"Disk","operator":"Include","values":["*"]}],
+                                    "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"NetworkInterface","operator":"Include","values":["*"]}],
                                     "failingPeriods": {
                                       "numberOfEvaluationPeriods": "[[parameters('evaluationPeriods')]",
                                       "minFailingPeriodsToAlert": "[[parameters('failingPeriods')]"

--- a/services/HybridCompute/machines/alerts.yaml
+++ b/services/HybridCompute/machines/alerts.yaml
@@ -219,7 +219,7 @@
       operator: Include
       values:
       - '*'
-    - name: Disk
+    - name: NetworkInterface
       operator: Include
       values:
       - '*'
@@ -270,7 +270,7 @@
       operator: Include
       values:
       - '*'
-    - name: Disk
+    - name: NetworkInterface
       operator: Include
       values:
       - '*'

--- a/services/HybridCompute/machines/templates/policy-arm/HybridMachineNetworkReadAlert_5e223d13-112e-4f84-82ba-e03a76f6350f.json
+++ b/services/HybridCompute/machines/templates/policy-arm/HybridMachineNetworkReadAlert_5e223d13-112e-4f84-82ba-e03a76f6350f.json
@@ -477,7 +477,7 @@
                                         "resourceIdColumn": "_ResourceId",
                                         "metricMeasureColumn": "AggregatedValue",
                                         "timeAggregation": "[[parameters('timeAggregation')]",
-                                        "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"Disk","operator":"Include","values":["*"]}],
+                                        "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"NetworkInterface","operator":"Include","values":["*"]}],
                                         "failingPeriods": {
                                           "numberOfEvaluationPeriods": "[[parameters('evaluationPeriods')]",
                                           "minFailingPeriodsToAlert": "[[parameters('failingPeriods')]"

--- a/services/HybridCompute/machines/templates/policy-arm/HybridMachineNetworkWriteAlert_bb1969d8-eaa2-45b6-bd9f-09348b1ee346.json
+++ b/services/HybridCompute/machines/templates/policy-arm/HybridMachineNetworkWriteAlert_bb1969d8-eaa2-45b6-bd9f-09348b1ee346.json
@@ -477,7 +477,7 @@
                                         "resourceIdColumn": "_ResourceId",
                                         "metricMeasureColumn": "AggregatedValue",
                                         "timeAggregation": "[[parameters('timeAggregation')]",
-                                        "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"Disk","operator":"Include","values":["*"]}],
+                                        "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"NetworkInterface","operator":"Include","values":["*"]}],
                                         "failingPeriods": {
                                           "numberOfEvaluationPeriods": "[[parameters('evaluationPeriods')]",
                                           "minFailingPeriodsToAlert": "[[parameters('failingPeriods')]"

--- a/services/HybridCompute/machines/templates/policy/HybridMachineNetworkReadAlert_5e223d13-112e-4f84-82ba-e03a76f6350f.json
+++ b/services/HybridCompute/machines/templates/policy/HybridMachineNetworkReadAlert_5e223d13-112e-4f84-82ba-e03a76f6350f.json
@@ -435,7 +435,7 @@
                                     "resourceIdColumn": "_ResourceId",
                                     "metricMeasureColumn": "AggregatedValue",
                                     "timeAggregation": "[[parameters('timeAggregation')]",
-                                    "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"Disk","operator":"Include","values":["*"]}],
+                                    "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"NetworkInterface","operator":"Include","values":["*"]}],
                                     "failingPeriods": {
                                       "numberOfEvaluationPeriods": "[[parameters('evaluationPeriods')]",
                                       "minFailingPeriodsToAlert": "[[parameters('failingPeriods')]"

--- a/services/HybridCompute/machines/templates/policy/HybridMachineNetworkWriteAlert_bb1969d8-eaa2-45b6-bd9f-09348b1ee346.json
+++ b/services/HybridCompute/machines/templates/policy/HybridMachineNetworkWriteAlert_bb1969d8-eaa2-45b6-bd9f-09348b1ee346.json
@@ -435,7 +435,7 @@
                                     "resourceIdColumn": "_ResourceId",
                                     "metricMeasureColumn": "AggregatedValue",
                                     "timeAggregation": "[[parameters('timeAggregation')]",
-                                    "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"Disk","operator":"Include","values":["*"]}],
+                                    "dimensions": [{"name":"Computer","operator":"Include","values":["*"]},{"name":"NetworkInterface","operator":"Include","values":["*"]}],
                                     "failingPeriods": {
                                       "numberOfEvaluationPeriods": "[[parameters('evaluationPeriods')]",
                                       "minFailingPeriodsToAlert": "[[parameters('failingPeriods')]"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Fix dimensions for VM and HybridCompute Log Alerts 

## This PR fixes/adds/changes/removes

1. *Replace me*
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

### Testing evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
