### PR TITLE
Fix policy ARM templates to remove special chars from effect name

### DIFF
--- a/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAIContextTokensCacheMatchRate_81f8369c-65bf-4194-bfd2-ffdfa2470577.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAIContextTokensCacheMatchRate_81f8369c-65bf-4194-bfd2-ffdfa2470577.json
@@ -228,7 +228,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].timeAggregation",
-                    "equals": "Total"
+                    "equals": "Average"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].StaticThresholdCriterion.operator",
@@ -307,7 +307,7 @@
                                 "metricName": "AzureOpenAIContextTokensCacheMatchRate",
                                 "operator": "GreaterThan",
                                 "threshold": "[[parameters('threshold')]",
-                                "timeAggregation": "Total",
+                                "timeAggregation": "Average",
                                 "criterionType": "StaticThresholdCriterion"
                               }
                             ],

--- a/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAIProvisionedManagedUtilizationV2_693a3b37-1e2a-42d1-aaed-b1f374276d1c.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAIProvisionedManagedUtilizationV2_693a3b37-1e2a-42d1-aaed-b1f374276d1c.json
@@ -228,7 +228,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].timeAggregation",
-                    "equals": "Total"
+                    "equals": "Average"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].StaticThresholdCriterion.operator",
@@ -307,7 +307,7 @@
                                 "metricName": "AzureOpenAIProvisionedManagedUtilizationV2",
                                 "operator": "GreaterThan",
                                 "threshold": "[[parameters('threshold')]",
-                                "timeAggregation": "Total",
+                                "timeAggregation": "Average",
                                 "criterionType": "StaticThresholdCriterion"
                               }
                             ],

--- a/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAITimeToResponse_995cc12a-1887-4669-92c5-70a6ca8bfe70.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAITimeToResponse_995cc12a-1887-4669-92c5-70a6ca8bfe70.json
@@ -228,7 +228,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].timeAggregation",
-                    "equals": "Total"
+                    "equals": "Average"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].StaticThresholdCriterion.operator",
@@ -307,7 +307,7 @@
                                 "metricName": "AzureOpenAITimeToResponse",
                                 "operator": "GreaterThan",
                                 "threshold": "[[parameters('threshold')]",
-                                "timeAggregation": "Total",
+                                "timeAggregation": "Average",
                                 "criterionType": "StaticThresholdCriterion"
                               }
                             ],

--- a/services/Compute/virtualMachineScaleSets/templates/policy-arm/DiskReadOperationsSec_ea8be16a-f5e9-4a8b-a1df-a8c5efff039b.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy-arm/DiskReadOperationsSec_ea8be16a-f5e9-4a8b-a1df-a8c5efff039b.json
@@ -192,7 +192,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Disk Read Operations/Sec')]",
+              "name": "[[concat(field('name'), '-Disk Read OperationsSec')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -294,7 +294,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Disk Read Operations/Sec')]",
+                        "name": "[[concat(parameters('resourceName'), '-Disk Read OperationsSec')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/Compute/virtualMachineScaleSets/templates/policy-arm/DiskWriteOperationsSec_dce1cda8-1dab-4941-b607-1d5d449709d5.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy-arm/DiskWriteOperationsSec_dce1cda8-1dab-4941-b607-1d5d449709d5.json
@@ -192,7 +192,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Disk Write Operations/Sec')]",
+              "name": "[[concat(field('name'), '-Disk Write OperationsSec')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -294,7 +294,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Disk Write Operations/Sec')]",
+                        "name": "[[concat(parameters('resourceName'), '-Disk Write OperationsSec')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/Compute/virtualMachines/templates/policy-arm/DataDiskReadOperationsSec_3c5518ea-9a0f-44ff-b197-47b3d6db060b.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DataDiskReadOperationsSec_3c5518ea-9a0f-44ff-b197-47b3d6db060b.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Data Disk Read Operations/Sec')]",
+              "name": "[[concat(field('name'), '-Data Disk Read OperationsSec')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Data Disk Read Operations/Sec')]",
+                        "name": "[[concat(parameters('resourceName'), '-Data Disk Read OperationsSec')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/Compute/virtualMachines/templates/policy-arm/DataDiskWriteBytessec_e45d685d-14c4-4422-8096-6f11d628fb20.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DataDiskWriteBytessec_e45d685d-14c4-4422-8096-6f11d628fb20.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Data Disk Write Bytes/sec')]",
+              "name": "[[concat(field('name'), '-Data Disk Write Bytessec')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Data Disk Write Bytes/sec')]",
+                        "name": "[[concat(parameters('resourceName'), '-Data Disk Write Bytessec')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/Compute/virtualMachines/templates/policy-arm/DataDiskWriteOperationsSec_326b359d-e0a2-4055-8e1f-f9c5f9df5599.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DataDiskWriteOperationsSec_326b359d-e0a2-4055-8e1f-f9c5f9df5599.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Data Disk Write Operations/Sec')]",
+              "name": "[[concat(field('name'), '-Data Disk Write OperationsSec')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Data Disk Write Operations/Sec')]",
+                        "name": "[[concat(parameters('resourceName'), '-Data Disk Write OperationsSec')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/Compute/virtualMachines/templates/policy-arm/DiskWriteOperationsSec_edff41cb-d9b8-46ba-ba39-42747c1a4c4b.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DiskWriteOperationsSec_edff41cb-d9b8-46ba-ba39-42747c1a4c4b.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Disk Write Operations/Sec')]",
+              "name": "[[concat(field('name'), '-Disk Write OperationsSec')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Disk Write Operations/Sec')]",
+                        "name": "[[concat(parameters('resourceName'), '-Disk Write OperationsSec')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/Compute/virtualMachines/templates/policy-arm/OSDiskWriteBytessec_929b095e-5ea1-48b4-bf4e-bfc1a941a908.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/OSDiskWriteBytessec_929b095e-5ea1-48b4-bf4e-bfc1a941a908.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-OS Disk Write Bytes/sec')]",
+              "name": "[[concat(field('name'), '-OS Disk Write Bytessec')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-OS Disk Write Bytes/sec')]",
+                        "name": "[[concat(parameters('resourceName'), '-OS Disk Write Bytessec')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/Compute/virtualMachines/templates/policy-arm/OSDiskWriteOperationsSec_3be4037a-c692-402d-843d-b3fe43053edf.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/OSDiskWriteOperationsSec_3be4037a-c692-402d-843d-b3fe43053edf.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-OS Disk Write Operations/Sec')]",
+              "name": "[[concat(field('name'), '-OS Disk Write OperationsSec')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-OS Disk Write Operations/Sec')]",
+                        "name": "[[concat(parameters('resourceName'), '-OS Disk Write OperationsSec')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/Devices/IotHubs/templates/policy-arm/d2ctelemetryegressdropped_d5a028d1-ae0e-4349-8a79-630f891c8235.json
+++ b/services/Devices/IotHubs/templates/policy-arm/d2ctelemetryegressdropped_d5a028d1-ae0e-4349-8a79-630f891c8235.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-d2c.telemetry.egress.dropped')]",
+              "name": "[[concat(field('name'), '-d2ctelemetryegressdropped')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-d2c.telemetry.egress.dropped')]",
+                        "name": "[[concat(parameters('resourceName'), '-d2ctelemetryegressdropped')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/Devices/IotHubs/templates/policy-arm/d2ctelemetryingresssendThrottle_65deae31-85e8-477a-b17e-50d2d10cd7b0.json
+++ b/services/Devices/IotHubs/templates/policy-arm/d2ctelemetryingresssendThrottle_65deae31-85e8-477a-b17e-50d2d10cd7b0.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-d2c.telemetry.ingress.sendThrottle')]",
+              "name": "[[concat(field('name'), '-d2ctelemetryingresssendThrottle')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-d2c.telemetry.ingress.sendThrottle')]",
+                        "name": "[[concat(parameters('resourceName'), '-d2ctelemetryingresssendThrottle')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/Devices/IotHubs/templates/policy-arm/d2ctelemetryingresssuccess_85de8003-c1d8-4cd1-80b5-e125399ef293.json
+++ b/services/Devices/IotHubs/templates/policy-arm/d2ctelemetryingresssuccess_85de8003-c1d8-4cd1-80b5-e125399ef293.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-d2c.telemetry.ingress.success')]",
+              "name": "[[concat(field('name'), '-d2ctelemetryingresssuccess')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-d2c.telemetry.ingress.success')]",
+                        "name": "[[concat(parameters('resourceName'), '-d2ctelemetryingresssuccess')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/DataUsage_0914c189-0adc-45d6-8704-d2ae73b9b7b6.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/DataUsage_0914c189-0adc-45d6-8704-d2ae73b9b7b6.json
@@ -79,16 +79,12 @@
               "description": "Window size for the alert"
             },
             "allowedValues": [
-              "PT1M",
               "PT5M",
               "PT15M",
               "PT30M",
-              "PT1H",
-              "PT6H",
-              "PT12H",
-              "P1D"
+              "PT1H"
             ],
-            "defaultValue": "PT5M"
+            "defaultValue": "PT1H"
           },
           "evaluationFrequency": {
             "type": "String",
@@ -103,7 +99,20 @@
               "PT30M",
               "PT1H"
             ],
-            "defaultValue": "PT1M"
+            "defaultValue": "PT15M"
+          },
+          "alertSensitivity": {
+            "type": "String",
+            "metadata": {
+              "displayName": "Alert Sensitivity",
+              "description": "Alert Sensitivity for the alert"
+            },
+            "allowedValues": [
+              "Low",
+              "Medium",
+              "High"
+            ],
+            "defaultValue": "Low"
           },
           "autoMitigate": {
             "type": "String",
@@ -128,14 +137,6 @@
               "false"
             ],
             "defaultValue": "true"
-          },
-          "threshold": {
-            "type": "String",
-            "metadata": {
-              "displayName": "Threshold",
-              "description": "Threshold for the alert"
-            },
-            "defaultValue": "2147483648"
           },
           "effect": {
             "type": "String",
@@ -227,16 +228,24 @@
                     "equals": "[[parameters('autoMitigate')]"
                   },
                   {
-                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].timeAggregation",
-                    "equals": "Total"
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].timeAggregation",
+                    "equals": "Average"
                   },
                   {
-                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].StaticThresholdCriterion.operator",
-                    "equals": "GreaterThan"
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator",
+                    "equals": "GreaterThanOrLessThan"
                   },
                   {
-                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].StaticThresholdCriterion.threshold",
-                    "equals": "[[if(contains(field('tags'), '_amba-DataUsage-threshold-Override_'), field('tags._amba-DataUsage-threshold-Override_'), parameters('threshold'))]"
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity",
+                    "equals": "[[parameters('alertSensitivity')]"
+                  },
+                  {
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert",
+                    "equals": 4
+                  },
+                  {
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods",
+                    "equals": 4
                   }
                 ]
               },
@@ -270,13 +279,13 @@
                       "evaluationFrequency": {
                         "type": "String"
                       },
+                      "alertSensitivity": {
+                        "type": "String"
+                      },
                       "autoMitigate": {
                         "type": "String"
                       },
                       "enabled": {
-                        "type": "String"
-                      },
-                      "threshold": {
                         "type": "String"
                       }
                     },
@@ -305,13 +314,17 @@
                                 "name": "DataUsage",
                                 "metricNamespace": "Microsoft.DocumentDB/databaseAccounts",
                                 "metricName": "DataUsage",
-                                "operator": "GreaterThan",
-                                "threshold": "[[parameters('threshold')]",
-                                "timeAggregation": "Total",
-                                "criterionType": "StaticThresholdCriterion"
+                                "operator": "GreaterThanOrLessThan",
+                                "alertSensitivity": "[[parameters('alertSensitivity')]",
+                                "failingPeriods": {
+                                  "minFailingPeriodsToAlert": 4,
+                                  "numberOfEvaluationPeriods": 4
+                                },
+                                "timeAggregation": "Average",
+                                "criterionType": "DynamicThresholdCriterion"
                               }
                             ],
-                            "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
+                            "odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria"
                           },
                           "autoMitigate": "[[parameters('autoMitigate')]",
                           "parameters": {
@@ -324,14 +337,14 @@
                             "evaluationFrequency": {
                               "value": "[[parameters('evaluationFrequency')]"
                             },
+                            "alertSensitivity": {
+                              "value": "[[parameters('alertSensitivity')]"
+                            },
                             "autoMitigate": {
                               "value": "[[parameters('autoMitigate')]"
                             },
                             "enabled": {
                               "value": "[[parameters('enabled')]"
-                            },
-                            "threshold": {
-                              "value": "[[parameters('threshold')]"
                             }
                           }
                         }
@@ -354,14 +367,14 @@
                     "evaluationFrequency": {
                       "value": "[[parameters('evaluationFrequency')]"
                     },
+                    "alertSensitivity": {
+                      "value": "[[parameters('alertSensitivity')]"
+                    },
                     "autoMitigate": {
                       "value": "[[parameters('autoMitigate')]"
                     },
                     "enabled": {
                       "value": "[[parameters('enabled')]"
-                    },
-                    "threshold": {
-                      "value": "[[if(contains(field('tags'), '_amba-DataUsage-threshold-Override_'), field('tags._amba-DataUsage-threshold-Override_'), parameters('threshold'))]"
                     }
                   }
                 }

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/MongoRequests_3f30e3aa-7e17-4eaf-a437-a420f5a23bf2.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/MongoRequests_3f30e3aa-7e17-4eaf-a437-a420f5a23bf2.json
@@ -79,14 +79,10 @@
               "description": "Window size for the alert"
             },
             "allowedValues": [
-              "PT1M",
               "PT5M",
               "PT15M",
               "PT30M",
-              "PT1H",
-              "PT6H",
-              "PT12H",
-              "P1D"
+              "PT1H"
             ],
             "defaultValue": "PT5M"
           },
@@ -104,6 +100,19 @@
               "PT1H"
             ],
             "defaultValue": "PT1M"
+          },
+          "alertSensitivity": {
+            "type": "String",
+            "metadata": {
+              "displayName": "Alert Sensitivity",
+              "description": "Alert Sensitivity for the alert"
+            },
+            "allowedValues": [
+              "Low",
+              "Medium",
+              "High"
+            ],
+            "defaultValue": "Low"
           },
           "autoMitigate": {
             "type": "String",
@@ -128,14 +137,6 @@
               "false"
             ],
             "defaultValue": "true"
-          },
-          "threshold": {
-            "type": "String",
-            "metadata": {
-              "displayName": "Threshold",
-              "description": "Threshold for the alert"
-            },
-            "defaultValue": "9"
           },
           "effect": {
             "type": "String",
@@ -227,16 +228,24 @@
                     "equals": "[[parameters('autoMitigate')]"
                   },
                   {
-                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].timeAggregation",
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].timeAggregation",
                     "equals": "Count"
                   },
                   {
-                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].StaticThresholdCriterion.operator",
-                    "equals": "GreaterThan"
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator",
+                    "equals": "GreaterThanOrLessThan"
                   },
                   {
-                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].StaticThresholdCriterion.threshold",
-                    "equals": "[[if(contains(field('tags'), '_amba-MongoRequests-threshold-Override_'), field('tags._amba-MongoRequests-threshold-Override_'), parameters('threshold'))]"
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity",
+                    "equals": "[[parameters('alertSensitivity')]"
+                  },
+                  {
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert",
+                    "equals": 4
+                  },
+                  {
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods",
+                    "equals": 4
                   }
                 ]
               },
@@ -270,13 +279,13 @@
                       "evaluationFrequency": {
                         "type": "String"
                       },
+                      "alertSensitivity": {
+                        "type": "String"
+                      },
                       "autoMitigate": {
                         "type": "String"
                       },
                       "enabled": {
-                        "type": "String"
-                      },
-                      "threshold": {
                         "type": "String"
                       }
                     },
@@ -305,13 +314,17 @@
                                 "name": "MongoRequests",
                                 "metricNamespace": "Microsoft.DocumentDB/databaseAccounts",
                                 "metricName": "MongoRequests",
-                                "operator": "GreaterThan",
-                                "threshold": "[[parameters('threshold')]",
+                                "operator": "GreaterThanOrLessThan",
+                                "alertSensitivity": "[[parameters('alertSensitivity')]",
+                                "failingPeriods": {
+                                  "minFailingPeriodsToAlert": 4,
+                                  "numberOfEvaluationPeriods": 4
+                                },
                                 "timeAggregation": "Count",
-                                "criterionType": "StaticThresholdCriterion"
+                                "criterionType": "DynamicThresholdCriterion"
                               }
                             ],
-                            "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
+                            "odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria"
                           },
                           "autoMitigate": "[[parameters('autoMitigate')]",
                           "parameters": {
@@ -324,14 +337,14 @@
                             "evaluationFrequency": {
                               "value": "[[parameters('evaluationFrequency')]"
                             },
+                            "alertSensitivity": {
+                              "value": "[[parameters('alertSensitivity')]"
+                            },
                             "autoMitigate": {
                               "value": "[[parameters('autoMitigate')]"
                             },
                             "enabled": {
                               "value": "[[parameters('enabled')]"
-                            },
-                            "threshold": {
-                              "value": "[[parameters('threshold')]"
                             }
                           }
                         }
@@ -354,14 +367,14 @@
                     "evaluationFrequency": {
                       "value": "[[parameters('evaluationFrequency')]"
                     },
+                    "alertSensitivity": {
+                      "value": "[[parameters('alertSensitivity')]"
+                    },
                     "autoMitigate": {
                       "value": "[[parameters('autoMitigate')]"
                     },
                     "enabled": {
                       "value": "[[parameters('enabled')]"
-                    },
-                    "threshold": {
-                      "value": "[[if(contains(field('tags'), '_amba-MongoRequests-threshold-Override_'), field('tags._amba-MongoRequests-threshold-Override_'), parameters('threshold'))]"
                     }
                   }
                 }

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/RegionFailover_9c41c539-b81b-4917-b04a-e67225f78e75.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/RegionFailover_9c41c539-b81b-4917-b04a-e67225f78e75.json
@@ -70,7 +70,7 @@
               "3",
               "4"
             ],
-            "defaultValue": "3"
+            "defaultValue": "2"
           },
           "windowSize": {
             "type": "String",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/ServiceAvailability_ee10b769-b38b-44d1-9fd3-926b8dca4c41.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/ServiceAvailability_ee10b769-b38b-44d1-9fd3-926b8dca4c41.json
@@ -70,7 +70,7 @@
               "3",
               "4"
             ],
-            "defaultValue": "1"
+            "defaultValue": "2"
           },
           "windowSize": {
             "type": "String",
@@ -103,7 +103,7 @@
               "PT30M",
               "PT1H"
             ],
-            "defaultValue": "PT5M"
+            "defaultValue": "PT1M"
           },
           "autoMitigate": {
             "type": "String",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/ThrottledRequests_fc8db431-f429-40ee-a51a-de1858198e19.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/ThrottledRequests_fc8db431-f429-40ee-a51a-de1858198e19.json
@@ -3,14 +3,14 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "displayName": {
-      "defaultValue": "Deploy Compute virtualMachines Disk Read Operations/Sec Alert",
+      "defaultValue": "Deploy DocumentDB databaseAccounts ThrottledRequests Alert",
       "type": "String",
       "metadata": {
         "description": "Display name of policy"
       }
     },
     "description": {
-      "defaultValue": "Policy to Audit/Deploy Compute virtualMachines Disk Read Operations/Sec Alert",
+      "defaultValue": "Policy to Audit/Deploy DocumentDB databaseAccounts ThrottledRequests Alert",
       "type": "String",
       "metadata": {
         "description": "Description of policy"
@@ -43,7 +43,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "apiVersion": "2021-06-01",
-      "name": "8bc489c0-d2f7-43c1-9bb7-478c9503fb2e",
+      "name": "fc8db431-f429-40ee-a51a-de1858198e19",
       "properties": {
         "policyType": "Custom",
         "mode": "All",
@@ -51,7 +51,7 @@
         "description": "[parameters('description')]",
         "metadata": {
           "version": "1.0.0-preview",
-          "category": "Compute",
+          "category": "DocumentDB",
           "preview": true,
           "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
           "_deployed_by_amba": "True"
@@ -70,7 +70,7 @@
               "3",
               "4"
             ],
-            "defaultValue": "3"
+            "defaultValue": "2"
           },
           "windowSize": {
             "type": "String",
@@ -135,7 +135,7 @@
               "displayName": "Threshold",
               "description": "Threshold for the alert"
             },
-            "defaultValue": "400"
+            "defaultValue": "50"
           },
           "effect": {
             "type": "String",
@@ -176,7 +176,7 @@
             "allOf": [
               {
                 "field": "type",
-                "equals": "Microsoft.Compute/virtualMachines"
+                "equals": "Microsoft.DocumentDB/databaseAccounts"
               },
               {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
@@ -191,20 +191,20 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Disk Read OperationsSec')]",
+              "name": "[[concat(field('name'), '-ThrottledRequests')]",
               "existenceCondition": {
                 "allOf": [
                   {
                     "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].metricNamespace",
-                    "equals": "Microsoft.Compute/virtualMachines"
+                    "equals": "Microsoft.DocumentDB/databaseAccounts"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].metricName",
-                    "equals": "Disk Read Operations/Sec"
+                    "equals": "ThrottledRequests"
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",
@@ -228,7 +228,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].timeAggregation",
-                    "equals": "Average"
+                    "equals": "Count"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].StaticThresholdCriterion.operator",
@@ -236,7 +236,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].StaticThresholdCriterion.threshold",
-                    "equals": "[[if(contains(field('tags'), '_amba-Disk Read Operations/Sec-threshold-Override_'), field('tags._amba-Disk Read Operations/Sec-threshold-Override_'), parameters('threshold'))]"
+                    "equals": "[[if(contains(field('tags'), '_amba-ThrottledRequests-threshold-Override_'), field('tags._amba-ThrottledRequests-threshold-Override_'), parameters('threshold'))]"
                   }
                 ]
               },
@@ -285,13 +285,13 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Disk Read OperationsSec')]",
+                        "name": "[[concat(parameters('resourceName'), '-ThrottledRequests')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true
                         },
                         "properties": {
-                          "description": "Metric Alert for Compute virtualMachines Disk Read Operations/Sec",
+                          "description": "Metric Alert for DocumentDB databaseAccounts ThrottledRequests",
                           "severity": "[[parameters('severity')]",
                           "enabled": "[[parameters('enabled')]",
                           "scopes": [
@@ -302,12 +302,12 @@
                           "criteria": {
                             "allOf": [
                               {
-                                "name": "Disk Read Operations/Sec",
-                                "metricNamespace": "Microsoft.Compute/virtualMachines",
-                                "metricName": "Disk Read Operations/Sec",
+                                "name": "ThrottledRequests",
+                                "metricNamespace": "Microsoft.DocumentDB/databaseAccounts",
+                                "metricName": "ThrottledRequests",
                                 "operator": "GreaterThan",
                                 "threshold": "[[parameters('threshold')]",
-                                "timeAggregation": "Average",
+                                "timeAggregation": "Count",
                                 "criterionType": "StaticThresholdCriterion"
                               }
                             ],
@@ -361,7 +361,7 @@
                       "value": "[[parameters('enabled')]"
                     },
                     "threshold": {
-                      "value": "[[if(contains(field('tags'), '_amba-Disk Read Operations/Sec-threshold-Override_'), field('tags._amba-Disk Read Operations/Sec-threshold-Override_'), parameters('threshold'))]"
+                      "value": "[[if(contains(field('tags'), '_amba-ThrottledRequests-threshold-Override_'), field('tags._amba-ThrottledRequests-threshold-Override_'), parameters('threshold'))]"
                     }
                   }
                 }

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/TotalRequests_2a1deb2d-1fc0-499b-a828-04aeece855fe.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/TotalRequests_2a1deb2d-1fc0-499b-a828-04aeece855fe.json
@@ -79,14 +79,10 @@
               "description": "Window size for the alert"
             },
             "allowedValues": [
-              "PT1M",
               "PT5M",
               "PT15M",
               "PT30M",
-              "PT1H",
-              "PT6H",
-              "PT12H",
-              "P1D"
+              "PT1H"
             ],
             "defaultValue": "PT5M"
           },
@@ -104,6 +100,19 @@
               "PT1H"
             ],
             "defaultValue": "PT1M"
+          },
+          "alertSensitivity": {
+            "type": "String",
+            "metadata": {
+              "displayName": "Alert Sensitivity",
+              "description": "Alert Sensitivity for the alert"
+            },
+            "allowedValues": [
+              "Low",
+              "Medium",
+              "High"
+            ],
+            "defaultValue": "Low"
           },
           "autoMitigate": {
             "type": "String",
@@ -128,14 +137,6 @@
               "false"
             ],
             "defaultValue": "true"
-          },
-          "threshold": {
-            "type": "String",
-            "metadata": {
-              "displayName": "Threshold",
-              "description": "Threshold for the alert"
-            },
-            "defaultValue": "5"
           },
           "effect": {
             "type": "String",
@@ -227,16 +228,24 @@
                     "equals": "[[parameters('autoMitigate')]"
                   },
                   {
-                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].timeAggregation",
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].timeAggregation",
                     "equals": "Count"
                   },
                   {
-                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].StaticThresholdCriterion.operator",
-                    "equals": "GreaterThan"
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator",
+                    "equals": "GreaterThanOrLessThan"
                   },
                   {
-                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].StaticThresholdCriterion.threshold",
-                    "equals": "[[if(contains(field('tags'), '_amba-TotalRequests-threshold-Override_'), field('tags._amba-TotalRequests-threshold-Override_'), parameters('threshold'))]"
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity",
+                    "equals": "[[parameters('alertSensitivity')]"
+                  },
+                  {
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert",
+                    "equals": 4
+                  },
+                  {
+                    "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods",
+                    "equals": 4
                   }
                 ]
               },
@@ -270,13 +279,13 @@
                       "evaluationFrequency": {
                         "type": "String"
                       },
+                      "alertSensitivity": {
+                        "type": "String"
+                      },
                       "autoMitigate": {
                         "type": "String"
                       },
                       "enabled": {
-                        "type": "String"
-                      },
-                      "threshold": {
                         "type": "String"
                       }
                     },
@@ -305,13 +314,17 @@
                                 "name": "TotalRequests",
                                 "metricNamespace": "Microsoft.DocumentDB/databaseAccounts",
                                 "metricName": "TotalRequests",
-                                "operator": "GreaterThan",
-                                "threshold": "[[parameters('threshold')]",
+                                "operator": "GreaterThanOrLessThan",
+                                "alertSensitivity": "[[parameters('alertSensitivity')]",
+                                "failingPeriods": {
+                                  "minFailingPeriodsToAlert": 4,
+                                  "numberOfEvaluationPeriods": 4
+                                },
                                 "timeAggregation": "Count",
-                                "criterionType": "StaticThresholdCriterion"
+                                "criterionType": "DynamicThresholdCriterion"
                               }
                             ],
-                            "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria"
+                            "odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria"
                           },
                           "autoMitigate": "[[parameters('autoMitigate')]",
                           "parameters": {
@@ -324,14 +337,14 @@
                             "evaluationFrequency": {
                               "value": "[[parameters('evaluationFrequency')]"
                             },
+                            "alertSensitivity": {
+                              "value": "[[parameters('alertSensitivity')]"
+                            },
                             "autoMitigate": {
                               "value": "[[parameters('autoMitigate')]"
                             },
                             "enabled": {
                               "value": "[[parameters('enabled')]"
-                            },
-                            "threshold": {
-                              "value": "[[parameters('threshold')]"
                             }
                           }
                         }
@@ -354,14 +367,14 @@
                     "evaluationFrequency": {
                       "value": "[[parameters('evaluationFrequency')]"
                     },
+                    "alertSensitivity": {
+                      "value": "[[parameters('alertSensitivity')]"
+                    },
                     "autoMitigate": {
                       "value": "[[parameters('autoMitigate')]"
                     },
                     "enabled": {
                       "value": "[[parameters('enabled')]"
-                    },
-                    "threshold": {
-                      "value": "[[if(contains(field('tags'), '_amba-TotalRequests-threshold-Override_'), field('tags._amba-TotalRequests-threshold-Override_'), parameters('threshold'))]"
                     }
                   }
                 }

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/UpdateAccountKeys_d4d7685a-ce55-4709-a847-747d02165cb7.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/UpdateAccountKeys_d4d7685a-ce55-4709-a847-747d02165cb7.json
@@ -135,7 +135,7 @@
               "displayName": "Threshold",
               "description": "Threshold for the alert"
             },
-            "defaultValue": "1"
+            "defaultValue": "0"
           },
           "effect": {
             "type": "String",
@@ -232,7 +232,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].StaticThresholdCriterion.operator",
-                    "equals": "GreaterThanOrEqual"
+                    "equals": "GreaterThan"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].StaticThresholdCriterion.threshold",
@@ -305,7 +305,7 @@
                                 "name": "UpdateAccountKeys",
                                 "metricNamespace": "Microsoft.DocumentDB/databaseAccounts",
                                 "metricName": "UpdateAccountKeys",
-                                "operator": "GreaterThanOrEqual",
+                                "operator": "GreaterThan",
                                 "threshold": "[[parameters('threshold')]",
                                 "timeAggregation": "Count",
                                 "criterionType": "StaticThresholdCriterion"

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvailableMemory_91044c16-83bc-457f-80a9-360bad5dedb4.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvailableMemory_91044c16-83bc-457f-80a9-360bad5dedb4.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_% Available Memory')]",
+              "name": "[[concat(field('name'), '-Average_ Available Memory')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_% Available Memory')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_ Available Memory')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvgDisksecRead_8b472051-ff68-4059-9e50-243bfb64bae4.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvgDisksecRead_8b472051-ff68-4059-9e50-243bfb64bae4.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_Avg. Disk sec/Read')]",
+              "name": "[[concat(field('name'), '-Average_Avg Disk secRead')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_Avg. Disk sec/Read')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_Avg Disk secRead')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvgDisksecWrite_aad0e64e-3cda-45bf-b6bd-8cff29ee35e5.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvgDisksecWrite_aad0e64e-3cda-45bf-b6bd-8cff29ee35e5.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_Avg. Disk sec/Write')]",
+              "name": "[[concat(field('name'), '-Average_Avg Disk secWrite')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_Avg. Disk sec/Write')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_Avg Disk secWrite')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageBytesReceivedsec_60ec2790-dc83-419c-bdb5-38da9a477c68.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageBytesReceivedsec_60ec2790-dc83-419c-bdb5-38da9a477c68.json
@@ -192,7 +192,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_Bytes Received/sec')]",
+              "name": "[[concat(field('name'), '-Average_Bytes Receivedsec')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -294,7 +294,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_Bytes Received/sec')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_Bytes Receivedsec')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageBytesSentsec_de6d5087-bc5a-474f-9319-248a3c03ab44.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageBytesSentsec_de6d5087-bc5a-474f-9319-248a3c03ab44.json
@@ -192,7 +192,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_Bytes Sent/sec')]",
+              "name": "[[concat(field('name'), '-Average_Bytes Sentsec')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -294,7 +294,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_Bytes Sent/sec')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_Bytes Sentsec')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageCommittedBytesInUse_a70e406c-a0ae-4e0f-99cd-8b0836812c59.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageCommittedBytesInUse_a70e406c-a0ae-4e0f-99cd-8b0836812c59.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_% Committed Bytes In Use')]",
+              "name": "[[concat(field('name'), '-Average_ Committed Bytes In Use')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_% Committed Bytes In Use')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_ Committed Bytes In Use')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageDiskTransferssec_30b462dd-d026-4122-9bcf-3a114517e04c.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageDiskTransferssec_30b462dd-d026-4122-9bcf-3a114517e04c.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_Disk Transfers/sec')]",
+              "name": "[[concat(field('name'), '-Average_Disk Transferssec')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_Disk Transfers/sec')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_Disk Transferssec')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageFreeSpace_db621663-ec0a-4fa3-82a7-b6b110726568.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageFreeSpace_db621663-ec0a-4fa3-82a7-b6b110726568.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_% Free Space')]",
+              "name": "[[concat(field('name'), '-Average_ Free Space')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_% Free Space')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_ Free Space')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageIOWaitTime_1116a5eb-9e12-415a-af46-fad552421d36.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageIOWaitTime_1116a5eb-9e12-415a-af46-fad552421d36.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_% IO Wait Time')]",
+              "name": "[[concat(field('name'), '-Average_ IO Wait Time')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_% IO Wait Time')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_ IO Wait Time')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageIdleTime_732c0a7b-ac17-47cb-bf78-2ebaa839fa0d.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageIdleTime_732c0a7b-ac17-47cb-bf78-2ebaa839fa0d.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_% Idle Time')]",
+              "name": "[[concat(field('name'), '-Average_ Idle Time')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_% Idle Time')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_ Idle Time')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AveragePagessec_88b7198b-32a5-4ae2-aaa5-7925066cc08c.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AveragePagessec_88b7198b-32a5-4ae2-aaa5-7925066cc08c.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_Pages/sec')]",
+              "name": "[[concat(field('name'), '-Average_Pagessec')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_Pages/sec')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_Pagessec')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageProcessorTime_0c416177-e7ce-40d5-8f15-8566b3d7c03c.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageProcessorTime_0c416177-e7ce-40d5-8f15-8566b3d7c03c.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_% Processor Time')]",
+              "name": "[[concat(field('name'), '-Average_ Processor Time')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_% Processor Time')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_ Processor Time')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedInodes_af5d055f-0e1f-4c48-808a-d21f8268357d.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedInodes_af5d055f-0e1f-4c48-808a-d21f8268357d.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_% Used Inodes')]",
+              "name": "[[concat(field('name'), '-Average_ Used Inodes')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_% Used Inodes')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_ Used Inodes')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedMemory_171e5b5c-78cc-44a1-b7fb-7d750914ed5e.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedMemory_171e5b5c-78cc-44a1-b7fb-7d750914ed5e.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_% Used Memory')]",
+              "name": "[[concat(field('name'), '-Average_ Used Memory')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_% Used Memory')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_ Used Memory')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedSpace_49ba0df7-18bf-4b3e-9d0f-f8c055762fd5.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedSpace_49ba0df7-18bf-4b3e-9d0f-f8c055762fd5.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_% Used Space')]",
+              "name": "[[concat(field('name'), '-Average_ Used Space')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_% Used Space')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_ Used Space')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedSwapSpace_04f64694-48a2-48ee-9455-ccce8e59b66f.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedSwapSpace_04f64694-48a2-48ee-9455-ccce8e59b66f.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_% Used Swap Space')]",
+              "name": "[[concat(field('name'), '-Average_ Used Swap Space')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_% Used Swap Space')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_ Used Swap Space')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageUserTime_b8140cdb-5492-4177-881f-8668372947a8.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageUserTime_b8140cdb-5492-4177-881f-8668372947a8.json
@@ -191,7 +191,7 @@
                 "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
               ],
               "type": "Microsoft.Insights/metricAlerts",
-              "name": "[[concat(field('name'), '-Average_% User Time')]",
+              "name": "[[concat(field('name'), '-Average_ User Time')]",
               "existenceCondition": {
                 "allOf": [
                   {
@@ -285,7 +285,7 @@
                       {
                         "type": "Microsoft.Insights/metricAlerts",
                         "apiVersion": "2018-03-01",
-                        "name": "[[concat(parameters('resourceName'), '-Average_% User Time')]",
+                        "name": "[[concat(parameters('resourceName'), '-Average_ User Time')]",
                         "location": "global",
                         "tags": {
                           "_deployed_by_amba": true


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Special chars such as "/" and "%" in the alert metric names would cause issues when trying to assign the policy. This PR updates the policy ARM templates to remove the special chars from the policy effect name and deployed resource name. This PR also updates policy ARM files generated for DocumentDB and Cognitive services based on recent alert.yaml changes.

## This PR fixes/adds/changes/removes

1. Fixes issues with special chars in metric names
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

### Testing evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
