### PR TITLE
Fix Nginx capitalization in IaaS documentation

### DIFF
--- a/docs/content/patterns/monitoring packs/IaaS/_index.md
+++ b/docs/content/patterns/monitoring packs/IaaS/_index.md
@@ -9,6 +9,6 @@ geekdocCollapseSection: true
 |[DNS2016](./DNS2016)|DNS 2016|
 |[IIS](./IIS)|Internet Information Services|
 |[IIS2016](./IIS2016)|Internet Information Services 2016|
-|[NGinx](./Nginx)|NGinx (prototype)|
+|[Nginx](./Nginx)|Nginx (prototype)|
 |[PS2016](./PS2016)|Print Services 2016|
 |[VMInsights](./VMInsights)|Virtual Machine Insights|


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

The title is 'Nginx'. This PR fixes spelling in [IaaS monitoring pack list](https://azure.github.io/azure-monitor-baseline-alerts/patterns/monitoring-packs/IaaS/).

## This PR fixes/adds/changes/removes

Changes the spelling from 'NGinx' to 'Nginx' in the Monitoring Packs of IaaS list to maintain consistency with other documentation. c.f. the [Nginx.md](https://github.com/Azure/azure-monitor-baseline-alerts/blob/14d475cc8a661331e6926c4821d3b144daec09df/docs/content/patterns/monitoring%20packs/IaaS/Nginx.md)

### Breaking Changes

N/A

### Testing evidence

Links tested and working.

![image](https://github.com/user-attachments/assets/33fa6bd0-2d2a-4caf-b6b5-611ab838d667)


## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
