### PR TITLE
Update policy templates for metric alerts "scopes" field

### DIFF
--- a/services/AVS/privateClouds/templates/policy-arm/CPUCritical_bb83ae53-3b91-49ff-a351-9545ea747335.json
+++ b/services/AVS/privateClouds/templates/policy-arm/CPUCritical_bb83ae53-3b91-49ff-a351-9545ea747335.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AVS/privateClouds/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AVS/privateClouds/templates/policy-arm/CPU_282cb835-592b-4e49-89c1-ea1aaefb37c4.json
+++ b/services/AVS/privateClouds/templates/policy-arm/CPU_282cb835-592b-4e49-89c1-ea1aaefb37c4.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AVS/privateClouds/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AVS/privateClouds/templates/policy-arm/DiskUsedPercentage_23ac19cb-5eff-4cfa-9817-93466e1a94f7.json
+++ b/services/AVS/privateClouds/templates/policy-arm/DiskUsedPercentage_23ac19cb-5eff-4cfa-9817-93466e1a94f7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AVS/privateClouds/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AVS/privateClouds/templates/policy-arm/MemoryCritical_a2f5e5a3-ec38-4201-970f-971ad4707b93.json
+++ b/services/AVS/privateClouds/templates/policy-arm/MemoryCritical_a2f5e5a3-ec38-4201-970f-971ad4707b93.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AVS/privateClouds/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AVS/privateClouds/templates/policy-arm/Memory_e840c7a9-e070-4dc9-919b-c75a3679f6b7.json
+++ b/services/AVS/privateClouds/templates/policy-arm/Memory_e840c7a9-e070-4dc9-919b-c75a3679f6b7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AVS/privateClouds/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AVS/privateClouds/templates/policy-arm/Storage_8bafb3d5-d961-49a4-9867-f1cddfd703e0.json
+++ b/services/AVS/privateClouds/templates/policy-arm/Storage_8bafb3d5-d961-49a4-9867-f1cddfd703e0.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AVS/privateClouds/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AVS/privateClouds/templates/policy-arm/UsageAverage_b9f2fe91-023a-443c-b376-b12f0cd5d965.json
+++ b/services/AVS/privateClouds/templates/policy-arm/UsageAverage_b9f2fe91-023a-443c-b376-b12f0cd5d965.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AVS/privateClouds/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AVS/privateClouds/templates/policy/CPUCritical_bb83ae53-3b91-49ff-a351-9545ea747335.json
+++ b/services/AVS/privateClouds/templates/policy/CPUCritical_bb83ae53-3b91-49ff-a351-9545ea747335.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AVS/privateClouds/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AVS/privateClouds/templates/policy/CPU_282cb835-592b-4e49-89c1-ea1aaefb37c4.json
+++ b/services/AVS/privateClouds/templates/policy/CPU_282cb835-592b-4e49-89c1-ea1aaefb37c4.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AVS/privateClouds/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AVS/privateClouds/templates/policy/DiskUsedPercentage_23ac19cb-5eff-4cfa-9817-93466e1a94f7.json
+++ b/services/AVS/privateClouds/templates/policy/DiskUsedPercentage_23ac19cb-5eff-4cfa-9817-93466e1a94f7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AVS/privateClouds/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AVS/privateClouds/templates/policy/MemoryCritical_a2f5e5a3-ec38-4201-970f-971ad4707b93.json
+++ b/services/AVS/privateClouds/templates/policy/MemoryCritical_a2f5e5a3-ec38-4201-970f-971ad4707b93.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AVS/privateClouds/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AVS/privateClouds/templates/policy/Memory_e840c7a9-e070-4dc9-919b-c75a3679f6b7.json
+++ b/services/AVS/privateClouds/templates/policy/Memory_e840c7a9-e070-4dc9-919b-c75a3679f6b7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AVS/privateClouds/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AVS/privateClouds/templates/policy/Storage_8bafb3d5-d961-49a4-9867-f1cddfd703e0.json
+++ b/services/AVS/privateClouds/templates/policy/Storage_8bafb3d5-d961-49a4-9867-f1cddfd703e0.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AVS/privateClouds/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AVS/privateClouds/templates/policy/UsageAverage_b9f2fe91-023a-443c-b376-b12f0cd5d965.json
+++ b/services/AVS/privateClouds/templates/policy/UsageAverage_b9f2fe91-023a-443c-b376-b12f0cd5d965.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AVS/privateClouds/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AnalysisServices/servers/templates/policy-arm/memorymetric_0289bc11-db65-4a58-91ed-fda8637322ec.json
+++ b/services/AnalysisServices/servers/templates/policy-arm/memorymetric_0289bc11-db65-4a58-91ed-fda8637322ec.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AnalysisServices/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AnalysisServices/servers/templates/policy-arm/qpumetric_ea6a4d59-822f-4fb7-a29d-69e523e95bdb.json
+++ b/services/AnalysisServices/servers/templates/policy-arm/qpumetric_ea6a4d59-822f-4fb7-a29d-69e523e95bdb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AnalysisServices/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AnalysisServices/servers/templates/policy/memorymetric_0289bc11-db65-4a58-91ed-fda8637322ec.json
+++ b/services/AnalysisServices/servers/templates/policy/memorymetric_0289bc11-db65-4a58-91ed-fda8637322ec.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AnalysisServices/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AnalysisServices/servers/templates/policy/qpumetric_ea6a4d59-822f-4fb7-a29d-69e523e95bdb.json
+++ b/services/AnalysisServices/servers/templates/policy/qpumetric_ea6a4d59-822f-4fb7-a29d-69e523e95bdb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AnalysisServices/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ApiManagement/service/templates/policy-arm/BackendDuration_fd5d63e0-ab2f-4300-af65-05bf2e490d0e.json
+++ b/services/ApiManagement/service/templates/policy-arm/BackendDuration_fd5d63e0-ab2f-4300-af65-05bf2e490d0e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ApiManagement/service/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ApiManagement/service/templates/policy-arm/Capacity_6b1dd1ae-05de-43d2-bdea-7981c49127fc.json
+++ b/services/ApiManagement/service/templates/policy-arm/Capacity_6b1dd1ae-05de-43d2-bdea-7981c49127fc.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ApiManagement/service/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ApiManagement/service/templates/policy-arm/Duration_52cd4aba-4ad0-402a-880d-ba625ebcf37f.json
+++ b/services/ApiManagement/service/templates/policy-arm/Duration_52cd4aba-4ad0-402a-880d-ba625ebcf37f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ApiManagement/service/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ApiManagement/service/templates/policy-arm/FailedRequests_1f8626fe-812a-48a7-b237-2f9181a5ea12.json
+++ b/services/ApiManagement/service/templates/policy-arm/FailedRequests_1f8626fe-812a-48a7-b237-2f9181a5ea12.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ApiManagement/service/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ApiManagement/service/templates/policy-arm/Requests_2e16fd84-d92f-44ee-8191-ff47e90a9526.json
+++ b/services/ApiManagement/service/templates/policy-arm/Requests_2e16fd84-d92f-44ee-8191-ff47e90a9526.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ApiManagement/service/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ApiManagement/service/templates/policy-arm/TotalRequests_a9480e7f-1cd0-4c46-b5c4-e7f35fe963a5.json
+++ b/services/ApiManagement/service/templates/policy-arm/TotalRequests_a9480e7f-1cd0-4c46-b5c4-e7f35fe963a5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ApiManagement/service/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ApiManagement/service/templates/policy-arm/UnauthorizedRequests_c0c3e784-f488-43a6-a423-18dbb444d443.json
+++ b/services/ApiManagement/service/templates/policy-arm/UnauthorizedRequests_c0c3e784-f488-43a6-a423-18dbb444d443.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ApiManagement/service/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ApiManagement/service/templates/policy/BackendDuration_fd5d63e0-ab2f-4300-af65-05bf2e490d0e.json
+++ b/services/ApiManagement/service/templates/policy/BackendDuration_fd5d63e0-ab2f-4300-af65-05bf2e490d0e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ApiManagement/service/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ApiManagement/service/templates/policy/Capacity_6b1dd1ae-05de-43d2-bdea-7981c49127fc.json
+++ b/services/ApiManagement/service/templates/policy/Capacity_6b1dd1ae-05de-43d2-bdea-7981c49127fc.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ApiManagement/service/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ApiManagement/service/templates/policy/Duration_52cd4aba-4ad0-402a-880d-ba625ebcf37f.json
+++ b/services/ApiManagement/service/templates/policy/Duration_52cd4aba-4ad0-402a-880d-ba625ebcf37f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ApiManagement/service/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ApiManagement/service/templates/policy/FailedRequests_1f8626fe-812a-48a7-b237-2f9181a5ea12.json
+++ b/services/ApiManagement/service/templates/policy/FailedRequests_1f8626fe-812a-48a7-b237-2f9181a5ea12.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ApiManagement/service/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ApiManagement/service/templates/policy/Requests_2e16fd84-d92f-44ee-8191-ff47e90a9526.json
+++ b/services/ApiManagement/service/templates/policy/Requests_2e16fd84-d92f-44ee-8191-ff47e90a9526.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ApiManagement/service/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ApiManagement/service/templates/policy/TotalRequests_a9480e7f-1cd0-4c46-b5c4-e7f35fe963a5.json
+++ b/services/ApiManagement/service/templates/policy/TotalRequests_a9480e7f-1cd0-4c46-b5c4-e7f35fe963a5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ApiManagement/service/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ApiManagement/service/templates/policy/UnauthorizedRequests_c0c3e784-f488-43a6-a423-18dbb444d443.json
+++ b/services/ApiManagement/service/templates/policy/UnauthorizedRequests_c0c3e784-f488-43a6-a423-18dbb444d443.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ApiManagement/service/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/App/containerApps/templates/policy-arm/Replicas_94ae53cd-6e3b-47f5-9709-9c2e10eae6d7.json
+++ b/services/App/containerApps/templates/policy-arm/Replicas_94ae53cd-6e3b-47f5-9709-9c2e10eae6d7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.App/containerApps/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/App/containerApps/templates/policy-arm/RestartCount_b12cad96-7ef2-4223-97f4-53b3dc64ecfa.json
+++ b/services/App/containerApps/templates/policy-arm/RestartCount_b12cad96-7ef2-4223-97f4-53b3dc64ecfa.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.App/containerApps/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/App/containerApps/templates/policy-arm/UsageNanoCores_a9e1306a-a541-423f-a69e-bd37f8f5013a.json
+++ b/services/App/containerApps/templates/policy-arm/UsageNanoCores_a9e1306a-a541-423f-a69e-bd37f8f5013a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.App/containerApps/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/App/containerApps/templates/policy-arm/WorkingSetBytes_423b4280-1f68-49d8-b11a-6a816b0d9172.json
+++ b/services/App/containerApps/templates/policy-arm/WorkingSetBytes_423b4280-1f68-49d8-b11a-6a816b0d9172.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.App/containerApps/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/App/containerApps/templates/policy/Replicas_94ae53cd-6e3b-47f5-9709-9c2e10eae6d7.json
+++ b/services/App/containerApps/templates/policy/Replicas_94ae53cd-6e3b-47f5-9709-9c2e10eae6d7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.App/containerApps/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/App/containerApps/templates/policy/RestartCount_b12cad96-7ef2-4223-97f4-53b3dc64ecfa.json
+++ b/services/App/containerApps/templates/policy/RestartCount_b12cad96-7ef2-4223-97f4-53b3dc64ecfa.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.App/containerApps/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/App/containerApps/templates/policy/UsageNanoCores_a9e1306a-a541-423f-a69e-bd37f8f5013a.json
+++ b/services/App/containerApps/templates/policy/UsageNanoCores_a9e1306a-a541-423f-a69e-bd37f8f5013a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.App/containerApps/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/App/containerApps/templates/policy/WorkingSetBytes_423b4280-1f68-49d8-b11a-6a816b0d9172.json
+++ b/services/App/containerApps/templates/policy/WorkingSetBytes_423b4280-1f68-49d8-b11a-6a816b0d9172.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.App/containerApps/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AppConfiguration/configurationStores/templates/policy-arm/ThrottledHttpRequestCount_0be9dd7c-ae7f-41f7-b3a6-844e64059b73.json
+++ b/services/AppConfiguration/configurationStores/templates/policy-arm/ThrottledHttpRequestCount_0be9dd7c-ae7f-41f7-b3a6-844e64059b73.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AppConfiguration/configurationStores/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/AppConfiguration/configurationStores/templates/policy/ThrottledHttpRequestCount_0be9dd7c-ae7f-41f7-b3a6-844e64059b73.json
+++ b/services/AppConfiguration/configurationStores/templates/policy/ThrottledHttpRequestCount_0be9dd7c-ae7f-41f7-b3a6-844e64059b73.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.AppConfiguration/configurationStores/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Automation/automationAccounts/templates/policy-arm/TotalJob_74e0e3b4-62aa-4503-b05d-c5c79a029ed6.json
+++ b/services/Automation/automationAccounts/templates/policy-arm/TotalJob_74e0e3b4-62aa-4503-b05d-c5c79a029ed6.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Automation/automationAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Automation/automationAccounts/templates/policy-arm/TotalUpdateDeploymentMachineRuns_49e7f58f-4910-4d2f-8589-573e8a65c6dd.json
+++ b/services/Automation/automationAccounts/templates/policy-arm/TotalUpdateDeploymentMachineRuns_49e7f58f-4910-4d2f-8589-573e8a65c6dd.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Automation/automationAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Automation/automationAccounts/templates/policy-arm/TotalUpdateDeploymentRuns_c521bf0d-efec-4d3a-8541-d8749915bfd4.json
+++ b/services/Automation/automationAccounts/templates/policy-arm/TotalUpdateDeploymentRuns_c521bf0d-efec-4d3a-8541-d8749915bfd4.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Automation/automationAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Automation/automationAccounts/templates/policy/TotalJob_74e0e3b4-62aa-4503-b05d-c5c79a029ed6.json
+++ b/services/Automation/automationAccounts/templates/policy/TotalJob_74e0e3b4-62aa-4503-b05d-c5c79a029ed6.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Automation/automationAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Automation/automationAccounts/templates/policy/TotalUpdateDeploymentMachineRuns_49e7f58f-4910-4d2f-8589-573e8a65c6dd.json
+++ b/services/Automation/automationAccounts/templates/policy/TotalUpdateDeploymentMachineRuns_49e7f58f-4910-4d2f-8589-573e8a65c6dd.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Automation/automationAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Automation/automationAccounts/templates/policy/TotalUpdateDeploymentRuns_c521bf0d-efec-4d3a-8541-d8749915bfd4.json
+++ b/services/Automation/automationAccounts/templates/policy/TotalUpdateDeploymentRuns_c521bf0d-efec-4d3a-8541-d8749915bfd4.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Automation/automationAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Batch/batchAccounts/templates/policy-arm/OfflineNodeCount_b40fdb04-cada-4870-80f3-317afc57e5fb.json
+++ b/services/Batch/batchAccounts/templates/policy-arm/OfflineNodeCount_b40fdb04-cada-4870-80f3-317afc57e5fb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Batch/batchAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Batch/batchAccounts/templates/policy-arm/PreemptedNodeCount_8ce7d791-41a5-4d6a-9516-b009eabbd8f7.json
+++ b/services/Batch/batchAccounts/templates/policy-arm/PreemptedNodeCount_8ce7d791-41a5-4d6a-9516-b009eabbd8f7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Batch/batchAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Batch/batchAccounts/templates/policy-arm/RebootingNodeCount_f49539ff-35b1-4d83-8541-e3cf49b383e5.json
+++ b/services/Batch/batchAccounts/templates/policy-arm/RebootingNodeCount_f49539ff-35b1-4d83-8541-e3cf49b383e5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Batch/batchAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Batch/batchAccounts/templates/policy-arm/TaskFailEvent_70b8ce6d-0d28-4997-84df-957791877eec.json
+++ b/services/Batch/batchAccounts/templates/policy-arm/TaskFailEvent_70b8ce6d-0d28-4997-84df-957791877eec.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Batch/batchAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Batch/batchAccounts/templates/policy-arm/UnusableNodeCount_6c9857e4-7d6b-4384-80da-b88a2e6858ac.json
+++ b/services/Batch/batchAccounts/templates/policy-arm/UnusableNodeCount_6c9857e4-7d6b-4384-80da-b88a2e6858ac.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Batch/batchAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Batch/batchAccounts/templates/policy/OfflineNodeCount_b40fdb04-cada-4870-80f3-317afc57e5fb.json
+++ b/services/Batch/batchAccounts/templates/policy/OfflineNodeCount_b40fdb04-cada-4870-80f3-317afc57e5fb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Batch/batchAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Batch/batchAccounts/templates/policy/PreemptedNodeCount_8ce7d791-41a5-4d6a-9516-b009eabbd8f7.json
+++ b/services/Batch/batchAccounts/templates/policy/PreemptedNodeCount_8ce7d791-41a5-4d6a-9516-b009eabbd8f7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Batch/batchAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Batch/batchAccounts/templates/policy/RebootingNodeCount_f49539ff-35b1-4d83-8541-e3cf49b383e5.json
+++ b/services/Batch/batchAccounts/templates/policy/RebootingNodeCount_f49539ff-35b1-4d83-8541-e3cf49b383e5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Batch/batchAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Batch/batchAccounts/templates/policy/TaskFailEvent_70b8ce6d-0d28-4997-84df-957791877eec.json
+++ b/services/Batch/batchAccounts/templates/policy/TaskFailEvent_70b8ce6d-0d28-4997-84df-957791877eec.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Batch/batchAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Batch/batchAccounts/templates/policy/UnusableNodeCount_6c9857e4-7d6b-4384-80da-b88a2e6858ac.json
+++ b/services/Batch/batchAccounts/templates/policy/UnusableNodeCount_6c9857e4-7d6b-4384-80da-b88a2e6858ac.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Batch/batchAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy-arm/allconnectedclients_af750dfc-62e5-4b74-9514-ca419d800590.json
+++ b/services/Cache/Redis/templates/policy-arm/allconnectedclients_af750dfc-62e5-4b74-9514-ca419d800590.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy-arm/allpercentprocessortime_24c5276b-77b1-48ab-a8c1-15844b11e0aa.json
+++ b/services/Cache/Redis/templates/policy-arm/allpercentprocessortime_24c5276b-77b1-48ab-a8c1-15844b11e0aa.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy-arm/allserverLoad_7072ba94-41d2-4584-89ab-a5824ed045f4.json
+++ b/services/Cache/Redis/templates/policy-arm/allserverLoad_7072ba94-41d2-4584-89ab-a5824ed045f4.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy-arm/allusedmemorypercentage_b9ffe52a-f430-4605-a2b1-d815eb1bcc56.json
+++ b/services/Cache/Redis/templates/policy-arm/allusedmemorypercentage_b9ffe52a-f430-4605-a2b1-d815eb1bcc56.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy-arm/cacheLatency_82cb3ad7-d44f-4131-9078-5aac82d3333a.json
+++ b/services/Cache/Redis/templates/policy-arm/cacheLatency_82cb3ad7-d44f-4131-9078-5aac82d3333a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy-arm/cacheRead_cc764431-e1b0-4455-94b1-b66d32cc54b4.json
+++ b/services/Cache/Redis/templates/policy-arm/cacheRead_cc764431-e1b0-4455-94b1-b66d32cc54b4.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy-arm/connectedclients_f0c2ec92-15bc-47b1-8edb-d0c5d10aaddc.json
+++ b/services/Cache/Redis/templates/policy-arm/connectedclients_f0c2ec92-15bc-47b1-8edb-d0c5d10aaddc.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy-arm/errors_24b37318-9353-4424-9d8e-ac28450328b6.json
+++ b/services/Cache/Redis/templates/policy-arm/errors_24b37318-9353-4424-9d8e-ac28450328b6.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy-arm/percentProcessorTime_8d5df17c-a5b7-4cf1-a01e-f9d8625297a6.json
+++ b/services/Cache/Redis/templates/policy-arm/percentProcessorTime_8d5df17c-a5b7-4cf1-a01e-f9d8625297a6.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy-arm/serverLoad_837ecf42-3f25-41ae-b97d-34193f0669da.json
+++ b/services/Cache/Redis/templates/policy-arm/serverLoad_837ecf42-3f25-41ae-b97d-34193f0669da.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy-arm/usedmemoryRss_1b68776d-4d11-4d27-96c5-4d51cf17e1fc.json
+++ b/services/Cache/Redis/templates/policy-arm/usedmemoryRss_1b68776d-4d11-4d27-96c5-4d51cf17e1fc.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy-arm/usedmemory_aecc75bf-f961-4c22-86e9-84c5039a2938.json
+++ b/services/Cache/Redis/templates/policy-arm/usedmemory_aecc75bf-f961-4c22-86e9-84c5039a2938.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy-arm/usedmemorypercentage_d6c4011c-f4e6-4b12-b6e6-9486eab0fecc.json
+++ b/services/Cache/Redis/templates/policy-arm/usedmemorypercentage_d6c4011c-f4e6-4b12-b6e6-9486eab0fecc.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy/allconnectedclients_af750dfc-62e5-4b74-9514-ca419d800590.json
+++ b/services/Cache/Redis/templates/policy/allconnectedclients_af750dfc-62e5-4b74-9514-ca419d800590.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy/allpercentprocessortime_24c5276b-77b1-48ab-a8c1-15844b11e0aa.json
+++ b/services/Cache/Redis/templates/policy/allpercentprocessortime_24c5276b-77b1-48ab-a8c1-15844b11e0aa.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy/allserverLoad_7072ba94-41d2-4584-89ab-a5824ed045f4.json
+++ b/services/Cache/Redis/templates/policy/allserverLoad_7072ba94-41d2-4584-89ab-a5824ed045f4.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy/allusedmemorypercentage_b9ffe52a-f430-4605-a2b1-d815eb1bcc56.json
+++ b/services/Cache/Redis/templates/policy/allusedmemorypercentage_b9ffe52a-f430-4605-a2b1-d815eb1bcc56.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy/cacheLatency_82cb3ad7-d44f-4131-9078-5aac82d3333a.json
+++ b/services/Cache/Redis/templates/policy/cacheLatency_82cb3ad7-d44f-4131-9078-5aac82d3333a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy/cacheRead_cc764431-e1b0-4455-94b1-b66d32cc54b4.json
+++ b/services/Cache/Redis/templates/policy/cacheRead_cc764431-e1b0-4455-94b1-b66d32cc54b4.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy/connectedclients_f0c2ec92-15bc-47b1-8edb-d0c5d10aaddc.json
+++ b/services/Cache/Redis/templates/policy/connectedclients_f0c2ec92-15bc-47b1-8edb-d0c5d10aaddc.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy/errors_24b37318-9353-4424-9d8e-ac28450328b6.json
+++ b/services/Cache/Redis/templates/policy/errors_24b37318-9353-4424-9d8e-ac28450328b6.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy/percentProcessorTime_8d5df17c-a5b7-4cf1-a01e-f9d8625297a6.json
+++ b/services/Cache/Redis/templates/policy/percentProcessorTime_8d5df17c-a5b7-4cf1-a01e-f9d8625297a6.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy/serverLoad_837ecf42-3f25-41ae-b97d-34193f0669da.json
+++ b/services/Cache/Redis/templates/policy/serverLoad_837ecf42-3f25-41ae-b97d-34193f0669da.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy/usedmemoryRss_1b68776d-4d11-4d27-96c5-4d51cf17e1fc.json
+++ b/services/Cache/Redis/templates/policy/usedmemoryRss_1b68776d-4d11-4d27-96c5-4d51cf17e1fc.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy/usedmemory_aecc75bf-f961-4c22-86e9-84c5039a2938.json
+++ b/services/Cache/Redis/templates/policy/usedmemory_aecc75bf-f961-4c22-86e9-84c5039a2938.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cache/Redis/templates/policy/usedmemorypercentage_d6c4011c-f4e6-4b12-b6e6-9486eab0fecc.json
+++ b/services/Cache/Redis/templates/policy/usedmemorypercentage_d6c4011c-f4e6-4b12-b6e6-9486eab0fecc.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cache/Redis/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cdn/profiles/templates/policy-arm/ByteHitRatio_5e8aaa27-e5b3-4774-9807-af61ec96b001.json
+++ b/services/Cdn/profiles/templates/policy-arm/ByteHitRatio_5e8aaa27-e5b3-4774-9807-af61ec96b001.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cdn/profiles/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cdn/profiles/templates/policy-arm/OriginHealthPercentage_c42138d4-bb4c-4171-8802-ba44d671d72f.json
+++ b/services/Cdn/profiles/templates/policy-arm/OriginHealthPercentage_c42138d4-bb4c-4171-8802-ba44d671d72f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cdn/profiles/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cdn/profiles/templates/policy-arm/Percentage5XX_c47441d4-7061-4acd-8ad8-69e52d00557c.json
+++ b/services/Cdn/profiles/templates/policy-arm/Percentage5XX_c47441d4-7061-4acd-8ad8-69e52d00557c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cdn/profiles/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cdn/profiles/templates/policy-arm/RequestCount_cf6babc2-f623-4f12-a352-c30a02bcb6c6.json
+++ b/services/Cdn/profiles/templates/policy-arm/RequestCount_cf6babc2-f623-4f12-a352-c30a02bcb6c6.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cdn/profiles/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cdn/profiles/templates/policy-arm/TotalLatency_5fb9c4bf-3799-44e0-bd75-656d1cfa26d2.json
+++ b/services/Cdn/profiles/templates/policy-arm/TotalLatency_5fb9c4bf-3799-44e0-bd75-656d1cfa26d2.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cdn/profiles/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cdn/profiles/templates/policy/ByteHitRatio_5e8aaa27-e5b3-4774-9807-af61ec96b001.json
+++ b/services/Cdn/profiles/templates/policy/ByteHitRatio_5e8aaa27-e5b3-4774-9807-af61ec96b001.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cdn/profiles/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cdn/profiles/templates/policy/OriginHealthPercentage_c42138d4-bb4c-4171-8802-ba44d671d72f.json
+++ b/services/Cdn/profiles/templates/policy/OriginHealthPercentage_c42138d4-bb4c-4171-8802-ba44d671d72f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cdn/profiles/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cdn/profiles/templates/policy/Percentage5XX_c47441d4-7061-4acd-8ad8-69e52d00557c.json
+++ b/services/Cdn/profiles/templates/policy/Percentage5XX_c47441d4-7061-4acd-8ad8-69e52d00557c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cdn/profiles/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cdn/profiles/templates/policy/RequestCount_cf6babc2-f623-4f12-a352-c30a02bcb6c6.json
+++ b/services/Cdn/profiles/templates/policy/RequestCount_cf6babc2-f623-4f12-a352-c30a02bcb6c6.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cdn/profiles/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Cdn/profiles/templates/policy/TotalLatency_5fb9c4bf-3799-44e0-bd75-656d1cfa26d2.json
+++ b/services/Cdn/profiles/templates/policy/TotalLatency_5fb9c4bf-3799-44e0-bd75-656d1cfa26d2.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Cdn/profiles/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ActionFeaturesIdOccurrences_397fef65-9192-4310-b9da-57cc1513c809.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ActionFeaturesIdOccurrences_397fef65-9192-4310-b9da-57cc1513c809.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ActionFeaturesPerEvent_780c451d-bf30-4e36-b544-ea994ca32f43.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ActionFeaturesPerEvent_780c451d-bf30-4e36-b544-ea994ca32f43.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ActionIfOccurrence_69338f82-3e4a-4ff2-bb00-6aec7e84e3f4.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ActionIfOccurrence_69338f82-3e4a-4ff2-bb00-6aec7e84e3f4.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ActionNamespacePerEvent_0db7da9c-960d-4122-9976-adc029da7b12.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ActionNamespacePerEvent_0db7da9c-960d-4122-9976-adc029da7b12.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ActionPerEvent_1221f6e7-8f44-4d91-b0ed-d72920d4d496.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ActionPerEvent_1221f6e7-8f44-4d91-b0ed-d72920d4d496.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ActiveTokens_ab9d016d-b31b-4144-9b76-f5b1c625fa9b.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ActiveTokens_ab9d016d-b31b-4144-9b76-f5b1c625fa9b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/AudioSecondsTranscribed_43d8c4af-9534-4bda-8840-1513181fabb2.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/AudioSecondsTranscribed_43d8c4af-9534-4bda-8840-1513181fabb2.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/AudioSecondsTranslated_d0bc3cdd-eade-4dfd-9b44-3ce8219a5e13.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/AudioSecondsTranslated_d0bc3cdd-eade-4dfd-9b44-3ce8219a5e13.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/AvatarModelHostingSeconds_0fc4ed4a-068b-4144-b2b3-d34114577175.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/AvatarModelHostingSeconds_0fc4ed4a-068b-4144-b2b3-d34114577175.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAIContextTokensCacheMatchRate_81f8369c-65bf-4194-bfd2-ffdfa2470577.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAIContextTokensCacheMatchRate_81f8369c-65bf-4194-bfd2-ffdfa2470577.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAIProvisionedManagedUtilizationV2_693a3b37-1e2a-42d1-aaed-b1f374276d1c.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAIProvisionedManagedUtilizationV2_693a3b37-1e2a-42d1-aaed-b1f374276d1c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAIProvisionedManagedUtilization_5ca4e110-09b4-4fe5-bb8f-4fa3f35f8fca.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAIProvisionedManagedUtilization_5ca4e110-09b4-4fe5-bb8f-4fa3f35f8fca.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAIRequests_a1528d17-f288-46b1-b084-8b8fe3af90fa.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAIRequests_a1528d17-f288-46b1-b084-8b8fe3af90fa.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAITimeToResponse_995cc12a-1887-4669-92c5-70a6ca8bfe70.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/AzureOpenAITimeToResponse_995cc12a-1887-4669-92c5-70a6ca8bfe70.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/BaselineEstimatorOverallReward_a27171ed-8c6c-4995-b3e4-ff1f1dd0cc90.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/BaselineEstimatorOverallReward_a27171ed-8c6c-4995-b3e4-ff1f1dd0cc90.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/BaselineEstimatorSlotReward_cd9ba872-2f2d-4cf8-8957-e7ffa6b7e5fc.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/BaselineEstimatorSlotReward_cd9ba872-2f2d-4cf8-8957-e7ffa6b7e5fc.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/BaselineRandomEstimatorOverallReward_8081760a-4b0c-4ae8-86a0-5b7cc418d2bb.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/BaselineRandomEstimatorOverallReward_8081760a-4b0c-4ae8-86a0-5b7cc418d2bb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/BaselineRandomEstimatorSlotReward_7fd0ac93-49e5-4ecd-96dd-5a1b91c27ce1.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/BaselineRandomEstimatorSlotReward_7fd0ac93-49e5-4ecd-96dd-5a1b91c27ce1.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/BaselineRandomEventCount_b34ff46a-3335-485d-8955-3c12b89e0429.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/BaselineRandomEventCount_b34ff46a-3335-485d-8955-3c12b89e0429.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/BaselineRandomReward_d4666cca-c55a-4c38-9c83-35184d82dbb0.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/BaselineRandomReward_d4666cca-c55a-4c38-9c83-35184d82dbb0.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/BlockedCalls_87fe8679-655d-4acb-a37c-b7faebe26d47.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/BlockedCalls_87fe8679-655d-4acb-a37c-b7faebe26d47.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/CarnegieInferenceCount_87cf02fd-d12a-4c8d-85b7-01f616866f8c.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/CarnegieInferenceCount_87cf02fd-d12a-4c8d-85b7-01f616866f8c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ClientErrors_ec8c928a-5206-4059-8aea-8486004dd30d.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ClientErrors_ec8c928a-5206-4059-8aea-8486004dd30d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ComputerVisionTransactions_493511fe-f9a1-450d-a5c6-c4062fb0d2c9.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ComputerVisionTransactions_493511fe-f9a1-450d-a5c6-c4062fb0d2c9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ContentSafetyImageAnalyzeRequestCount_404c9224-ecfd-4f11-b6de-9439f5c4ff9b.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ContentSafetyImageAnalyzeRequestCount_404c9224-ecfd-4f11-b6de-9439f5c4ff9b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ContentSafetyTextAnalyzeRequestCount_4be881a1-a702-481c-a1ad-399b100cabdb.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ContentSafetyTextAnalyzeRequestCount_4be881a1-a702-481c-a1ad-399b100cabdb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ContextFeatureIdOccurrences_a86c358c-5603-4e66-b5f7-87c19ddd5e9f.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ContextFeatureIdOccurrences_a86c358c-5603-4e66-b5f7-87c19ddd5e9f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ContextFeaturesPerEvent_0704975d-f5fb-4031-8d07-18a79f4788da.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ContextFeaturesPerEvent_0704975d-f5fb-4031-8d07-18a79f4788da.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ContextNamespacesPerEvent_60aa78cd-66d4-421b-92a4-e20f138518d9.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ContextNamespacesPerEvent_60aa78cd-66d4-421b-92a4-e20f138518d9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/CustomVisionTrainingTime_1de7e287-53d0-41e4-b37c-701470e82543.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/CustomVisionTrainingTime_1de7e287-53d0-41e4-b37c-701470e82543.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/CustomVisionTransactions_e7d44227-8e9b-4698-a398-24e2afe25408.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/CustomVisionTransactions_e7d44227-8e9b-4698-a398-24e2afe25408.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/DataIn_0fd9d459-4d84-422c-ad72-ce8788a13f4d.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/DataIn_0fd9d459-4d84-422c-ad72-ce8788a13f4d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/DataOut_0e4e5a62-95e2-4fc0-97e0-b6b6574fe1f5.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/DataOut_0e4e5a62-95e2-4fc0-97e0-b6b6574fe1f5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/DocumentCharactersTranslated_fe4eba6e-8488-4d69-8c5b-b247fe556012.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/DocumentCharactersTranslated_fe4eba6e-8488-4d69-8c5b-b247fe556012.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/DocumentCustomCharactersTranslated_7fce7630-0db2-4279-9b81-cb06ad7d83ca.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/DocumentCustomCharactersTranslated_7fce7630-0db2-4279-9b81-cb06ad7d83ca.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/FaceImagesTrained_fa6564b0-870b-4b21-b648-6a793d7a2797.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/FaceImagesTrained_fa6564b0-870b-4b21-b648-6a793d7a2797.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/FaceTransactions_c382a635-df8d-4d19-86de-daa28de4dce7.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/FaceTransactions_c382a635-df8d-4d19-86de-daa28de4dce7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/FacesStored_3846fe0-d373-4548-af44-a2d7a2ba3399.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/FacesStored_3846fe0-d373-4548-af44-a2d7a2ba3399.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/FeatureCardinalityAction_3657d258-5623-4480-84ca-3ba6226d1378.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/FeatureCardinalityAction_3657d258-5623-4480-84ca-3ba6226d1378.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/FeatureCardinalityContext_d582a978-ce14-484a-b759-84903838979c.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/FeatureCardinalityContext_d582a978-ce14-484a-b759-84903838979c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/FeatureCardinalitySlot_bfe3b067-314b-46bf-925e-e81f66cf910f.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/FeatureCardinalitySlot_bfe3b067-314b-46bf-925e-e81f66cf910f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/FineTunedTrainingHours_52909b9b-190d-4d7b-9900-1789ce0b937b.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/FineTunedTrainingHours_52909b9b-190d-4d7b-9900-1789ce0b937b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/GeneratedTokens_7fbd5f2d-00f0-4ca1-8d5f-0233d0a3f910.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/GeneratedTokens_7fbd5f2d-00f0-4ca1-8d5f-0233d0a3f910.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ImagesStored_2b1b7563-e1ec-4f56-9caf-f2cb019bc04f.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ImagesStored_2b1b7563-e1ec-4f56-9caf-f2cb019bc04f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/LUISSpeechRequests_e4c3e04b-15c3-4883-8351-a87a4510e40e.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/LUISSpeechRequests_e4c3e04b-15c3-4883-8351-a87a4510e40e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/LUISTextRequests_4c766f95-57b7-4a3b-bba3-8801265dbc01.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/LUISTextRequests_4c766f95-57b7-4a3b-bba3-8801265dbc01.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/Latency_d76ab40a-2831-4fa2-b476-5fdcda3d7c4c.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/Latency_d76ab40a-2831-4fa2-b476-5fdcda3d7c4c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/LearnedEvents_66b4ade6-1ae4-430e-b545-5c1c188b780c.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/LearnedEvents_66b4ade6-1ae4-430e-b545-5c1c188b780c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/MatchedRewards_c41c172e-b804-42c4-b329-aa255c85f506.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/MatchedRewards_c41c172e-b804-42c4-b329-aa255c85f506.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/NonActivatedEvents_b5283ee6-b4a5-4e5e-890d-12ebca7f54e7.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/NonActivatedEvents_b5283ee6-b4a5-4e5e-890d-12ebca7f54e7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/NumberOfSlots_a1d7f8c7-1182-4241-b3f6-e086309d7ac1.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/NumberOfSlots_a1d7f8c7-1182-4241-b3f6-e086309d7ac1.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/NumberofSpeakerProfiles_f5425eb7-e311-4336-b5ab-7a9b2b0d5dea.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/NumberofSpeakerProfiles_f5425eb7-e311-4336-b5ab-7a9b2b0d5dea.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ObservedRewards_6b7ae03b-e2c8-4115-a560-4144a455816b.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ObservedRewards_6b7ae03b-e2c8-4115-a560-4144a455816b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/OneDocumentCharactersTranslated_eee95c4b-db79-48e5-9a5c-ef921a22e3c0.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/OneDocumentCharactersTranslated_eee95c4b-db79-48e5-9a5c-ef921a22e3c0.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/OnlineEstimatorOverallReward_73c87a60-8de8-414e-9cc5-81a3ca14d687.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/OnlineEstimatorOverallReward_73c87a60-8de8-414e-9cc5-81a3ca14d687.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/OnlineEstimatorSlotReward_c61d3a5c-4aa4-4c6a-8bc0-859061559b4c.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/OnlineEstimatorSlotReward_c61d3a5c-4aa4-4c6a-8bc0-859061559b4c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/OnlineEventCount_e360aeac-66a6-4bf0-8e36-475608c6d02b.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/OnlineEventCount_e360aeac-66a6-4bf0-8e36-475608c6d02b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/OnlineReward_86e00692-7e42-4a4c-86a3-21c70add7bd3.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/OnlineReward_86e00692-7e42-4a4c-86a3-21c70add7bd3.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ProcessedCharacters_4b474463-3243-4966-a4d0-8404760b9ca3.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ProcessedCharacters_4b474463-3243-4966-a4d0-8404760b9ca3.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ProcessedHealthTextRecords_bf42c604-b4f7-4b6c-8a33-2f5e1912d306.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ProcessedHealthTextRecords_bf42c604-b4f7-4b6c-8a33-2f5e1912d306.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ProcessedImages_fcd3e37c-82bb-48df-8860-f1b4f01d4cc3.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ProcessedImages_fcd3e37c-82bb-48df-8860-f1b4f01d4cc3.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ProcessedPages_bb4ebaf2-e5ec-47cc-b8a8-2428e924721c.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ProcessedPages_bb4ebaf2-e5ec-47cc-b8a8-2428e924721c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ProcessedPromptTokens_30dc0126-1466-4c11-9096-a7fffc552bc8.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ProcessedPromptTokens_30dc0126-1466-4c11-9096-a7fffc552bc8.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ProcessedTextRecords_5aeb1d15-f8f3-49d5-8894-b6af0d89d935.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ProcessedTextRecords_5aeb1d15-f8f3-49d5-8894-b6af0d89d935.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/QuestionAnsweringTextRecords_c8f71cfd-42cd-4063-92fc-d6560697250d.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/QuestionAnsweringTextRecords_c8f71cfd-42cd-4063-92fc-d6560697250d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/RAIAbusiveUsersCount_f2926569-df78-4c68-90a7-3c5f96cfa1f3.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/RAIAbusiveUsersCount_f2926569-df78-4c68-90a7-3c5f96cfa1f3.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/RAIHarmfulRequests_e7341b29-84ea-4ca2-8140-e774b1cd1444.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/RAIHarmfulRequests_e7341b29-84ea-4ca2-8140-e774b1cd1444.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/RAIRejectedRequests_a97c7421-8268-4837-b433-762882c3887f.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/RAIRejectedRequests_a97c7421-8268-4837-b433-762882c3887f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/RAISystemEvent_b0bf777b-90e9-4aed-b8e2-94ab9755d1ca.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/RAISystemEvent_b0bf777b-90e9-4aed-b8e2-94ab9755d1ca.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/RAITotalRequests_82c2b472-2084-4122-8bb5-51142ce19101.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/RAITotalRequests_82c2b472-2084-4122-8bb5-51142ce19101.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/Ratelimit_b269a4f9-ba74-4061-abc1-655d656c1c5f.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/Ratelimit_b269a4f9-ba74-4061-abc1-655d656c1c5f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/Reward_3984067c-1e9b-41ee-9464-1f6b2df45cea.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/Reward_3984067c-1e9b-41ee-9464-1f6b2df45cea.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/ServerErrors_3c550d9c-8276-4a61-b0cf-ef437a55e299.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/ServerErrors_3c550d9c-8276-4a61-b0cf-ef437a55e299.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/SlotFeatureIdOccurrences_b05249b2-d6f2-4c2e-a14b-a25353053e6d.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/SlotFeatureIdOccurrences_b05249b2-d6f2-4c2e-a14b-a25353053e6d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/SlotFeaturesPerEvent_6495d787-2701-45ea-8abd-f23b18ed6e66.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/SlotFeaturesPerEvent_6495d787-2701-45ea-8abd-f23b18ed6e66.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/SlotIdOccurrences_12ffdc4a-2ac4-4b4b-bf04-c5b48d2f0904.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/SlotIdOccurrences_12ffdc4a-2ac4-4b4b-bf04-c5b48d2f0904.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/SlotNamespacesPerEvent_c87a2b96-2308-4d2c-9353-8d300f0e542c.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/SlotNamespacesPerEvent_c87a2b96-2308-4d2c-9353-8d300f0e542c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/SlotRewards_13d1dc54-12a8-475d-8a87-d9060df9f348.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/SlotRewards_13d1dc54-12a8-475d-8a87-d9060df9f348.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/SpeakerRecognitionTransactions_1f6e25bb-1412-46b8-b4cf-de1498a03927.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/SpeakerRecognitionTransactions_1f6e25bb-1412-46b8-b4cf-de1498a03927.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/SpeechModelHostingHours_0433dc7d-e9c0-4d32-8295-ce24cd9e453b.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/SpeechModelHostingHours_0433dc7d-e9c0-4d32-8295-ce24cd9e453b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/SpeechModelHostingHours_2aa2bd92-85bd-47b8-ac48-3c672fdbb486.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/SpeechModelHostingHours_2aa2bd92-85bd-47b8-ac48-3c672fdbb486.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/SuccessRate_80f3c9ae-7da9-462f-ab44-2ff80d27c8f1.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/SuccessRate_80f3c9ae-7da9-462f-ab44-2ff80d27c8f1.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/SuccessfulCalls_715804f2-6789-4b83-9c5f-bee2a805bbc2.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/SuccessfulCalls_715804f2-6789-4b83-9c5f-bee2a805bbc2.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/SynthesizedCharacters_b0320e4c-7f6d-4990-b2b9-12f1fcb103cf.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/SynthesizedCharacters_b0320e4c-7f6d-4990-b2b9-12f1fcb103cf.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/TextCharactersTranslated_2785f1ab-abcc-44da-8e08-d16c74e67002.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/TextCharactersTranslated_2785f1ab-abcc-44da-8e08-d16c74e67002.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/TextCustomCharactersTranslated_50959073-a6ad-4b63-b76e-4a22745e5852.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/TextCustomCharactersTranslated_50959073-a6ad-4b63-b76e-4a22745e5852.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/TextTrainedCharacters_528496f5-e701-4a9e-8b4c-c876be59c9dc.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/TextTrainedCharacters_528496f5-e701-4a9e-8b4c-c876be59c9dc.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/TokenTransaction_287a29bf-097d-4c4a-9ac5-df70a10f6903.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/TokenTransaction_287a29bf-097d-4c4a-9ac5-df70a10f6903.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/TotalCalls_07f1ae0a-94f3-41da-b3a6-ca9188e416cb.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/TotalCalls_07f1ae0a-94f3-41da-b3a6-ca9188e416cb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/TotalErrors_e228ad2d-7f9f-4843-88e2-57f6d44c59e9.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/TotalErrors_e228ad2d-7f9f-4843-88e2-57f6d44c59e9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/TotalEvents_2a65a81a-be78-499f-bca4-64976249a0cd.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/TotalEvents_2a65a81a-be78-499f-bca4-64976249a0cd.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/TotalTokenCalls_369652ae-56b1-4620-be56-0024629b2cad.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/TotalTokenCalls_369652ae-56b1-4620-be56-0024629b2cad.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/UserBaselineEventCount_61defc4a-43af-4667-b63a-02c28af099be.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/UserBaselineEventCount_61defc4a-43af-4667-b63a-02c28af099be.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/UserBaselineReward_9386f63a-026e-4c91-886e-c10478132bdd.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/UserBaselineReward_9386f63a-026e-4c91-886e-c10478132bdd.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/VideoSecondsSynthesized_81268206-66e5-4b33-8205-93147fc5989c.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/VideoSecondsSynthesized_81268206-66e5-4b33-8205-93147fc5989c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/VoiceModelHostingHours_7d5cc479-cf69-44bc-a612-eac4b20fdc08.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/VoiceModelHostingHours_7d5cc479-cf69-44bc-a612-eac4b20fdc08.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy-arm/VoiceModelTrainingMinutes_39eaa390-7c58-4b79-af20-e47138e7ed97.json
+++ b/services/CognitiveServices/accounts/templates/policy-arm/VoiceModelTrainingMinutes_39eaa390-7c58-4b79-af20-e47138e7ed97.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ActionFeaturesIdOccurrences_397fef65-9192-4310-b9da-57cc1513c809.json
+++ b/services/CognitiveServices/accounts/templates/policy/ActionFeaturesIdOccurrences_397fef65-9192-4310-b9da-57cc1513c809.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ActionFeaturesPerEvent_780c451d-bf30-4e36-b544-ea994ca32f43.json
+++ b/services/CognitiveServices/accounts/templates/policy/ActionFeaturesPerEvent_780c451d-bf30-4e36-b544-ea994ca32f43.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ActionIfOccurrence_69338f82-3e4a-4ff2-bb00-6aec7e84e3f4.json
+++ b/services/CognitiveServices/accounts/templates/policy/ActionIfOccurrence_69338f82-3e4a-4ff2-bb00-6aec7e84e3f4.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ActionNamespacePerEvent_0db7da9c-960d-4122-9976-adc029da7b12.json
+++ b/services/CognitiveServices/accounts/templates/policy/ActionNamespacePerEvent_0db7da9c-960d-4122-9976-adc029da7b12.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ActionPerEvent_1221f6e7-8f44-4d91-b0ed-d72920d4d496.json
+++ b/services/CognitiveServices/accounts/templates/policy/ActionPerEvent_1221f6e7-8f44-4d91-b0ed-d72920d4d496.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ActiveTokens_ab9d016d-b31b-4144-9b76-f5b1c625fa9b.json
+++ b/services/CognitiveServices/accounts/templates/policy/ActiveTokens_ab9d016d-b31b-4144-9b76-f5b1c625fa9b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/AudioSecondsTranscribed_43d8c4af-9534-4bda-8840-1513181fabb2.json
+++ b/services/CognitiveServices/accounts/templates/policy/AudioSecondsTranscribed_43d8c4af-9534-4bda-8840-1513181fabb2.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/AudioSecondsTranslated_d0bc3cdd-eade-4dfd-9b44-3ce8219a5e13.json
+++ b/services/CognitiveServices/accounts/templates/policy/AudioSecondsTranslated_d0bc3cdd-eade-4dfd-9b44-3ce8219a5e13.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/AvatarModelHostingSeconds_0fc4ed4a-068b-4144-b2b3-d34114577175.json
+++ b/services/CognitiveServices/accounts/templates/policy/AvatarModelHostingSeconds_0fc4ed4a-068b-4144-b2b3-d34114577175.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/AzureOpenAIContextTokensCacheMatchRate_81f8369c-65bf-4194-bfd2-ffdfa2470577.json
+++ b/services/CognitiveServices/accounts/templates/policy/AzureOpenAIContextTokensCacheMatchRate_81f8369c-65bf-4194-bfd2-ffdfa2470577.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/AzureOpenAIProvisionedManagedUtilizationV2_693a3b37-1e2a-42d1-aaed-b1f374276d1c.json
+++ b/services/CognitiveServices/accounts/templates/policy/AzureOpenAIProvisionedManagedUtilizationV2_693a3b37-1e2a-42d1-aaed-b1f374276d1c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/AzureOpenAIProvisionedManagedUtilization_5ca4e110-09b4-4fe5-bb8f-4fa3f35f8fca.json
+++ b/services/CognitiveServices/accounts/templates/policy/AzureOpenAIProvisionedManagedUtilization_5ca4e110-09b4-4fe5-bb8f-4fa3f35f8fca.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/AzureOpenAIRequests_a1528d17-f288-46b1-b084-8b8fe3af90fa.json
+++ b/services/CognitiveServices/accounts/templates/policy/AzureOpenAIRequests_a1528d17-f288-46b1-b084-8b8fe3af90fa.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/AzureOpenAITimeToResponse_995cc12a-1887-4669-92c5-70a6ca8bfe70.json
+++ b/services/CognitiveServices/accounts/templates/policy/AzureOpenAITimeToResponse_995cc12a-1887-4669-92c5-70a6ca8bfe70.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/BaselineEstimatorOverallReward_a27171ed-8c6c-4995-b3e4-ff1f1dd0cc90.json
+++ b/services/CognitiveServices/accounts/templates/policy/BaselineEstimatorOverallReward_a27171ed-8c6c-4995-b3e4-ff1f1dd0cc90.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/BaselineEstimatorSlotReward_cd9ba872-2f2d-4cf8-8957-e7ffa6b7e5fc.json
+++ b/services/CognitiveServices/accounts/templates/policy/BaselineEstimatorSlotReward_cd9ba872-2f2d-4cf8-8957-e7ffa6b7e5fc.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/BaselineRandomEstimatorOverallReward_8081760a-4b0c-4ae8-86a0-5b7cc418d2bb.json
+++ b/services/CognitiveServices/accounts/templates/policy/BaselineRandomEstimatorOverallReward_8081760a-4b0c-4ae8-86a0-5b7cc418d2bb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/BaselineRandomEstimatorSlotReward_7fd0ac93-49e5-4ecd-96dd-5a1b91c27ce1.json
+++ b/services/CognitiveServices/accounts/templates/policy/BaselineRandomEstimatorSlotReward_7fd0ac93-49e5-4ecd-96dd-5a1b91c27ce1.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/BaselineRandomEventCount_b34ff46a-3335-485d-8955-3c12b89e0429.json
+++ b/services/CognitiveServices/accounts/templates/policy/BaselineRandomEventCount_b34ff46a-3335-485d-8955-3c12b89e0429.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/BaselineRandomReward_d4666cca-c55a-4c38-9c83-35184d82dbb0.json
+++ b/services/CognitiveServices/accounts/templates/policy/BaselineRandomReward_d4666cca-c55a-4c38-9c83-35184d82dbb0.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/BlockedCalls_87fe8679-655d-4acb-a37c-b7faebe26d47.json
+++ b/services/CognitiveServices/accounts/templates/policy/BlockedCalls_87fe8679-655d-4acb-a37c-b7faebe26d47.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/CarnegieInferenceCount_87cf02fd-d12a-4c8d-85b7-01f616866f8c.json
+++ b/services/CognitiveServices/accounts/templates/policy/CarnegieInferenceCount_87cf02fd-d12a-4c8d-85b7-01f616866f8c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ClientErrors_ec8c928a-5206-4059-8aea-8486004dd30d.json
+++ b/services/CognitiveServices/accounts/templates/policy/ClientErrors_ec8c928a-5206-4059-8aea-8486004dd30d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ComputerVisionTransactions_493511fe-f9a1-450d-a5c6-c4062fb0d2c9.json
+++ b/services/CognitiveServices/accounts/templates/policy/ComputerVisionTransactions_493511fe-f9a1-450d-a5c6-c4062fb0d2c9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ContentSafetyImageAnalyzeRequestCount_404c9224-ecfd-4f11-b6de-9439f5c4ff9b.json
+++ b/services/CognitiveServices/accounts/templates/policy/ContentSafetyImageAnalyzeRequestCount_404c9224-ecfd-4f11-b6de-9439f5c4ff9b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ContentSafetyTextAnalyzeRequestCount_4be881a1-a702-481c-a1ad-399b100cabdb.json
+++ b/services/CognitiveServices/accounts/templates/policy/ContentSafetyTextAnalyzeRequestCount_4be881a1-a702-481c-a1ad-399b100cabdb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ContextFeatureIdOccurrences_a86c358c-5603-4e66-b5f7-87c19ddd5e9f.json
+++ b/services/CognitiveServices/accounts/templates/policy/ContextFeatureIdOccurrences_a86c358c-5603-4e66-b5f7-87c19ddd5e9f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ContextFeaturesPerEvent_0704975d-f5fb-4031-8d07-18a79f4788da.json
+++ b/services/CognitiveServices/accounts/templates/policy/ContextFeaturesPerEvent_0704975d-f5fb-4031-8d07-18a79f4788da.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ContextNamespacesPerEvent_60aa78cd-66d4-421b-92a4-e20f138518d9.json
+++ b/services/CognitiveServices/accounts/templates/policy/ContextNamespacesPerEvent_60aa78cd-66d4-421b-92a4-e20f138518d9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/CustomVisionTrainingTime_1de7e287-53d0-41e4-b37c-701470e82543.json
+++ b/services/CognitiveServices/accounts/templates/policy/CustomVisionTrainingTime_1de7e287-53d0-41e4-b37c-701470e82543.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/CustomVisionTransactions_e7d44227-8e9b-4698-a398-24e2afe25408.json
+++ b/services/CognitiveServices/accounts/templates/policy/CustomVisionTransactions_e7d44227-8e9b-4698-a398-24e2afe25408.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/DataIn_0fd9d459-4d84-422c-ad72-ce8788a13f4d.json
+++ b/services/CognitiveServices/accounts/templates/policy/DataIn_0fd9d459-4d84-422c-ad72-ce8788a13f4d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/DataOut_0e4e5a62-95e2-4fc0-97e0-b6b6574fe1f5.json
+++ b/services/CognitiveServices/accounts/templates/policy/DataOut_0e4e5a62-95e2-4fc0-97e0-b6b6574fe1f5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/DocumentCharactersTranslated_fe4eba6e-8488-4d69-8c5b-b247fe556012.json
+++ b/services/CognitiveServices/accounts/templates/policy/DocumentCharactersTranslated_fe4eba6e-8488-4d69-8c5b-b247fe556012.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/DocumentCustomCharactersTranslated_7fce7630-0db2-4279-9b81-cb06ad7d83ca.json
+++ b/services/CognitiveServices/accounts/templates/policy/DocumentCustomCharactersTranslated_7fce7630-0db2-4279-9b81-cb06ad7d83ca.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/FaceImagesTrained_fa6564b0-870b-4b21-b648-6a793d7a2797.json
+++ b/services/CognitiveServices/accounts/templates/policy/FaceImagesTrained_fa6564b0-870b-4b21-b648-6a793d7a2797.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/FaceTransactions_c382a635-df8d-4d19-86de-daa28de4dce7.json
+++ b/services/CognitiveServices/accounts/templates/policy/FaceTransactions_c382a635-df8d-4d19-86de-daa28de4dce7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/FacesStored_3846fe0-d373-4548-af44-a2d7a2ba3399.json
+++ b/services/CognitiveServices/accounts/templates/policy/FacesStored_3846fe0-d373-4548-af44-a2d7a2ba3399.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/FeatureCardinalityAction_3657d258-5623-4480-84ca-3ba6226d1378.json
+++ b/services/CognitiveServices/accounts/templates/policy/FeatureCardinalityAction_3657d258-5623-4480-84ca-3ba6226d1378.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/FeatureCardinalityContext_d582a978-ce14-484a-b759-84903838979c.json
+++ b/services/CognitiveServices/accounts/templates/policy/FeatureCardinalityContext_d582a978-ce14-484a-b759-84903838979c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/FeatureCardinalitySlot_bfe3b067-314b-46bf-925e-e81f66cf910f.json
+++ b/services/CognitiveServices/accounts/templates/policy/FeatureCardinalitySlot_bfe3b067-314b-46bf-925e-e81f66cf910f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/FineTunedTrainingHours_52909b9b-190d-4d7b-9900-1789ce0b937b.json
+++ b/services/CognitiveServices/accounts/templates/policy/FineTunedTrainingHours_52909b9b-190d-4d7b-9900-1789ce0b937b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/GeneratedTokens_7fbd5f2d-00f0-4ca1-8d5f-0233d0a3f910.json
+++ b/services/CognitiveServices/accounts/templates/policy/GeneratedTokens_7fbd5f2d-00f0-4ca1-8d5f-0233d0a3f910.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ImagesStored_2b1b7563-e1ec-4f56-9caf-f2cb019bc04f.json
+++ b/services/CognitiveServices/accounts/templates/policy/ImagesStored_2b1b7563-e1ec-4f56-9caf-f2cb019bc04f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/LUISSpeechRequests_e4c3e04b-15c3-4883-8351-a87a4510e40e.json
+++ b/services/CognitiveServices/accounts/templates/policy/LUISSpeechRequests_e4c3e04b-15c3-4883-8351-a87a4510e40e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/LUISTextRequests_4c766f95-57b7-4a3b-bba3-8801265dbc01.json
+++ b/services/CognitiveServices/accounts/templates/policy/LUISTextRequests_4c766f95-57b7-4a3b-bba3-8801265dbc01.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/Latency_d76ab40a-2831-4fa2-b476-5fdcda3d7c4c.json
+++ b/services/CognitiveServices/accounts/templates/policy/Latency_d76ab40a-2831-4fa2-b476-5fdcda3d7c4c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/LearnedEvents_66b4ade6-1ae4-430e-b545-5c1c188b780c.json
+++ b/services/CognitiveServices/accounts/templates/policy/LearnedEvents_66b4ade6-1ae4-430e-b545-5c1c188b780c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/MatchedRewards_c41c172e-b804-42c4-b329-aa255c85f506.json
+++ b/services/CognitiveServices/accounts/templates/policy/MatchedRewards_c41c172e-b804-42c4-b329-aa255c85f506.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/NonActivatedEvents_b5283ee6-b4a5-4e5e-890d-12ebca7f54e7.json
+++ b/services/CognitiveServices/accounts/templates/policy/NonActivatedEvents_b5283ee6-b4a5-4e5e-890d-12ebca7f54e7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/NumberOfSlots_a1d7f8c7-1182-4241-b3f6-e086309d7ac1.json
+++ b/services/CognitiveServices/accounts/templates/policy/NumberOfSlots_a1d7f8c7-1182-4241-b3f6-e086309d7ac1.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/NumberofSpeakerProfiles_f5425eb7-e311-4336-b5ab-7a9b2b0d5dea.json
+++ b/services/CognitiveServices/accounts/templates/policy/NumberofSpeakerProfiles_f5425eb7-e311-4336-b5ab-7a9b2b0d5dea.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ObservedRewards_6b7ae03b-e2c8-4115-a560-4144a455816b.json
+++ b/services/CognitiveServices/accounts/templates/policy/ObservedRewards_6b7ae03b-e2c8-4115-a560-4144a455816b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/OneDocumentCharactersTranslated_eee95c4b-db79-48e5-9a5c-ef921a22e3c0.json
+++ b/services/CognitiveServices/accounts/templates/policy/OneDocumentCharactersTranslated_eee95c4b-db79-48e5-9a5c-ef921a22e3c0.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/OnlineEstimatorOverallReward_73c87a60-8de8-414e-9cc5-81a3ca14d687.json
+++ b/services/CognitiveServices/accounts/templates/policy/OnlineEstimatorOverallReward_73c87a60-8de8-414e-9cc5-81a3ca14d687.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/OnlineEstimatorSlotReward_c61d3a5c-4aa4-4c6a-8bc0-859061559b4c.json
+++ b/services/CognitiveServices/accounts/templates/policy/OnlineEstimatorSlotReward_c61d3a5c-4aa4-4c6a-8bc0-859061559b4c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/OnlineEventCount_e360aeac-66a6-4bf0-8e36-475608c6d02b.json
+++ b/services/CognitiveServices/accounts/templates/policy/OnlineEventCount_e360aeac-66a6-4bf0-8e36-475608c6d02b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/OnlineReward_86e00692-7e42-4a4c-86a3-21c70add7bd3.json
+++ b/services/CognitiveServices/accounts/templates/policy/OnlineReward_86e00692-7e42-4a4c-86a3-21c70add7bd3.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ProcessedCharacters_4b474463-3243-4966-a4d0-8404760b9ca3.json
+++ b/services/CognitiveServices/accounts/templates/policy/ProcessedCharacters_4b474463-3243-4966-a4d0-8404760b9ca3.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ProcessedHealthTextRecords_bf42c604-b4f7-4b6c-8a33-2f5e1912d306.json
+++ b/services/CognitiveServices/accounts/templates/policy/ProcessedHealthTextRecords_bf42c604-b4f7-4b6c-8a33-2f5e1912d306.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ProcessedImages_fcd3e37c-82bb-48df-8860-f1b4f01d4cc3.json
+++ b/services/CognitiveServices/accounts/templates/policy/ProcessedImages_fcd3e37c-82bb-48df-8860-f1b4f01d4cc3.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ProcessedPages_bb4ebaf2-e5ec-47cc-b8a8-2428e924721c.json
+++ b/services/CognitiveServices/accounts/templates/policy/ProcessedPages_bb4ebaf2-e5ec-47cc-b8a8-2428e924721c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ProcessedPromptTokens_30dc0126-1466-4c11-9096-a7fffc552bc8.json
+++ b/services/CognitiveServices/accounts/templates/policy/ProcessedPromptTokens_30dc0126-1466-4c11-9096-a7fffc552bc8.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ProcessedTextRecords_5aeb1d15-f8f3-49d5-8894-b6af0d89d935.json
+++ b/services/CognitiveServices/accounts/templates/policy/ProcessedTextRecords_5aeb1d15-f8f3-49d5-8894-b6af0d89d935.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/QuestionAnsweringTextRecords_c8f71cfd-42cd-4063-92fc-d6560697250d.json
+++ b/services/CognitiveServices/accounts/templates/policy/QuestionAnsweringTextRecords_c8f71cfd-42cd-4063-92fc-d6560697250d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/RAIAbusiveUsersCount_f2926569-df78-4c68-90a7-3c5f96cfa1f3.json
+++ b/services/CognitiveServices/accounts/templates/policy/RAIAbusiveUsersCount_f2926569-df78-4c68-90a7-3c5f96cfa1f3.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/RAIHarmfulRequests_e7341b29-84ea-4ca2-8140-e774b1cd1444.json
+++ b/services/CognitiveServices/accounts/templates/policy/RAIHarmfulRequests_e7341b29-84ea-4ca2-8140-e774b1cd1444.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/RAIRejectedRequests_a97c7421-8268-4837-b433-762882c3887f.json
+++ b/services/CognitiveServices/accounts/templates/policy/RAIRejectedRequests_a97c7421-8268-4837-b433-762882c3887f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/RAISystemEvent_b0bf777b-90e9-4aed-b8e2-94ab9755d1ca.json
+++ b/services/CognitiveServices/accounts/templates/policy/RAISystemEvent_b0bf777b-90e9-4aed-b8e2-94ab9755d1ca.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/RAITotalRequests_82c2b472-2084-4122-8bb5-51142ce19101.json
+++ b/services/CognitiveServices/accounts/templates/policy/RAITotalRequests_82c2b472-2084-4122-8bb5-51142ce19101.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/Ratelimit_b269a4f9-ba74-4061-abc1-655d656c1c5f.json
+++ b/services/CognitiveServices/accounts/templates/policy/Ratelimit_b269a4f9-ba74-4061-abc1-655d656c1c5f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/Reward_3984067c-1e9b-41ee-9464-1f6b2df45cea.json
+++ b/services/CognitiveServices/accounts/templates/policy/Reward_3984067c-1e9b-41ee-9464-1f6b2df45cea.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/ServerErrors_3c550d9c-8276-4a61-b0cf-ef437a55e299.json
+++ b/services/CognitiveServices/accounts/templates/policy/ServerErrors_3c550d9c-8276-4a61-b0cf-ef437a55e299.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/SlotFeatureIdOccurrences_b05249b2-d6f2-4c2e-a14b-a25353053e6d.json
+++ b/services/CognitiveServices/accounts/templates/policy/SlotFeatureIdOccurrences_b05249b2-d6f2-4c2e-a14b-a25353053e6d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/SlotFeaturesPerEvent_6495d787-2701-45ea-8abd-f23b18ed6e66.json
+++ b/services/CognitiveServices/accounts/templates/policy/SlotFeaturesPerEvent_6495d787-2701-45ea-8abd-f23b18ed6e66.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/SlotIdOccurrences_12ffdc4a-2ac4-4b4b-bf04-c5b48d2f0904.json
+++ b/services/CognitiveServices/accounts/templates/policy/SlotIdOccurrences_12ffdc4a-2ac4-4b4b-bf04-c5b48d2f0904.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/SlotNamespacesPerEvent_c87a2b96-2308-4d2c-9353-8d300f0e542c.json
+++ b/services/CognitiveServices/accounts/templates/policy/SlotNamespacesPerEvent_c87a2b96-2308-4d2c-9353-8d300f0e542c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/SlotRewards_13d1dc54-12a8-475d-8a87-d9060df9f348.json
+++ b/services/CognitiveServices/accounts/templates/policy/SlotRewards_13d1dc54-12a8-475d-8a87-d9060df9f348.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/SpeakerRecognitionTransactions_1f6e25bb-1412-46b8-b4cf-de1498a03927.json
+++ b/services/CognitiveServices/accounts/templates/policy/SpeakerRecognitionTransactions_1f6e25bb-1412-46b8-b4cf-de1498a03927.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/SpeechModelHostingHours_0433dc7d-e9c0-4d32-8295-ce24cd9e453b.json
+++ b/services/CognitiveServices/accounts/templates/policy/SpeechModelHostingHours_0433dc7d-e9c0-4d32-8295-ce24cd9e453b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/SpeechModelHostingHours_2aa2bd92-85bd-47b8-ac48-3c672fdbb486.json
+++ b/services/CognitiveServices/accounts/templates/policy/SpeechModelHostingHours_2aa2bd92-85bd-47b8-ac48-3c672fdbb486.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/SuccessRate_80f3c9ae-7da9-462f-ab44-2ff80d27c8f1.json
+++ b/services/CognitiveServices/accounts/templates/policy/SuccessRate_80f3c9ae-7da9-462f-ab44-2ff80d27c8f1.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/SuccessfulCalls_715804f2-6789-4b83-9c5f-bee2a805bbc2.json
+++ b/services/CognitiveServices/accounts/templates/policy/SuccessfulCalls_715804f2-6789-4b83-9c5f-bee2a805bbc2.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/SynthesizedCharacters_b0320e4c-7f6d-4990-b2b9-12f1fcb103cf.json
+++ b/services/CognitiveServices/accounts/templates/policy/SynthesizedCharacters_b0320e4c-7f6d-4990-b2b9-12f1fcb103cf.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/TextCharactersTranslated_2785f1ab-abcc-44da-8e08-d16c74e67002.json
+++ b/services/CognitiveServices/accounts/templates/policy/TextCharactersTranslated_2785f1ab-abcc-44da-8e08-d16c74e67002.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/TextCustomCharactersTranslated_50959073-a6ad-4b63-b76e-4a22745e5852.json
+++ b/services/CognitiveServices/accounts/templates/policy/TextCustomCharactersTranslated_50959073-a6ad-4b63-b76e-4a22745e5852.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/TextTrainedCharacters_528496f5-e701-4a9e-8b4c-c876be59c9dc.json
+++ b/services/CognitiveServices/accounts/templates/policy/TextTrainedCharacters_528496f5-e701-4a9e-8b4c-c876be59c9dc.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/TokenTransaction_287a29bf-097d-4c4a-9ac5-df70a10f6903.json
+++ b/services/CognitiveServices/accounts/templates/policy/TokenTransaction_287a29bf-097d-4c4a-9ac5-df70a10f6903.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/TotalCalls_07f1ae0a-94f3-41da-b3a6-ca9188e416cb.json
+++ b/services/CognitiveServices/accounts/templates/policy/TotalCalls_07f1ae0a-94f3-41da-b3a6-ca9188e416cb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/TotalErrors_e228ad2d-7f9f-4843-88e2-57f6d44c59e9.json
+++ b/services/CognitiveServices/accounts/templates/policy/TotalErrors_e228ad2d-7f9f-4843-88e2-57f6d44c59e9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/TotalEvents_2a65a81a-be78-499f-bca4-64976249a0cd.json
+++ b/services/CognitiveServices/accounts/templates/policy/TotalEvents_2a65a81a-be78-499f-bca4-64976249a0cd.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/TotalTokenCalls_369652ae-56b1-4620-be56-0024629b2cad.json
+++ b/services/CognitiveServices/accounts/templates/policy/TotalTokenCalls_369652ae-56b1-4620-be56-0024629b2cad.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/UserBaselineEventCount_61defc4a-43af-4667-b63a-02c28af099be.json
+++ b/services/CognitiveServices/accounts/templates/policy/UserBaselineEventCount_61defc4a-43af-4667-b63a-02c28af099be.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/UserBaselineReward_9386f63a-026e-4c91-886e-c10478132bdd.json
+++ b/services/CognitiveServices/accounts/templates/policy/UserBaselineReward_9386f63a-026e-4c91-886e-c10478132bdd.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/VideoSecondsSynthesized_81268206-66e5-4b33-8205-93147fc5989c.json
+++ b/services/CognitiveServices/accounts/templates/policy/VideoSecondsSynthesized_81268206-66e5-4b33-8205-93147fc5989c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/VoiceModelHostingHours_7d5cc479-cf69-44bc-a612-eac4b20fdc08.json
+++ b/services/CognitiveServices/accounts/templates/policy/VoiceModelHostingHours_7d5cc479-cf69-44bc-a612-eac4b20fdc08.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/CognitiveServices/accounts/templates/policy/VoiceModelTrainingMinutes_39eaa390-7c58-4b79-af20-e47138e7ed97.json
+++ b/services/CognitiveServices/accounts/templates/policy/VoiceModelTrainingMinutes_39eaa390-7c58-4b79-af20-e47138e7ed97.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.CognitiveServices/accounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/cloudServices/templates/policy-arm/PercentageCPU_e98657ed-8a0b-4992-9d20-a54e2d6065ef.json
+++ b/services/Compute/cloudServices/templates/policy-arm/PercentageCPU_e98657ed-8a0b-4992-9d20-a54e2d6065ef.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/cloudServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/cloudServices/templates/policy/PercentageCPU_e98657ed-8a0b-4992-9d20-a54e2d6065ef.json
+++ b/services/Compute/cloudServices/templates/policy/PercentageCPU_e98657ed-8a0b-4992-9d20-a54e2d6065ef.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/cloudServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy-arm/AvailableMemoryBytes_d9089d09-ddec-4f6a-8dc1-e2544e5765cb.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy-arm/AvailableMemoryBytes_d9089d09-ddec-4f6a-8dc1-e2544e5765cb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy-arm/DataDiskIOPSConsumedPercentage_a8c08a0f-fcd7-4b97-8a6e-06b34bac0b9f.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy-arm/DataDiskIOPSConsumedPercentage_a8c08a0f-fcd7-4b97-8a6e-06b34bac0b9f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy-arm/DiskReadOperationsSec_ea8be16a-f5e9-4a8b-a1df-a8c5efff039b.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy-arm/DiskReadOperationsSec_ea8be16a-f5e9-4a8b-a1df-a8c5efff039b.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy-arm/DiskWriteOperationsSec_dce1cda8-1dab-4941-b607-1d5d449709d5.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy-arm/DiskWriteOperationsSec_dce1cda8-1dab-4941-b607-1d5d449709d5.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy-arm/InboundFlows_86991e6e-efc9-4898-adf8-4e8e3a60c57e.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy-arm/InboundFlows_86991e6e-efc9-4898-adf8-4e8e3a60c57e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy-arm/NetworkInTotal_f0e94112-5509-47b6-8def-91fb5ca5d0cd.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy-arm/NetworkInTotal_f0e94112-5509-47b6-8def-91fb5ca5d0cd.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy-arm/NetworkIn_87dfe717-217f-4447-b59a-7ea39160b83a.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy-arm/NetworkIn_87dfe717-217f-4447-b59a-7ea39160b83a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy-arm/NetworkOutTotal_98de2aed-3493-4e65-919b-b1f8e6995819.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy-arm/NetworkOutTotal_98de2aed-3493-4e65-919b-b1f8e6995819.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy-arm/OSDiskIOPSConsumedPercentage_55dc79f4-5666-420f-8c53-141d73e01fee.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy-arm/OSDiskIOPSConsumedPercentage_55dc79f4-5666-420f-8c53-141d73e01fee.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy-arm/OutboundFlows_d336cfa2-724e-419a-809d-c716741d5279.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy-arm/OutboundFlows_d336cfa2-724e-419a-809d-c716741d5279.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy-arm/PercentageCPU_310c2a27-8933-434e-a366-cb35831cde44.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy-arm/PercentageCPU_310c2a27-8933-434e-a366-cb35831cde44.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy-arm/VmAvailabilityMetric_6cf11f1e-273a-4f42-bf9b-9310b26c1c4f.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy-arm/VmAvailabilityMetric_6cf11f1e-273a-4f42-bf9b-9310b26c1c4f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy/AvailableMemoryBytes_d9089d09-ddec-4f6a-8dc1-e2544e5765cb.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy/AvailableMemoryBytes_d9089d09-ddec-4f6a-8dc1-e2544e5765cb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy/DataDiskIOPSConsumedPercentage_a8c08a0f-fcd7-4b97-8a6e-06b34bac0b9f.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy/DataDiskIOPSConsumedPercentage_a8c08a0f-fcd7-4b97-8a6e-06b34bac0b9f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy/DiskReadOperationsSec_ea8be16a-f5e9-4a8b-a1df-a8c5efff039b.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy/DiskReadOperationsSec_ea8be16a-f5e9-4a8b-a1df-a8c5efff039b.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy/DiskWriteOperationsSec_dce1cda8-1dab-4941-b607-1d5d449709d5.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy/DiskWriteOperationsSec_dce1cda8-1dab-4941-b607-1d5d449709d5.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy/InboundFlows_86991e6e-efc9-4898-adf8-4e8e3a60c57e.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy/InboundFlows_86991e6e-efc9-4898-adf8-4e8e3a60c57e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy/NetworkInTotal_f0e94112-5509-47b6-8def-91fb5ca5d0cd.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy/NetworkInTotal_f0e94112-5509-47b6-8def-91fb5ca5d0cd.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy/NetworkIn_87dfe717-217f-4447-b59a-7ea39160b83a.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy/NetworkIn_87dfe717-217f-4447-b59a-7ea39160b83a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy/NetworkOutTotal_98de2aed-3493-4e65-919b-b1f8e6995819.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy/NetworkOutTotal_98de2aed-3493-4e65-919b-b1f8e6995819.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy/OSDiskIOPSConsumedPercentage_55dc79f4-5666-420f-8c53-141d73e01fee.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy/OSDiskIOPSConsumedPercentage_55dc79f4-5666-420f-8c53-141d73e01fee.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy/OutboundFlows_d336cfa2-724e-419a-809d-c716741d5279.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy/OutboundFlows_d336cfa2-724e-419a-809d-c716741d5279.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy/PercentageCPU_310c2a27-8933-434e-a366-cb35831cde44.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy/PercentageCPU_310c2a27-8933-434e-a366-cb35831cde44.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachineScaleSets/templates/policy/VmAvailabilityMetric_6cf11f1e-273a-4f42-bf9b-9310b26c1c4f.json
+++ b/services/Compute/virtualMachineScaleSets/templates/policy/VmAvailabilityMetric_6cf11f1e-273a-4f42-bf9b-9310b26c1c4f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/AvailableMemoryBytesMBytes_b0bd7c37-eb24-47c2-a032-f925594152ed.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/AvailableMemoryBytesMBytes_b0bd7c37-eb24-47c2-a032-f925594152ed.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/AvailableMemoryBytes_bf1e0006-6089-4f92-a115-fc83aa0fbdd5.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/AvailableMemoryBytes_bf1e0006-6089-4f92-a115-fc83aa0fbdd5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/CPUCreditsConsumed_a407ae10-6263-449c-81b9-172760d6dc6d.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/CPUCreditsConsumed_a407ae10-6263-449c-81b9-172760d6dc6d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/CPUCreditsRemaining_821888a1-6490-4a2d-8850-bdc45057a853.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/CPUCreditsRemaining_821888a1-6490-4a2d-8850-bdc45057a853.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/DataDiskBandwidthConsumedPercentage_b57b0749-f851-4c3d-b7fb-7cf26f3bf16a.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DataDiskBandwidthConsumedPercentage_b57b0749-f851-4c3d-b7fb-7cf26f3bf16a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/DataDiskIOPSConsumedPercentage_b0cbb9f8-cc67-4e7d-95a8-5a058c6de7e0.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DataDiskIOPSConsumedPercentage_b0cbb9f8-cc67-4e7d-95a8-5a058c6de7e0.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/DataDiskMaxBurstIOPS_9b0f41af-1c52-4890-a23a-3bfebfee1154.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DataDiskMaxBurstIOPS_9b0f41af-1c52-4890-a23a-3bfebfee1154.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/DataDiskQueueDepth_040bc9c3-da5c-4fd0-b160-979ce89364ae.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DataDiskQueueDepth_040bc9c3-da5c-4fd0-b160-979ce89364ae.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/DataDiskReadOperationsSec_3c5518ea-9a0f-44ff-b197-47b3d6db060b.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DataDiskReadOperationsSec_3c5518ea-9a0f-44ff-b197-47b3d6db060b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/DataDiskWriteBytessec_e45d685d-14c4-4422-8096-6f11d628fb20.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DataDiskWriteBytessec_e45d685d-14c4-4422-8096-6f11d628fb20.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/DataDiskWriteOperationsSec_326b359d-e0a2-4055-8e1f-f9c5f9df5599.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DataDiskWriteOperationsSec_326b359d-e0a2-4055-8e1f-f9c5f9df5599.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/DiskReadBytes_b9221998-f2bb-4ae8-b2c8-f9c4750e06f7.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DiskReadBytes_b9221998-f2bb-4ae8-b2c8-f9c4750e06f7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/DiskReadOperationsSec_8bc489c0-d2f7-43c1-9bb7-478c9503fb2e.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DiskReadOperationsSec_8bc489c0-d2f7-43c1-9bb7-478c9503fb2e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/DiskWriteBytes_b1cc650c-24fe-4f9e-a2ec-5757816526c0.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DiskWriteBytes_b1cc650c-24fe-4f9e-a2ec-5757816526c0.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/DiskWriteOperationsSec_edff41cb-d9b8-46ba-ba39-42747c1a4c4b.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/DiskWriteOperationsSec_edff41cb-d9b8-46ba-ba39-42747c1a4c4b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/InboundFlows_6de4e570-4270-4e9b-949e-5680b061e7fd.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/InboundFlows_6de4e570-4270-4e9b-949e-5680b061e7fd.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/NetworkInTotal_ea4501a3-1e77-4df1-ab61-3ee28ae529eb.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/NetworkInTotal_ea4501a3-1e77-4df1-ab61-3ee28ae529eb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/NetworkOutTotal_e2028144-b142-445c-b544-3bb438537c8f.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/NetworkOutTotal_e2028144-b142-445c-b544-3bb438537c8f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/OSDiskBandwidthConsumedPercentage_f7e19635-0118-4040-83d5-2f4c2150aef1.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/OSDiskBandwidthConsumedPercentage_f7e19635-0118-4040-83d5-2f4c2150aef1.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/OSDiskIOPSConsumedPercentage_a2bf3c43-d327-473b-9204-f77e2a0fe398.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/OSDiskIOPSConsumedPercentage_a2bf3c43-d327-473b-9204-f77e2a0fe398.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/OSDiskMaxBurstIOPS_916dc60b-b2d2-4708-9fa4-6a36b244f499.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/OSDiskMaxBurstIOPS_916dc60b-b2d2-4708-9fa4-6a36b244f499.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/OSDiskQueueDepth_36262245-4c8a-4143-9ab4-68e9c23ae19a.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/OSDiskQueueDepth_36262245-4c8a-4143-9ab4-68e9c23ae19a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/OSDiskWriteBytessec_929b095e-5ea1-48b4-bf4e-bfc1a941a908.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/OSDiskWriteBytessec_929b095e-5ea1-48b4-bf4e-bfc1a941a908.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/OSDiskWriteOperationsSec_3be4037a-c692-402d-843d-b3fe43053edf.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/OSDiskWriteOperationsSec_3be4037a-c692-402d-843d-b3fe43053edf.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/OutboundFlows_a477bf96-4b0f-471c-b5d3-0acdb59612e6.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/OutboundFlows_a477bf96-4b0f-471c-b5d3-0acdb59612e6.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/PercentageCPU_a9bac9fd-2382-4ce1-b68b-8898caf45038.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/PercentageCPU_a9bac9fd-2382-4ce1-b68b-8898caf45038.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/VMCachedBandwidthConsumedPercentage_eb85f15b-b705-418f-b8ed-93d8cc7a9a6c.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/VMCachedBandwidthConsumedPercentage_eb85f15b-b705-418f-b8ed-93d8cc7a9a6c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/VMCachedIOPSConsumedPercentage_c878115f-2a89-446e-8980-ef4f152120c5.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/VMCachedIOPSConsumedPercentage_c878115f-2a89-446e-8980-ef4f152120c5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/VMUncachedBandwidthConsumedPercentage_e3981e7b-fd8b-4e07-bb68-d598c020c12d.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/VMUncachedBandwidthConsumedPercentage_e3981e7b-fd8b-4e07-bb68-d598c020c12d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/VMUncachedIOPSConsumedPercentage_765ceb5b-ec1d-44d7-b94d-bb139030df81.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/VMUncachedIOPSConsumedPercentage_765ceb5b-ec1d-44d7-b94d-bb139030df81.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy-arm/VmAvailabilityMetric_3fa5376a-705a-48e4-b314-6282a74c9f7c.json
+++ b/services/Compute/virtualMachines/templates/policy-arm/VmAvailabilityMetric_3fa5376a-705a-48e4-b314-6282a74c9f7c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/AvailableMemoryBytesMBytes_b0bd7c37-eb24-47c2-a032-f925594152ed.json
+++ b/services/Compute/virtualMachines/templates/policy/AvailableMemoryBytesMBytes_b0bd7c37-eb24-47c2-a032-f925594152ed.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/AvailableMemoryBytes_bf1e0006-6089-4f92-a115-fc83aa0fbdd5.json
+++ b/services/Compute/virtualMachines/templates/policy/AvailableMemoryBytes_bf1e0006-6089-4f92-a115-fc83aa0fbdd5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/CPUCreditsConsumed_a407ae10-6263-449c-81b9-172760d6dc6d.json
+++ b/services/Compute/virtualMachines/templates/policy/CPUCreditsConsumed_a407ae10-6263-449c-81b9-172760d6dc6d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/CPUCreditsRemaining_821888a1-6490-4a2d-8850-bdc45057a853.json
+++ b/services/Compute/virtualMachines/templates/policy/CPUCreditsRemaining_821888a1-6490-4a2d-8850-bdc45057a853.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/DataDiskBandwidthConsumedPercentage_b57b0749-f851-4c3d-b7fb-7cf26f3bf16a.json
+++ b/services/Compute/virtualMachines/templates/policy/DataDiskBandwidthConsumedPercentage_b57b0749-f851-4c3d-b7fb-7cf26f3bf16a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/DataDiskIOPSConsumedPercentage_b0cbb9f8-cc67-4e7d-95a8-5a058c6de7e0.json
+++ b/services/Compute/virtualMachines/templates/policy/DataDiskIOPSConsumedPercentage_b0cbb9f8-cc67-4e7d-95a8-5a058c6de7e0.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/DataDiskMaxBurstIOPS_9b0f41af-1c52-4890-a23a-3bfebfee1154.json
+++ b/services/Compute/virtualMachines/templates/policy/DataDiskMaxBurstIOPS_9b0f41af-1c52-4890-a23a-3bfebfee1154.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/DataDiskQueueDepth_040bc9c3-da5c-4fd0-b160-979ce89364ae.json
+++ b/services/Compute/virtualMachines/templates/policy/DataDiskQueueDepth_040bc9c3-da5c-4fd0-b160-979ce89364ae.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/DataDiskReadOperationsSec_3c5518ea-9a0f-44ff-b197-47b3d6db060b.json
+++ b/services/Compute/virtualMachines/templates/policy/DataDiskReadOperationsSec_3c5518ea-9a0f-44ff-b197-47b3d6db060b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/DataDiskWriteBytessec_e45d685d-14c4-4422-8096-6f11d628fb20.json
+++ b/services/Compute/virtualMachines/templates/policy/DataDiskWriteBytessec_e45d685d-14c4-4422-8096-6f11d628fb20.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/DataDiskWriteOperationsSec_326b359d-e0a2-4055-8e1f-f9c5f9df5599.json
+++ b/services/Compute/virtualMachines/templates/policy/DataDiskWriteOperationsSec_326b359d-e0a2-4055-8e1f-f9c5f9df5599.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/DiskReadBytes_b9221998-f2bb-4ae8-b2c8-f9c4750e06f7.json
+++ b/services/Compute/virtualMachines/templates/policy/DiskReadBytes_b9221998-f2bb-4ae8-b2c8-f9c4750e06f7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/DiskReadOperationsSec_8bc489c0-d2f7-43c1-9bb7-478c9503fb2e.json
+++ b/services/Compute/virtualMachines/templates/policy/DiskReadOperationsSec_8bc489c0-d2f7-43c1-9bb7-478c9503fb2e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/DiskWriteBytes_b1cc650c-24fe-4f9e-a2ec-5757816526c0.json
+++ b/services/Compute/virtualMachines/templates/policy/DiskWriteBytes_b1cc650c-24fe-4f9e-a2ec-5757816526c0.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/DiskWriteOperationsSec_edff41cb-d9b8-46ba-ba39-42747c1a4c4b.json
+++ b/services/Compute/virtualMachines/templates/policy/DiskWriteOperationsSec_edff41cb-d9b8-46ba-ba39-42747c1a4c4b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/InboundFlows_6de4e570-4270-4e9b-949e-5680b061e7fd.json
+++ b/services/Compute/virtualMachines/templates/policy/InboundFlows_6de4e570-4270-4e9b-949e-5680b061e7fd.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/NetworkInTotal_ea4501a3-1e77-4df1-ab61-3ee28ae529eb.json
+++ b/services/Compute/virtualMachines/templates/policy/NetworkInTotal_ea4501a3-1e77-4df1-ab61-3ee28ae529eb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/NetworkOutTotal_e2028144-b142-445c-b544-3bb438537c8f.json
+++ b/services/Compute/virtualMachines/templates/policy/NetworkOutTotal_e2028144-b142-445c-b544-3bb438537c8f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/OSDiskBandwidthConsumedPercentage_f7e19635-0118-4040-83d5-2f4c2150aef1.json
+++ b/services/Compute/virtualMachines/templates/policy/OSDiskBandwidthConsumedPercentage_f7e19635-0118-4040-83d5-2f4c2150aef1.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/OSDiskIOPSConsumedPercentage_a2bf3c43-d327-473b-9204-f77e2a0fe398.json
+++ b/services/Compute/virtualMachines/templates/policy/OSDiskIOPSConsumedPercentage_a2bf3c43-d327-473b-9204-f77e2a0fe398.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/OSDiskMaxBurstIOPS_916dc60b-b2d2-4708-9fa4-6a36b244f499.json
+++ b/services/Compute/virtualMachines/templates/policy/OSDiskMaxBurstIOPS_916dc60b-b2d2-4708-9fa4-6a36b244f499.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/OSDiskQueueDepth_36262245-4c8a-4143-9ab4-68e9c23ae19a.json
+++ b/services/Compute/virtualMachines/templates/policy/OSDiskQueueDepth_36262245-4c8a-4143-9ab4-68e9c23ae19a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/OSDiskWriteBytessec_929b095e-5ea1-48b4-bf4e-bfc1a941a908.json
+++ b/services/Compute/virtualMachines/templates/policy/OSDiskWriteBytessec_929b095e-5ea1-48b4-bf4e-bfc1a941a908.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/OSDiskWriteOperationsSec_3be4037a-c692-402d-843d-b3fe43053edf.json
+++ b/services/Compute/virtualMachines/templates/policy/OSDiskWriteOperationsSec_3be4037a-c692-402d-843d-b3fe43053edf.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/OutboundFlows_a477bf96-4b0f-471c-b5d3-0acdb59612e6.json
+++ b/services/Compute/virtualMachines/templates/policy/OutboundFlows_a477bf96-4b0f-471c-b5d3-0acdb59612e6.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/PercentageCPU_a9bac9fd-2382-4ce1-b68b-8898caf45038.json
+++ b/services/Compute/virtualMachines/templates/policy/PercentageCPU_a9bac9fd-2382-4ce1-b68b-8898caf45038.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/VMCachedBandwidthConsumedPercentage_eb85f15b-b705-418f-b8ed-93d8cc7a9a6c.json
+++ b/services/Compute/virtualMachines/templates/policy/VMCachedBandwidthConsumedPercentage_eb85f15b-b705-418f-b8ed-93d8cc7a9a6c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/VMCachedIOPSConsumedPercentage_c878115f-2a89-446e-8980-ef4f152120c5.json
+++ b/services/Compute/virtualMachines/templates/policy/VMCachedIOPSConsumedPercentage_c878115f-2a89-446e-8980-ef4f152120c5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/VMUncachedBandwidthConsumedPercentage_e3981e7b-fd8b-4e07-bb68-d598c020c12d.json
+++ b/services/Compute/virtualMachines/templates/policy/VMUncachedBandwidthConsumedPercentage_e3981e7b-fd8b-4e07-bb68-d598c020c12d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/VMUncachedIOPSConsumedPercentage_765ceb5b-ec1d-44d7-b94d-bb139030df81.json
+++ b/services/Compute/virtualMachines/templates/policy/VMUncachedIOPSConsumedPercentage_765ceb5b-ec1d-44d7-b94d-bb139030df81.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Compute/virtualMachines/templates/policy/VmAvailabilityMetric_3fa5376a-705a-48e4-b314-6282a74c9f7c.json
+++ b/services/Compute/virtualMachines/templates/policy/VmAvailabilityMetric_3fa5376a-705a-48e4-b314-6282a74c9f7c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachines/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerInstance/containerGroups/templates/policy-arm/CpuUsage_970af9d6-9212-420d-af7b-4fbd790a2596.json
+++ b/services/ContainerInstance/containerGroups/templates/policy-arm/CpuUsage_970af9d6-9212-420d-af7b-4fbd790a2596.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerInstance/containerGroups/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerInstance/containerGroups/templates/policy-arm/MemoryUsage_4758386e-12ee-411a-9e49-445b5c5c3051.json
+++ b/services/ContainerInstance/containerGroups/templates/policy-arm/MemoryUsage_4758386e-12ee-411a-9e49-445b5c5c3051.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerInstance/containerGroups/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerInstance/containerGroups/templates/policy-arm/NetworkBytesReceivedPerSecond_8beff742-9cd8-43ed-9680-57ae35bee6e8.json
+++ b/services/ContainerInstance/containerGroups/templates/policy-arm/NetworkBytesReceivedPerSecond_8beff742-9cd8-43ed-9680-57ae35bee6e8.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerInstance/containerGroups/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerInstance/containerGroups/templates/policy-arm/NetworkBytesTransmittedPerSecond_5b26b965-2662-4a89-9d7e-771486357f39.json
+++ b/services/ContainerInstance/containerGroups/templates/policy-arm/NetworkBytesTransmittedPerSecond_5b26b965-2662-4a89-9d7e-771486357f39.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerInstance/containerGroups/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerInstance/containerGroups/templates/policy/CpuUsage_970af9d6-9212-420d-af7b-4fbd790a2596.json
+++ b/services/ContainerInstance/containerGroups/templates/policy/CpuUsage_970af9d6-9212-420d-af7b-4fbd790a2596.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerInstance/containerGroups/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerInstance/containerGroups/templates/policy/MemoryUsage_4758386e-12ee-411a-9e49-445b5c5c3051.json
+++ b/services/ContainerInstance/containerGroups/templates/policy/MemoryUsage_4758386e-12ee-411a-9e49-445b5c5c3051.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerInstance/containerGroups/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerInstance/containerGroups/templates/policy/NetworkBytesReceivedPerSecond_8beff742-9cd8-43ed-9680-57ae35bee6e8.json
+++ b/services/ContainerInstance/containerGroups/templates/policy/NetworkBytesReceivedPerSecond_8beff742-9cd8-43ed-9680-57ae35bee6e8.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerInstance/containerGroups/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerInstance/containerGroups/templates/policy/NetworkBytesTransmittedPerSecond_5b26b965-2662-4a89-9d7e-771486357f39.json
+++ b/services/ContainerInstance/containerGroups/templates/policy/NetworkBytesTransmittedPerSecond_5b26b965-2662-4a89-9d7e-771486357f39.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerInstance/containerGroups/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerRegistry/registries/templates/policy-arm/StorageUsed_fa9efde4-3586-4595-a442-b7e97f70fe91.json
+++ b/services/ContainerRegistry/registries/templates/policy-arm/StorageUsed_fa9efde4-3586-4595-a442-b7e97f70fe91.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerRegistry/registries/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerRegistry/registries/templates/policy-arm/StorageUsedforStandardPricingPlan_42995506-5bd2-4687-9316-d9399919990b.json
+++ b/services/ContainerRegistry/registries/templates/policy-arm/StorageUsedforStandardPricingPlan_42995506-5bd2-4687-9316-d9399919990b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerRegistry/registries/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerRegistry/registries/templates/policy-arm/SuccessfulPullCount_b8c8a846-a8d0-4e8f-b854-030955a20135.json
+++ b/services/ContainerRegistry/registries/templates/policy-arm/SuccessfulPullCount_b8c8a846-a8d0-4e8f-b854-030955a20135.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerRegistry/registries/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerRegistry/registries/templates/policy-arm/SuccessfulPushCount_9dca87c2-de00-40fd-b0bb-c8335e5f978a.json
+++ b/services/ContainerRegistry/registries/templates/policy-arm/SuccessfulPushCount_9dca87c2-de00-40fd-b0bb-c8335e5f978a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerRegistry/registries/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerRegistry/registries/templates/policy/StorageUsed_fa9efde4-3586-4595-a442-b7e97f70fe91.json
+++ b/services/ContainerRegistry/registries/templates/policy/StorageUsed_fa9efde4-3586-4595-a442-b7e97f70fe91.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerRegistry/registries/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerRegistry/registries/templates/policy/StorageUsedforStandardPricingPlan_42995506-5bd2-4687-9316-d9399919990b.json
+++ b/services/ContainerRegistry/registries/templates/policy/StorageUsedforStandardPricingPlan_42995506-5bd2-4687-9316-d9399919990b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerRegistry/registries/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerRegistry/registries/templates/policy/SuccessfulPullCount_b8c8a846-a8d0-4e8f-b854-030955a20135.json
+++ b/services/ContainerRegistry/registries/templates/policy/SuccessfulPullCount_b8c8a846-a8d0-4e8f-b854-030955a20135.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerRegistry/registries/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerRegistry/registries/templates/policy/SuccessfulPushCount_9dca87c2-de00-40fd-b0bb-c8335e5f978a.json
+++ b/services/ContainerRegistry/registries/templates/policy/SuccessfulPushCount_9dca87c2-de00-40fd-b0bb-c8335e5f978a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerRegistry/registries/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy-arm/clusterautoscalerclustersafetoautoscale_49fd8bac-d061-459d-8d80-a048c4c8ba56.json
+++ b/services/ContainerService/managedClusters/templates/policy-arm/clusterautoscalerclustersafetoautoscale_49fd8bac-d061-459d-8d80-a048c4c8ba56.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy-arm/clusterautoscalerunschedulablepodscount_301ca0e3-fc88-4285-be99-a2a587c412f5.json
+++ b/services/ContainerService/managedClusters/templates/policy-arm/clusterautoscalerunschedulablepodscount_301ca0e3-fc88-4285-be99-a2a587c412f5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy-arm/kubenodestatusallocatablecpucores_64a872f9-5ec6-4121-acad-edd12f4c3466.json
+++ b/services/ContainerService/managedClusters/templates/policy-arm/kubenodestatusallocatablecpucores_64a872f9-5ec6-4121-acad-edd12f4c3466.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy-arm/kubenodestatusallocatablememorybytes_14fa63fb-7da9-4d2e-9de9-203c4a3e0401.json
+++ b/services/ContainerService/managedClusters/templates/policy-arm/kubenodestatusallocatablememorybytes_14fa63fb-7da9-4d2e-9de9-203c4a3e0401.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy-arm/kubenodestatuscondition_ebbbbb92-5208-4d52-b407-6bea8e4473b9.json
+++ b/services/ContainerService/managedClusters/templates/policy-arm/kubenodestatuscondition_ebbbbb92-5208-4d52-b407-6bea8e4473b9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy-arm/kubepodstatusphase_e38e6e11-ac88-4014-98c8-8e64f70b832a.json
+++ b/services/ContainerService/managedClusters/templates/policy-arm/kubepodstatusphase_e38e6e11-ac88-4014-98c8-8e64f70b832a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy-arm/kubepodstatusready_cebf00b7-7294-4cf7-bc50-108f999d0c67.json
+++ b/services/ContainerService/managedClusters/templates/policy-arm/kubepodstatusready_cebf00b7-7294-4cf7-bc50-108f999d0c67.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy-arm/nodecpuusagepercentage_1303e91d-bc80-4ec2-937e-1d179fc32b43.json
+++ b/services/ContainerService/managedClusters/templates/policy-arm/nodecpuusagepercentage_1303e91d-bc80-4ec2-937e-1d179fc32b43.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy-arm/nodediskusagepercentage_aa3c5697-5cca-4c16-a37e-94f1d580701e.json
+++ b/services/ContainerService/managedClusters/templates/policy-arm/nodediskusagepercentage_aa3c5697-5cca-4c16-a37e-94f1d580701e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy-arm/nodememoryrsspercentage_e89e023e-117b-4db4-bfb2-853849e273f5.json
+++ b/services/ContainerService/managedClusters/templates/policy-arm/nodememoryrsspercentage_e89e023e-117b-4db4-bfb2-853849e273f5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy-arm/nodememoryworkingsetpercentage_9ae2dfbf-d69b-4802-8497-8b7836bef5e9.json
+++ b/services/ContainerService/managedClusters/templates/policy-arm/nodememoryworkingsetpercentage_9ae2dfbf-d69b-4802-8497-8b7836bef5e9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy/clusterautoscalerclustersafetoautoscale_49fd8bac-d061-459d-8d80-a048c4c8ba56.json
+++ b/services/ContainerService/managedClusters/templates/policy/clusterautoscalerclustersafetoautoscale_49fd8bac-d061-459d-8d80-a048c4c8ba56.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy/clusterautoscalerunschedulablepodscount_301ca0e3-fc88-4285-be99-a2a587c412f5.json
+++ b/services/ContainerService/managedClusters/templates/policy/clusterautoscalerunschedulablepodscount_301ca0e3-fc88-4285-be99-a2a587c412f5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy/kubenodestatusallocatablecpucores_64a872f9-5ec6-4121-acad-edd12f4c3466.json
+++ b/services/ContainerService/managedClusters/templates/policy/kubenodestatusallocatablecpucores_64a872f9-5ec6-4121-acad-edd12f4c3466.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy/kubenodestatusallocatablememorybytes_14fa63fb-7da9-4d2e-9de9-203c4a3e0401.json
+++ b/services/ContainerService/managedClusters/templates/policy/kubenodestatusallocatablememorybytes_14fa63fb-7da9-4d2e-9de9-203c4a3e0401.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy/kubenodestatuscondition_ebbbbb92-5208-4d52-b407-6bea8e4473b9.json
+++ b/services/ContainerService/managedClusters/templates/policy/kubenodestatuscondition_ebbbbb92-5208-4d52-b407-6bea8e4473b9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy/kubepodstatusphase_e38e6e11-ac88-4014-98c8-8e64f70b832a.json
+++ b/services/ContainerService/managedClusters/templates/policy/kubepodstatusphase_e38e6e11-ac88-4014-98c8-8e64f70b832a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy/kubepodstatusready_cebf00b7-7294-4cf7-bc50-108f999d0c67.json
+++ b/services/ContainerService/managedClusters/templates/policy/kubepodstatusready_cebf00b7-7294-4cf7-bc50-108f999d0c67.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy/nodecpuusagepercentage_1303e91d-bc80-4ec2-937e-1d179fc32b43.json
+++ b/services/ContainerService/managedClusters/templates/policy/nodecpuusagepercentage_1303e91d-bc80-4ec2-937e-1d179fc32b43.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy/nodediskusagepercentage_aa3c5697-5cca-4c16-a37e-94f1d580701e.json
+++ b/services/ContainerService/managedClusters/templates/policy/nodediskusagepercentage_aa3c5697-5cca-4c16-a37e-94f1d580701e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy/nodememoryrsspercentage_e89e023e-117b-4db4-bfb2-853849e273f5.json
+++ b/services/ContainerService/managedClusters/templates/policy/nodememoryrsspercentage_e89e023e-117b-4db4-bfb2-853849e273f5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ContainerService/managedClusters/templates/policy/nodememoryworkingsetpercentage_9ae2dfbf-d69b-4802-8497-8b7836bef5e9.json
+++ b/services/ContainerService/managedClusters/templates/policy/nodememoryworkingsetpercentage_9ae2dfbf-d69b-4802-8497-8b7836bef5e9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ContainerService/managedClusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMariaDB/servers/templates/policy-arm/cpupercent_0f19979d-9dc2-4636-8e15-435bbfa1f0f9.json
+++ b/services/DBforMariaDB/servers/templates/policy-arm/cpupercent_0f19979d-9dc2-4636-8e15-435bbfa1f0f9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMariaDB/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMariaDB/servers/templates/policy-arm/ioconsumptionpercent_13bbfe6e-3b65-4940-9344-6d1cc78e7d54.json
+++ b/services/DBforMariaDB/servers/templates/policy-arm/ioconsumptionpercent_13bbfe6e-3b65-4940-9344-6d1cc78e7d54.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMariaDB/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMariaDB/servers/templates/policy-arm/memorypercent_faf01668-c98a-4755-ae74-9dd4151f4c39.json
+++ b/services/DBforMariaDB/servers/templates/policy-arm/memorypercent_faf01668-c98a-4755-ae74-9dd4151f4c39.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMariaDB/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMariaDB/servers/templates/policy-arm/storagepercent_ef38051a-d9e3-4705-b208-29a421e729be.json
+++ b/services/DBforMariaDB/servers/templates/policy-arm/storagepercent_ef38051a-d9e3-4705-b208-29a421e729be.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMariaDB/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMariaDB/servers/templates/policy/cpupercent_0f19979d-9dc2-4636-8e15-435bbfa1f0f9.json
+++ b/services/DBforMariaDB/servers/templates/policy/cpupercent_0f19979d-9dc2-4636-8e15-435bbfa1f0f9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMariaDB/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMariaDB/servers/templates/policy/ioconsumptionpercent_13bbfe6e-3b65-4940-9344-6d1cc78e7d54.json
+++ b/services/DBforMariaDB/servers/templates/policy/ioconsumptionpercent_13bbfe6e-3b65-4940-9344-6d1cc78e7d54.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMariaDB/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMariaDB/servers/templates/policy/memorypercent_faf01668-c98a-4755-ae74-9dd4151f4c39.json
+++ b/services/DBforMariaDB/servers/templates/policy/memorypercent_faf01668-c98a-4755-ae74-9dd4151f4c39.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMariaDB/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMariaDB/servers/templates/policy/storagepercent_ef38051a-d9e3-4705-b208-29a421e729be.json
+++ b/services/DBforMariaDB/servers/templates/policy/storagepercent_ef38051a-d9e3-4705-b208-29a421e729be.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMariaDB/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy-arm/abortedconnections_269d640c-b6ba-45e1-a52f-67708f9f99d7.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy-arm/abortedconnections_269d640c-b6ba-45e1-a52f-67708f9f99d7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy-arm/activeconnections_347674ce-8534-403d-8281-cac9ea6f412a.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy-arm/activeconnections_347674ce-8534-403d-8281-cac9ea6f412a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy-arm/cpupercent_218161be-4952-495b-aed1-03cccda3d42f.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy-arm/cpupercent_218161be-4952-495b-aed1-03cccda3d42f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy-arm/ioconsumptionpercent_a3601973-f48c-4bf2-8384-90d250702a79.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy-arm/ioconsumptionpercent_a3601973-f48c-4bf2-8384-90d250702a79.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy-arm/memorypercent_757e2adf-60b8-4688-ae8f-03dd7dcd5226.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy-arm/memorypercent_757e2adf-60b8-4688-ae8f-03dd7dcd5226.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy-arm/replicationlag_dfe563fc-0ec1-401d-a362-8d293a06d02b.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy-arm/replicationlag_dfe563fc-0ec1-401d-a362-8d293a06d02b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy-arm/storagelimit_f285c23f-3b8e-428a-b289-8ff38a3c0e4b.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy-arm/storagelimit_f285c23f-3b8e-428a-b289-8ff38a3c0e4b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy-arm/storagepercent_e6771f44-f6d3-4a27-a9e4-b402a79c2891.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy-arm/storagepercent_e6771f44-f6d3-4a27-a9e4-b402a79c2891.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy/abortedconnections_269d640c-b6ba-45e1-a52f-67708f9f99d7.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy/abortedconnections_269d640c-b6ba-45e1-a52f-67708f9f99d7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy/activeconnections_347674ce-8534-403d-8281-cac9ea6f412a.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy/activeconnections_347674ce-8534-403d-8281-cac9ea6f412a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy/cpupercent_218161be-4952-495b-aed1-03cccda3d42f.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy/cpupercent_218161be-4952-495b-aed1-03cccda3d42f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy/ioconsumptionpercent_a3601973-f48c-4bf2-8384-90d250702a79.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy/ioconsumptionpercent_a3601973-f48c-4bf2-8384-90d250702a79.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy/memorypercent_757e2adf-60b8-4688-ae8f-03dd7dcd5226.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy/memorypercent_757e2adf-60b8-4688-ae8f-03dd7dcd5226.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy/replicationlag_dfe563fc-0ec1-401d-a362-8d293a06d02b.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy/replicationlag_dfe563fc-0ec1-401d-a362-8d293a06d02b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy/storagelimit_f285c23f-3b8e-428a-b289-8ff38a3c0e4b.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy/storagelimit_f285c23f-3b8e-428a-b289-8ff38a3c0e4b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/flexibleServers/templates/policy/storagepercent_e6771f44-f6d3-4a27-a9e4-b402a79c2891.json
+++ b/services/DBforMySQL/flexibleServers/templates/policy/storagepercent_e6771f44-f6d3-4a27-a9e4-b402a79c2891.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy-arm/activeconnections_60453255-5e0e-4fa5-95b5-6c449bee6902.json
+++ b/services/DBforMySQL/servers/templates/policy-arm/activeconnections_60453255-5e0e-4fa5-95b5-6c449bee6902.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy-arm/connectionsfailed_f0767b27-b88b-46a1-ab90-37dc8c399358.json
+++ b/services/DBforMySQL/servers/templates/policy-arm/connectionsfailed_f0767b27-b88b-46a1-ab90-37dc8c399358.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy-arm/cpupercent_173e6b88-e8a9-4763-becb-9c749878c767.json
+++ b/services/DBforMySQL/servers/templates/policy-arm/cpupercent_173e6b88-e8a9-4763-becb-9c749878c767.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy-arm/ioconsumptionpercent_978944c7-a049-4847-8483-dcf5baa92f6a.json
+++ b/services/DBforMySQL/servers/templates/policy-arm/ioconsumptionpercent_978944c7-a049-4847-8483-dcf5baa92f6a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy-arm/memorypercent_3a1dd0bd-ebe9-4f9b-b38c-88686a390bdd.json
+++ b/services/DBforMySQL/servers/templates/policy-arm/memorypercent_3a1dd0bd-ebe9-4f9b-b38c-88686a390bdd.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy-arm/secondsbehindmaster_85466088-8eb2-4faa-81f2-1ea40d8b6953.json
+++ b/services/DBforMySQL/servers/templates/policy-arm/secondsbehindmaster_85466088-8eb2-4faa-81f2-1ea40d8b6953.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy-arm/serverlogstoragepercent_af2b7bbb-9476-475a-b523-da3ee521eda7.json
+++ b/services/DBforMySQL/servers/templates/policy-arm/serverlogstoragepercent_af2b7bbb-9476-475a-b523-da3ee521eda7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy-arm/storagepercent_4f988eb2-c420-4ef2-82ed-2569b21b70e1.json
+++ b/services/DBforMySQL/servers/templates/policy-arm/storagepercent_4f988eb2-c420-4ef2-82ed-2569b21b70e1.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy/activeconnections_60453255-5e0e-4fa5-95b5-6c449bee6902.json
+++ b/services/DBforMySQL/servers/templates/policy/activeconnections_60453255-5e0e-4fa5-95b5-6c449bee6902.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy/connectionsfailed_f0767b27-b88b-46a1-ab90-37dc8c399358.json
+++ b/services/DBforMySQL/servers/templates/policy/connectionsfailed_f0767b27-b88b-46a1-ab90-37dc8c399358.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy/cpupercent_173e6b88-e8a9-4763-becb-9c749878c767.json
+++ b/services/DBforMySQL/servers/templates/policy/cpupercent_173e6b88-e8a9-4763-becb-9c749878c767.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy/ioconsumptionpercent_978944c7-a049-4847-8483-dcf5baa92f6a.json
+++ b/services/DBforMySQL/servers/templates/policy/ioconsumptionpercent_978944c7-a049-4847-8483-dcf5baa92f6a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy/memorypercent_3a1dd0bd-ebe9-4f9b-b38c-88686a390bdd.json
+++ b/services/DBforMySQL/servers/templates/policy/memorypercent_3a1dd0bd-ebe9-4f9b-b38c-88686a390bdd.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy/secondsbehindmaster_85466088-8eb2-4faa-81f2-1ea40d8b6953.json
+++ b/services/DBforMySQL/servers/templates/policy/secondsbehindmaster_85466088-8eb2-4faa-81f2-1ea40d8b6953.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy/serverlogstoragepercent_af2b7bbb-9476-475a-b523-da3ee521eda7.json
+++ b/services/DBforMySQL/servers/templates/policy/serverlogstoragepercent_af2b7bbb-9476-475a-b523-da3ee521eda7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforMySQL/servers/templates/policy/storagepercent_4f988eb2-c420-4ef2-82ed-2569b21b70e1.json
+++ b/services/DBforMySQL/servers/templates/policy/storagepercent_4f988eb2-c420-4ef2-82ed-2569b21b70e1.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforMySQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/activeconnections_f9b59221-8055-449e-bfd5-7a056945c694.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/activeconnections_f9b59221-8055-449e-bfd5-7a056945c694.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/connectionsfailed_5f9cdad0-db39-48c9-a4eb-3107b5b79414.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/connectionsfailed_5f9cdad0-db39-48c9-a4eb-3107b5b79414.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/cpupercent_389057c9-a0e0-4327-b89f-58c3dabb519d.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/cpupercent_389057c9-a0e0-4327-b89f-58c3dabb519d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/deadlocks_1904dd93-9655-403f-bb89-dc42e5ebc666.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/deadlocks_1904dd93-9655-403f-bb89-dc42e5ebc666.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/diskiopsconsumedpercentage_5856ad80-7256-441f-8a62-af1fdc712018.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/diskiopsconsumedpercentage_5856ad80-7256-441f-8a62-af1fdc712018.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/iops_eb3e1fb3-83e9-4764-b6e1-532bb22ce1aa.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/iops_eb3e1fb3-83e9-4764-b6e1-532bb22ce1aa.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/isdbalive_b0ac25d8-ae08-45e1-8a1e-5204514ad7bd.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/isdbalive_b0ac25d8-ae08-45e1-8a1e-5204514ad7bd.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/maximumusedtransactionIDs_1103b9a5-3d3d-4aa8-a3c2-66958e32c220.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/maximumusedtransactionIDs_1103b9a5-3d3d-4aa8-a3c2-66958e32c220.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/memorypercent_0c64aa8f-4bdb-4bb0-961c-d298000536af.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/memorypercent_0c64aa8f-4bdb-4bb0-961c-d298000536af.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/storagefree_d389ee62-f431-4faa-a4bc-4a3d02cea182.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/storagefree_d389ee62-f431-4faa-a4bc-4a3d02cea182.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/storagepercent_e397645f-359b-46d1-8182-d2cabab71aae.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy-arm/storagepercent_e397645f-359b-46d1-8182-d2cabab71aae.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy/activeconnections_f9b59221-8055-449e-bfd5-7a056945c694.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy/activeconnections_f9b59221-8055-449e-bfd5-7a056945c694.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy/connectionsfailed_5f9cdad0-db39-48c9-a4eb-3107b5b79414.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy/connectionsfailed_5f9cdad0-db39-48c9-a4eb-3107b5b79414.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy/cpupercent_389057c9-a0e0-4327-b89f-58c3dabb519d.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy/cpupercent_389057c9-a0e0-4327-b89f-58c3dabb519d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy/deadlocks_1904dd93-9655-403f-bb89-dc42e5ebc666.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy/deadlocks_1904dd93-9655-403f-bb89-dc42e5ebc666.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy/diskiopsconsumedpercentage_5856ad80-7256-441f-8a62-af1fdc712018.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy/diskiopsconsumedpercentage_5856ad80-7256-441f-8a62-af1fdc712018.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy/iops_eb3e1fb3-83e9-4764-b6e1-532bb22ce1aa.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy/iops_eb3e1fb3-83e9-4764-b6e1-532bb22ce1aa.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy/isdbalive_b0ac25d8-ae08-45e1-8a1e-5204514ad7bd.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy/isdbalive_b0ac25d8-ae08-45e1-8a1e-5204514ad7bd.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy/maximumusedtransactionIDs_1103b9a5-3d3d-4aa8-a3c2-66958e32c220.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy/maximumusedtransactionIDs_1103b9a5-3d3d-4aa8-a3c2-66958e32c220.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy/memorypercent_0c64aa8f-4bdb-4bb0-961c-d298000536af.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy/memorypercent_0c64aa8f-4bdb-4bb0-961c-d298000536af.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy/storagefree_d389ee62-f431-4faa-a4bc-4a3d02cea182.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy/storagefree_d389ee62-f431-4faa-a4bc-4a3d02cea182.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/flexibleServers/templates/policy/storagepercent_e397645f-359b-46d1-8182-d2cabab71aae.json
+++ b/services/DBforPostgreSQL/flexibleServers/templates/policy/storagepercent_e397645f-359b-46d1-8182-d2cabab71aae.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/flexibleServers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy-arm/activeconnections_186c5227-a9f4-4cd0-a355-c8d28f359398.json
+++ b/services/DBforPostgreSQL/servers/templates/policy-arm/activeconnections_186c5227-a9f4-4cd0-a355-c8d28f359398.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy-arm/connectionsfailed_0a6de1a0-e4df-470f-9bc7-247838fc428c.json
+++ b/services/DBforPostgreSQL/servers/templates/policy-arm/connectionsfailed_0a6de1a0-e4df-470f-9bc7-247838fc428c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy-arm/cpupercent_a2b3fa9d-f7e8-4d1e-967c-3d661bc06708.json
+++ b/services/DBforPostgreSQL/servers/templates/policy-arm/cpupercent_a2b3fa9d-f7e8-4d1e-967c-3d661bc06708.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy-arm/ioconsumptionpercent_ea7248bd-f96c-4391-ac48-c95312441028.json
+++ b/services/DBforPostgreSQL/servers/templates/policy-arm/ioconsumptionpercent_ea7248bd-f96c-4391-ac48-c95312441028.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy-arm/memorypercent_1d53e3ac-e98a-426c-81f1-aa1834c49692.json
+++ b/services/DBforPostgreSQL/servers/templates/policy-arm/memorypercent_1d53e3ac-e98a-426c-81f1-aa1834c49692.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy-arm/pgreplicalogdelayinseconds_90c0997a-f96e-4a34-87c7-c394c6e8b940.json
+++ b/services/DBforPostgreSQL/servers/templates/policy-arm/pgreplicalogdelayinseconds_90c0997a-f96e-4a34-87c7-c394c6e8b940.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy-arm/serverlogstoragepercent_56a13163-c2b6-4235-96bd-ef1e373b19ba.json
+++ b/services/DBforPostgreSQL/servers/templates/policy-arm/serverlogstoragepercent_56a13163-c2b6-4235-96bd-ef1e373b19ba.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy-arm/storagepercent_e031f8bf-ed3f-4a41-87fe-b301c1d02367.json
+++ b/services/DBforPostgreSQL/servers/templates/policy-arm/storagepercent_e031f8bf-ed3f-4a41-87fe-b301c1d02367.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy/activeconnections_186c5227-a9f4-4cd0-a355-c8d28f359398.json
+++ b/services/DBforPostgreSQL/servers/templates/policy/activeconnections_186c5227-a9f4-4cd0-a355-c8d28f359398.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy/connectionsfailed_0a6de1a0-e4df-470f-9bc7-247838fc428c.json
+++ b/services/DBforPostgreSQL/servers/templates/policy/connectionsfailed_0a6de1a0-e4df-470f-9bc7-247838fc428c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy/cpupercent_a2b3fa9d-f7e8-4d1e-967c-3d661bc06708.json
+++ b/services/DBforPostgreSQL/servers/templates/policy/cpupercent_a2b3fa9d-f7e8-4d1e-967c-3d661bc06708.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy/ioconsumptionpercent_ea7248bd-f96c-4391-ac48-c95312441028.json
+++ b/services/DBforPostgreSQL/servers/templates/policy/ioconsumptionpercent_ea7248bd-f96c-4391-ac48-c95312441028.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy/memorypercent_1d53e3ac-e98a-426c-81f1-aa1834c49692.json
+++ b/services/DBforPostgreSQL/servers/templates/policy/memorypercent_1d53e3ac-e98a-426c-81f1-aa1834c49692.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy/pgreplicalogdelayinseconds_90c0997a-f96e-4a34-87c7-c394c6e8b940.json
+++ b/services/DBforPostgreSQL/servers/templates/policy/pgreplicalogdelayinseconds_90c0997a-f96e-4a34-87c7-c394c6e8b940.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy/serverlogstoragepercent_56a13163-c2b6-4235-96bd-ef1e373b19ba.json
+++ b/services/DBforPostgreSQL/servers/templates/policy/serverlogstoragepercent_56a13163-c2b6-4235-96bd-ef1e373b19ba.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DBforPostgreSQL/servers/templates/policy/storagepercent_e031f8bf-ed3f-4a41-87fe-b301c1d02367.json
+++ b/services/DBforPostgreSQL/servers/templates/policy/storagepercent_e031f8bf-ed3f-4a41-87fe-b301c1d02367.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DBforPostgreSQL/servers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/ActivityFailedRuns_980f53cb-3eef-4263-952e-e69709e2a6e7.json
+++ b/services/DataFactory/factories/templates/policy-arm/ActivityFailedRuns_980f53cb-3eef-4263-952e-e69709e2a6e7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/ActivitySucceededRuns_321c2df7-c548-4e06-8729-8132b4dc3386.json
+++ b/services/DataFactory/factories/templates/policy-arm/ActivitySucceededRuns_321c2df7-c548-4e06-8729-8132b4dc3386.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/FactorySizeInGbUnits_08bfad59-0c23-4e6b-b577-e325f445a2cc.json
+++ b/services/DataFactory/factories/templates/policy-arm/FactorySizeInGbUnits_08bfad59-0c23-4e6b-b577-e325f445a2cc.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/IntegrationRuntimeAvailableMemory_e8fec7b1-ca81-48cd-a7ea-f81cc2fcb4a5.json
+++ b/services/DataFactory/factories/templates/policy-arm/IntegrationRuntimeAvailableMemory_e8fec7b1-ca81-48cd-a7ea-f81cc2fcb4a5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/IntegrationRuntimeAvailableNodeNumber_4b40d85d-f0be-41e5-9d60-ad9a99c54a41.json
+++ b/services/DataFactory/factories/templates/policy-arm/IntegrationRuntimeAvailableNodeNumber_4b40d85d-f0be-41e5-9d60-ad9a99c54a41.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/IntegrationRuntimeCpuPercentage_473c5450-95cc-4f86-bb8a-d0a06edd1357.json
+++ b/services/DataFactory/factories/templates/policy-arm/IntegrationRuntimeCpuPercentage_473c5450-95cc-4f86-bb8a-d0a06edd1357.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/MaxAllowedFactorySizeInGbUnits_71d5d464-ae1c-4383-835f-bb7369e307ea.json
+++ b/services/DataFactory/factories/templates/policy-arm/MaxAllowedFactorySizeInGbUnits_71d5d464-ae1c-4383-835f-bb7369e307ea.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/MaxAllowedResourceCount_a678b284-d23b-46e4-a8fa-75bb744a53bb.json
+++ b/services/DataFactory/factories/templates/policy-arm/MaxAllowedResourceCount_a678b284-d23b-46e4-a8fa-75bb744a53bb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/PipelineCancelledRuns_f5e0a050-1994-4864-b2c3-a09dc77fb5b4.json
+++ b/services/DataFactory/factories/templates/policy-arm/PipelineCancelledRuns_f5e0a050-1994-4864-b2c3-a09dc77fb5b4.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/PipelineElapsedTimeRuns_df4f3e6f-757e-4fa0-a411-b2cdf4039649.json
+++ b/services/DataFactory/factories/templates/policy-arm/PipelineElapsedTimeRuns_df4f3e6f-757e-4fa0-a411-b2cdf4039649.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/PipelineFailedRuns_2dd0b760-3235-479d-86d4-c152ca76b7e8.json
+++ b/services/DataFactory/factories/templates/policy-arm/PipelineFailedRuns_2dd0b760-3235-479d-86d4-c152ca76b7e8.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/PipelineSucceededRuns_47615ecc-bf5d-47e2-8c10-f8411e6c5d56.json
+++ b/services/DataFactory/factories/templates/policy-arm/PipelineSucceededRuns_47615ecc-bf5d-47e2-8c10-f8411e6c5d56.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/ResourceCount_740b104c-1ad2-4ef7-bafc-c98f22551548.json
+++ b/services/DataFactory/factories/templates/policy-arm/ResourceCount_740b104c-1ad2-4ef7-bafc-c98f22551548.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/SSISIntegrationRuntimeStartFailed_5f2a0272-792a-4cdd-ba94-9f46db438a0e.json
+++ b/services/DataFactory/factories/templates/policy-arm/SSISIntegrationRuntimeStartFailed_5f2a0272-792a-4cdd-ba94-9f46db438a0e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/SSISPackageExecutionFailed_c30b6089-59c5-4452-b382-d33152be9b03.json
+++ b/services/DataFactory/factories/templates/policy-arm/SSISPackageExecutionFailed_c30b6089-59c5-4452-b382-d33152be9b03.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/TriggerFailedRuns_9c7bde49-f0c2-4a07-b150-5dc9464fcf29.json
+++ b/services/DataFactory/factories/templates/policy-arm/TriggerFailedRuns_9c7bde49-f0c2-4a07-b150-5dc9464fcf29.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy-arm/TriggerSucceededRuns_b8286cfa-9f86-4309-954b-ef69a6d8982d.json
+++ b/services/DataFactory/factories/templates/policy-arm/TriggerSucceededRuns_b8286cfa-9f86-4309-954b-ef69a6d8982d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/ActivityFailedRuns_980f53cb-3eef-4263-952e-e69709e2a6e7.json
+++ b/services/DataFactory/factories/templates/policy/ActivityFailedRuns_980f53cb-3eef-4263-952e-e69709e2a6e7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/ActivitySucceededRuns_321c2df7-c548-4e06-8729-8132b4dc3386.json
+++ b/services/DataFactory/factories/templates/policy/ActivitySucceededRuns_321c2df7-c548-4e06-8729-8132b4dc3386.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/FactorySizeInGbUnits_08bfad59-0c23-4e6b-b577-e325f445a2cc.json
+++ b/services/DataFactory/factories/templates/policy/FactorySizeInGbUnits_08bfad59-0c23-4e6b-b577-e325f445a2cc.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/IntegrationRuntimeAvailableMemory_e8fec7b1-ca81-48cd-a7ea-f81cc2fcb4a5.json
+++ b/services/DataFactory/factories/templates/policy/IntegrationRuntimeAvailableMemory_e8fec7b1-ca81-48cd-a7ea-f81cc2fcb4a5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/IntegrationRuntimeAvailableNodeNumber_4b40d85d-f0be-41e5-9d60-ad9a99c54a41.json
+++ b/services/DataFactory/factories/templates/policy/IntegrationRuntimeAvailableNodeNumber_4b40d85d-f0be-41e5-9d60-ad9a99c54a41.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/IntegrationRuntimeCpuPercentage_473c5450-95cc-4f86-bb8a-d0a06edd1357.json
+++ b/services/DataFactory/factories/templates/policy/IntegrationRuntimeCpuPercentage_473c5450-95cc-4f86-bb8a-d0a06edd1357.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/MaxAllowedFactorySizeInGbUnits_71d5d464-ae1c-4383-835f-bb7369e307ea.json
+++ b/services/DataFactory/factories/templates/policy/MaxAllowedFactorySizeInGbUnits_71d5d464-ae1c-4383-835f-bb7369e307ea.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/MaxAllowedResourceCount_a678b284-d23b-46e4-a8fa-75bb744a53bb.json
+++ b/services/DataFactory/factories/templates/policy/MaxAllowedResourceCount_a678b284-d23b-46e4-a8fa-75bb744a53bb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/PipelineCancelledRuns_f5e0a050-1994-4864-b2c3-a09dc77fb5b4.json
+++ b/services/DataFactory/factories/templates/policy/PipelineCancelledRuns_f5e0a050-1994-4864-b2c3-a09dc77fb5b4.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/PipelineElapsedTimeRuns_df4f3e6f-757e-4fa0-a411-b2cdf4039649.json
+++ b/services/DataFactory/factories/templates/policy/PipelineElapsedTimeRuns_df4f3e6f-757e-4fa0-a411-b2cdf4039649.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/PipelineFailedRuns_2dd0b760-3235-479d-86d4-c152ca76b7e8.json
+++ b/services/DataFactory/factories/templates/policy/PipelineFailedRuns_2dd0b760-3235-479d-86d4-c152ca76b7e8.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/PipelineSucceededRuns_47615ecc-bf5d-47e2-8c10-f8411e6c5d56.json
+++ b/services/DataFactory/factories/templates/policy/PipelineSucceededRuns_47615ecc-bf5d-47e2-8c10-f8411e6c5d56.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/ResourceCount_740b104c-1ad2-4ef7-bafc-c98f22551548.json
+++ b/services/DataFactory/factories/templates/policy/ResourceCount_740b104c-1ad2-4ef7-bafc-c98f22551548.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/SSISIntegrationRuntimeStartFailed_5f2a0272-792a-4cdd-ba94-9f46db438a0e.json
+++ b/services/DataFactory/factories/templates/policy/SSISIntegrationRuntimeStartFailed_5f2a0272-792a-4cdd-ba94-9f46db438a0e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/SSISPackageExecutionFailed_c30b6089-59c5-4452-b382-d33152be9b03.json
+++ b/services/DataFactory/factories/templates/policy/SSISPackageExecutionFailed_c30b6089-59c5-4452-b382-d33152be9b03.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/TriggerFailedRuns_9c7bde49-f0c2-4a07-b150-5dc9464fcf29.json
+++ b/services/DataFactory/factories/templates/policy/TriggerFailedRuns_9c7bde49-f0c2-4a07-b150-5dc9464fcf29.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DataFactory/factories/templates/policy/TriggerSucceededRuns_b8286cfa-9f86-4309-954b-ef69a6d8982d.json
+++ b/services/DataFactory/factories/templates/policy/TriggerSucceededRuns_b8286cfa-9f86-4309-954b-ef69a6d8982d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DataFactory/factories/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Devices/IotHubs/templates/policy-arm/d2ctelemetryegressdropped_d5a028d1-ae0e-4349-8a79-630f891c8235.json
+++ b/services/Devices/IotHubs/templates/policy-arm/d2ctelemetryegressdropped_d5a028d1-ae0e-4349-8a79-630f891c8235.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Devices/IotHubs/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Devices/IotHubs/templates/policy-arm/d2ctelemetryingresssendThrottle_65deae31-85e8-477a-b17e-50d2d10cd7b0.json
+++ b/services/Devices/IotHubs/templates/policy-arm/d2ctelemetryingresssendThrottle_65deae31-85e8-477a-b17e-50d2d10cd7b0.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Devices/IotHubs/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Devices/IotHubs/templates/policy-arm/d2ctelemetryingresssuccess_85de8003-c1d8-4cd1-80b5-e125399ef293.json
+++ b/services/Devices/IotHubs/templates/policy-arm/d2ctelemetryingresssuccess_85de8003-c1d8-4cd1-80b5-e125399ef293.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Devices/IotHubs/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Devices/IotHubs/templates/policy-arm/dailyMessageQuotaUsed_d78fc655-68ca-4877-ac60-7fc805f1ae94.json
+++ b/services/Devices/IotHubs/templates/policy-arm/dailyMessageQuotaUsed_d78fc655-68ca-4877-ac60-7fc805f1ae94.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Devices/IotHubs/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Devices/IotHubs/templates/policy/d2ctelemetryegressdropped_d5a028d1-ae0e-4349-8a79-630f891c8235.json
+++ b/services/Devices/IotHubs/templates/policy/d2ctelemetryegressdropped_d5a028d1-ae0e-4349-8a79-630f891c8235.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Devices/IotHubs/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Devices/IotHubs/templates/policy/d2ctelemetryingresssendThrottle_65deae31-85e8-477a-b17e-50d2d10cd7b0.json
+++ b/services/Devices/IotHubs/templates/policy/d2ctelemetryingresssendThrottle_65deae31-85e8-477a-b17e-50d2d10cd7b0.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Devices/IotHubs/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Devices/IotHubs/templates/policy/d2ctelemetryingresssuccess_85de8003-c1d8-4cd1-80b5-e125399ef293.json
+++ b/services/Devices/IotHubs/templates/policy/d2ctelemetryingresssuccess_85de8003-c1d8-4cd1-80b5-e125399ef293.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Devices/IotHubs/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Devices/IotHubs/templates/policy/dailyMessageQuotaUsed_d78fc655-68ca-4877-ac60-7fc805f1ae94.json
+++ b/services/Devices/IotHubs/templates/policy/dailyMessageQuotaUsed_d78fc655-68ca-4877-ac60-7fc805f1ae94.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Devices/IotHubs/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/DataUsage_0914c189-0adc-45d6-8704-d2ae73b9b7b6.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/DataUsage_0914c189-0adc-45d6-8704-d2ae73b9b7b6.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/MongoRequests_3f30e3aa-7e17-4eaf-a437-a420f5a23bf2.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/MongoRequests_3f30e3aa-7e17-4eaf-a437-a420f5a23bf2.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/NormalizedRUConsumption_9bae539a-12ed-46e2-b105-101ce036c9a4.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/NormalizedRUConsumption_9bae539a-12ed-46e2-b105-101ce036c9a4.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/OfflineRegion_0cb53be3-76b5-44be-9f32-bcc821be34b6.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/OfflineRegion_0cb53be3-76b5-44be-9f32-bcc821be34b6.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/ProvisionedThroughput_f77ce9c2-bb95-47e7-8e5d-75d5c098f489.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/ProvisionedThroughput_f77ce9c2-bb95-47e7-8e5d-75d5c098f489.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/RegionFailover_9c41c539-b81b-4917-b04a-e67225f78e75.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/RegionFailover_9c41c539-b81b-4917-b04a-e67225f78e75.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/RemoveRegion_228e104f-002a-441d-91ec-6140f233c1a4.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/RemoveRegion_228e104f-002a-441d-91ec-6140f233c1a4.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/ReplicationLatency_cf0655a4-042d-4979-bbc7-5559eaa8f2b9.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/ReplicationLatency_cf0655a4-042d-4979-bbc7-5559eaa8f2b9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/ServerSideLatency_28f2e10d-2297-47f9-ac6a-c7a8cc0c8ead.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/ServerSideLatency_28f2e10d-2297-47f9-ac6a-c7a8cc0c8ead.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/ServiceAvailability_ee10b769-b38b-44d1-9fd3-926b8dca4c41.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/ServiceAvailability_ee10b769-b38b-44d1-9fd3-926b8dca4c41.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/SqlContainerDelete_faf5510e-28b7-42c9-8ad1-de68a5737eaf.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/SqlContainerDelete_faf5510e-28b7-42c9-8ad1-de68a5737eaf.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/SqlDatabaseDelete_a7958120-a386-46d0-9790-e80bfa72fb22.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/SqlDatabaseDelete_a7958120-a386-46d0-9790-e80bfa72fb22.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/ThrottledRequests_fc8db431-f429-40ee-a51a-de1858198e19.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/ThrottledRequests_fc8db431-f429-40ee-a51a-de1858198e19.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/TotalRequestUnits_14fc7c6b-484f-427f-a1d2-94cded799f88.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/TotalRequestUnits_14fc7c6b-484f-427f-a1d2-94cded799f88.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/TotalRequests_2a1deb2d-1fc0-499b-a828-04aeece855fe.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/TotalRequests_2a1deb2d-1fc0-499b-a828-04aeece855fe.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy-arm/UpdateAccountKeys_d4d7685a-ce55-4709-a847-747d02165cb7.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy-arm/UpdateAccountKeys_d4d7685a-ce55-4709-a847-747d02165cb7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/DataUsage_0914c189-0adc-45d6-8704-d2ae73b9b7b6.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/DataUsage_0914c189-0adc-45d6-8704-d2ae73b9b7b6.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/MongoRequests_3f30e3aa-7e17-4eaf-a437-a420f5a23bf2.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/MongoRequests_3f30e3aa-7e17-4eaf-a437-a420f5a23bf2.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/NormalizedRUConsumption_9bae539a-12ed-46e2-b105-101ce036c9a4.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/NormalizedRUConsumption_9bae539a-12ed-46e2-b105-101ce036c9a4.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/OfflineRegion_0cb53be3-76b5-44be-9f32-bcc821be34b6.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/OfflineRegion_0cb53be3-76b5-44be-9f32-bcc821be34b6.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/ProvisionedThroughput_f77ce9c2-bb95-47e7-8e5d-75d5c098f489.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/ProvisionedThroughput_f77ce9c2-bb95-47e7-8e5d-75d5c098f489.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/RegionFailover_9c41c539-b81b-4917-b04a-e67225f78e75.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/RegionFailover_9c41c539-b81b-4917-b04a-e67225f78e75.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/RemoveRegion_228e104f-002a-441d-91ec-6140f233c1a4.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/RemoveRegion_228e104f-002a-441d-91ec-6140f233c1a4.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/ReplicationLatency_cf0655a4-042d-4979-bbc7-5559eaa8f2b9.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/ReplicationLatency_cf0655a4-042d-4979-bbc7-5559eaa8f2b9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/ServerSideLatency_28f2e10d-2297-47f9-ac6a-c7a8cc0c8ead.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/ServerSideLatency_28f2e10d-2297-47f9-ac6a-c7a8cc0c8ead.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/ServiceAvailability_ee10b769-b38b-44d1-9fd3-926b8dca4c41.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/ServiceAvailability_ee10b769-b38b-44d1-9fd3-926b8dca4c41.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/SqlContainerDelete_faf5510e-28b7-42c9-8ad1-de68a5737eaf.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/SqlContainerDelete_faf5510e-28b7-42c9-8ad1-de68a5737eaf.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/SqlDatabaseDelete_a7958120-a386-46d0-9790-e80bfa72fb22.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/SqlDatabaseDelete_a7958120-a386-46d0-9790-e80bfa72fb22.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/ThrottledRequests_fc8db431-f429-40ee-a51a-de1858198e19.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/ThrottledRequests_fc8db431-f429-40ee-a51a-de1858198e19.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/TotalRequestUnits_14fc7c6b-484f-427f-a1d2-94cded799f88.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/TotalRequestUnits_14fc7c6b-484f-427f-a1d2-94cded799f88.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/TotalRequests_2a1deb2d-1fc0-499b-a828-04aeece855fe.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/TotalRequests_2a1deb2d-1fc0-499b-a828-04aeece855fe.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/DocumentDB/databaseAccounts/templates/policy/UpdateAccountKeys_d4d7685a-ce55-4709-a847-747d02165cb7.json
+++ b/services/DocumentDB/databaseAccounts/templates/policy/UpdateAccountKeys_d4d7685a-ce55-4709-a847-747d02165cb7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.DocumentDB/databaseAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/domains/templates/policy-arm/DeliveryAttemptFailCount_51ff86c0-2add-42e0-aab8-f6f0edcf2b51.json
+++ b/services/EventGrid/domains/templates/policy-arm/DeliveryAttemptFailCount_51ff86c0-2add-42e0-aab8-f6f0edcf2b51.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/domains/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/domains/templates/policy/DeliveryAttemptFailCount_51ff86c0-2add-42e0-aab8-f6f0edcf2b51.json
+++ b/services/EventGrid/domains/templates/policy/DeliveryAttemptFailCount_51ff86c0-2add-42e0-aab8-f6f0edcf2b51.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/domains/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/systemTopics/templates/policy-arm/DeadLetteredCount_c02f2d18-2b7e-4d85-81fa-2c1437d0b092.json
+++ b/services/EventGrid/systemTopics/templates/policy-arm/DeadLetteredCount_c02f2d18-2b7e-4d85-81fa-2c1437d0b092.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/systemTopics/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/systemTopics/templates/policy-arm/DeliveryAttemptFailCount_6584a39d-0795-4132-8c33-376d3926d21b.json
+++ b/services/EventGrid/systemTopics/templates/policy-arm/DeliveryAttemptFailCount_6584a39d-0795-4132-8c33-376d3926d21b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/systemTopics/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/systemTopics/templates/policy-arm/PublishFailCount_fb8bc2ae-26bc-45a1-b616-1f45ffb864ae.json
+++ b/services/EventGrid/systemTopics/templates/policy-arm/PublishFailCount_fb8bc2ae-26bc-45a1-b616-1f45ffb864ae.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/systemTopics/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/systemTopics/templates/policy/DeadLetteredCount_c02f2d18-2b7e-4d85-81fa-2c1437d0b092.json
+++ b/services/EventGrid/systemTopics/templates/policy/DeadLetteredCount_c02f2d18-2b7e-4d85-81fa-2c1437d0b092.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/systemTopics/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/systemTopics/templates/policy/DeliveryAttemptFailCount_6584a39d-0795-4132-8c33-376d3926d21b.json
+++ b/services/EventGrid/systemTopics/templates/policy/DeliveryAttemptFailCount_6584a39d-0795-4132-8c33-376d3926d21b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/systemTopics/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/systemTopics/templates/policy/PublishFailCount_fb8bc2ae-26bc-45a1-b616-1f45ffb864ae.json
+++ b/services/EventGrid/systemTopics/templates/policy/PublishFailCount_fb8bc2ae-26bc-45a1-b616-1f45ffb864ae.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/systemTopics/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/topics/templates/policy-arm/DeadLetteredCount_343258f9-4bb2-41fb-abfa-d04ea62a6aad.json
+++ b/services/EventGrid/topics/templates/policy-arm/DeadLetteredCount_343258f9-4bb2-41fb-abfa-d04ea62a6aad.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/topics/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/topics/templates/policy-arm/DeliveryAttemptFailCount_95865d3b-41d0-4ad6-b08b-a2dcfe0940a9.json
+++ b/services/EventGrid/topics/templates/policy-arm/DeliveryAttemptFailCount_95865d3b-41d0-4ad6-b08b-a2dcfe0940a9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/topics/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/topics/templates/policy-arm/DroppedEventCount_e9561f89-282e-4145-b5cc-8485a7fc987c.json
+++ b/services/EventGrid/topics/templates/policy-arm/DroppedEventCount_e9561f89-282e-4145-b5cc-8485a7fc987c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/topics/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/topics/templates/policy-arm/PublishFailCount_230c0173-8b36-4412-9617-3e096886a403.json
+++ b/services/EventGrid/topics/templates/policy-arm/PublishFailCount_230c0173-8b36-4412-9617-3e096886a403.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/topics/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/topics/templates/policy/DeadLetteredCount_343258f9-4bb2-41fb-abfa-d04ea62a6aad.json
+++ b/services/EventGrid/topics/templates/policy/DeadLetteredCount_343258f9-4bb2-41fb-abfa-d04ea62a6aad.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/topics/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/topics/templates/policy/DeliveryAttemptFailCount_95865d3b-41d0-4ad6-b08b-a2dcfe0940a9.json
+++ b/services/EventGrid/topics/templates/policy/DeliveryAttemptFailCount_95865d3b-41d0-4ad6-b08b-a2dcfe0940a9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/topics/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/topics/templates/policy/DroppedEventCount_e9561f89-282e-4145-b5cc-8485a7fc987c.json
+++ b/services/EventGrid/topics/templates/policy/DroppedEventCount_e9561f89-282e-4145-b5cc-8485a7fc987c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/topics/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventGrid/topics/templates/policy/PublishFailCount_230c0173-8b36-4412-9617-3e096886a403.json
+++ b/services/EventGrid/topics/templates/policy/PublishFailCount_230c0173-8b36-4412-9617-3e096886a403.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventGrid/topics/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/clusters/templates/policy-arm/CPU_8875590a-9f72-49a2-807f-62437f8079b1.json
+++ b/services/EventHub/clusters/templates/policy-arm/CPU_8875590a-9f72-49a2-807f-62437f8079b1.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/clusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/clusters/templates/policy/CPU_8875590a-9f72-49a2-807f-62437f8079b1.json
+++ b/services/EventHub/clusters/templates/policy/CPU_8875590a-9f72-49a2-807f-62437f8079b1.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/clusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy-arm/CaptureBacklog_2959b52d-6756-480d-9193-b2c0c4c5d305.json
+++ b/services/EventHub/namespaces/templates/policy-arm/CaptureBacklog_2959b52d-6756-480d-9193-b2c0c4c5d305.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy-arm/IncomingBytes_2ca39ff3-6f87-438c-81f6-7ce51f70902f.json
+++ b/services/EventHub/namespaces/templates/policy-arm/IncomingBytes_2ca39ff3-6f87-438c-81f6-7ce51f70902f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy-arm/IncomingMessages_4f1964ce-6938-499a-af3d-bb746aaff72a.json
+++ b/services/EventHub/namespaces/templates/policy-arm/IncomingMessages_4f1964ce-6938-499a-af3d-bb746aaff72a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy-arm/NamespaceCpuUsage_a9c1e74c-bd3a-438c-bd13-7a2fec2d172c.json
+++ b/services/EventHub/namespaces/templates/policy-arm/NamespaceCpuUsage_a9c1e74c-bd3a-438c-bd13-7a2fec2d172c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy-arm/NamespaceMemoryUsage_26972609-fbb4-4fb9-b7f8-7b99a06bb4e3.json
+++ b/services/EventHub/namespaces/templates/policy-arm/NamespaceMemoryUsage_26972609-fbb4-4fb9-b7f8-7b99a06bb4e3.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy-arm/OutgoingBytes_46a66177-c487-4ed1-b2fc-19c0bf52b168.json
+++ b/services/EventHub/namespaces/templates/policy-arm/OutgoingBytes_46a66177-c487-4ed1-b2fc-19c0bf52b168.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy-arm/OutgoingMessages_c67b86dc-74d5-4ea1-882e-de257d054ff3.json
+++ b/services/EventHub/namespaces/templates/policy-arm/OutgoingMessages_c67b86dc-74d5-4ea1-882e-de257d054ff3.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy-arm/QuotaExceededErrors_237493ef-15c0-4e87-80bc-f8c59dd897ce.json
+++ b/services/EventHub/namespaces/templates/policy-arm/QuotaExceededErrors_237493ef-15c0-4e87-80bc-f8c59dd897ce.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy-arm/ServerErrors_48581aa9-53ee-4467-b04c-402061fe40e8.json
+++ b/services/EventHub/namespaces/templates/policy-arm/ServerErrors_48581aa9-53ee-4467-b04c-402061fe40e8.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy-arm/ThrottledRequests_1684f387-04e6-440c-a931-f57efdc84cd2.json
+++ b/services/EventHub/namespaces/templates/policy-arm/ThrottledRequests_1684f387-04e6-440c-a931-f57efdc84cd2.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy-arm/UserErrors_b1700765-b168-4ad4-a73e-f3a93a6bf5cf.json
+++ b/services/EventHub/namespaces/templates/policy-arm/UserErrors_b1700765-b168-4ad4-a73e-f3a93a6bf5cf.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy/CaptureBacklog_2959b52d-6756-480d-9193-b2c0c4c5d305.json
+++ b/services/EventHub/namespaces/templates/policy/CaptureBacklog_2959b52d-6756-480d-9193-b2c0c4c5d305.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy/IncomingBytes_2ca39ff3-6f87-438c-81f6-7ce51f70902f.json
+++ b/services/EventHub/namespaces/templates/policy/IncomingBytes_2ca39ff3-6f87-438c-81f6-7ce51f70902f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy/IncomingMessages_4f1964ce-6938-499a-af3d-bb746aaff72a.json
+++ b/services/EventHub/namespaces/templates/policy/IncomingMessages_4f1964ce-6938-499a-af3d-bb746aaff72a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy/NamespaceCpuUsage_a9c1e74c-bd3a-438c-bd13-7a2fec2d172c.json
+++ b/services/EventHub/namespaces/templates/policy/NamespaceCpuUsage_a9c1e74c-bd3a-438c-bd13-7a2fec2d172c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy/NamespaceMemoryUsage_26972609-fbb4-4fb9-b7f8-7b99a06bb4e3.json
+++ b/services/EventHub/namespaces/templates/policy/NamespaceMemoryUsage_26972609-fbb4-4fb9-b7f8-7b99a06bb4e3.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy/OutgoingBytes_46a66177-c487-4ed1-b2fc-19c0bf52b168.json
+++ b/services/EventHub/namespaces/templates/policy/OutgoingBytes_46a66177-c487-4ed1-b2fc-19c0bf52b168.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy/OutgoingMessages_c67b86dc-74d5-4ea1-882e-de257d054ff3.json
+++ b/services/EventHub/namespaces/templates/policy/OutgoingMessages_c67b86dc-74d5-4ea1-882e-de257d054ff3.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy/QuotaExceededErrors_237493ef-15c0-4e87-80bc-f8c59dd897ce.json
+++ b/services/EventHub/namespaces/templates/policy/QuotaExceededErrors_237493ef-15c0-4e87-80bc-f8c59dd897ce.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy/ServerErrors_48581aa9-53ee-4467-b04c-402061fe40e8.json
+++ b/services/EventHub/namespaces/templates/policy/ServerErrors_48581aa9-53ee-4467-b04c-402061fe40e8.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy/ThrottledRequests_1684f387-04e6-440c-a931-f57efdc84cd2.json
+++ b/services/EventHub/namespaces/templates/policy/ThrottledRequests_1684f387-04e6-440c-a931-f57efdc84cd2.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/EventHub/namespaces/templates/policy/UserErrors_b1700765-b168-4ad4-a73e-f3a93a6bf5cf.json
+++ b/services/EventHub/namespaces/templates/policy/UserErrors_b1700765-b168-4ad4-a73e-f3a93a6bf5cf.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.EventHub/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/HealthcareApis/services/templates/policy-arm/TotalLatency_30ba09b3-4e96-403d-a295-8f37788914aa.json
+++ b/services/HealthcareApis/services/templates/policy-arm/TotalLatency_30ba09b3-4e96-403d-a295-8f37788914aa.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.HealthcareApis/services/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/HealthcareApis/services/templates/policy-arm/TotalRequests_75dbbcf0-d6ae-401f-8765-ba643385da9b.json
+++ b/services/HealthcareApis/services/templates/policy-arm/TotalRequests_75dbbcf0-d6ae-401f-8765-ba643385da9b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.HealthcareApis/services/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/HealthcareApis/services/templates/policy/TotalLatency_30ba09b3-4e96-403d-a295-8f37788914aa.json
+++ b/services/HealthcareApis/services/templates/policy/TotalLatency_30ba09b3-4e96-403d-a295-8f37788914aa.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.HealthcareApis/services/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/HealthcareApis/services/templates/policy/TotalRequests_75dbbcf0-d6ae-401f-8765-ba643385da9b.json
+++ b/services/HealthcareApis/services/templates/policy/TotalRequests_75dbbcf0-d6ae-401f-8765-ba643385da9b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.HealthcareApis/services/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/KeyVault/vaults/templates/policy-arm/Availability_a3c8bcb4-22ca-45be-92f7-605f232ecec2.json
+++ b/services/KeyVault/vaults/templates/policy-arm/Availability_a3c8bcb4-22ca-45be-92f7-605f232ecec2.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.KeyVault/vaults/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/KeyVault/vaults/templates/policy-arm/SaturationShoebox_dc852755-e5df-4fd0-83ac-cbbc516f60b3.json
+++ b/services/KeyVault/vaults/templates/policy-arm/SaturationShoebox_dc852755-e5df-4fd0-83ac-cbbc516f60b3.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.KeyVault/vaults/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/KeyVault/vaults/templates/policy-arm/ServiceApiHit_7b52bf07-3d86-4429-b5d4-829a6a5542df.json
+++ b/services/KeyVault/vaults/templates/policy-arm/ServiceApiHit_7b52bf07-3d86-4429-b5d4-829a6a5542df.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.KeyVault/vaults/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/KeyVault/vaults/templates/policy-arm/ServiceApiLatency_2651f57f-ac74-44f3-8511-c245488134f8.json
+++ b/services/KeyVault/vaults/templates/policy-arm/ServiceApiLatency_2651f57f-ac74-44f3-8511-c245488134f8.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.KeyVault/vaults/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/KeyVault/vaults/templates/policy-arm/ServiceApiResult_14356b19-1264-498d-b1cd-e3fa9f0c9fc9.json
+++ b/services/KeyVault/vaults/templates/policy-arm/ServiceApiResult_14356b19-1264-498d-b1cd-e3fa9f0c9fc9.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.KeyVault/vaults/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/KeyVault/vaults/templates/policy/Availability_a3c8bcb4-22ca-45be-92f7-605f232ecec2.json
+++ b/services/KeyVault/vaults/templates/policy/Availability_a3c8bcb4-22ca-45be-92f7-605f232ecec2.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.KeyVault/vaults/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/KeyVault/vaults/templates/policy/SaturationShoebox_dc852755-e5df-4fd0-83ac-cbbc516f60b3.json
+++ b/services/KeyVault/vaults/templates/policy/SaturationShoebox_dc852755-e5df-4fd0-83ac-cbbc516f60b3.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.KeyVault/vaults/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/KeyVault/vaults/templates/policy/ServiceApiHit_7b52bf07-3d86-4429-b5d4-829a6a5542df.json
+++ b/services/KeyVault/vaults/templates/policy/ServiceApiHit_7b52bf07-3d86-4429-b5d4-829a6a5542df.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.KeyVault/vaults/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/KeyVault/vaults/templates/policy/ServiceApiLatency_2651f57f-ac74-44f3-8511-c245488134f8.json
+++ b/services/KeyVault/vaults/templates/policy/ServiceApiLatency_2651f57f-ac74-44f3-8511-c245488134f8.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.KeyVault/vaults/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/KeyVault/vaults/templates/policy/ServiceApiResult_14356b19-1264-498d-b1cd-e3fa9f0c9fc9.json
+++ b/services/KeyVault/vaults/templates/policy/ServiceApiResult_14356b19-1264-498d-b1cd-e3fa9f0c9fc9.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.KeyVault/vaults/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Kusto/clusters/templates/policy-arm/BlobsDropped_422c292e-54e3-4e7d-93e2-bcd1bf65dae6.json
+++ b/services/Kusto/clusters/templates/policy-arm/BlobsDropped_422c292e-54e3-4e7d-93e2-bcd1bf65dae6.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Kusto/clusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Kusto/clusters/templates/policy-arm/CPU_cae6ec0a-a26d-494b-94b2-3d93dcedff42.json
+++ b/services/Kusto/clusters/templates/policy-arm/CPU_cae6ec0a-a26d-494b-94b2-3d93dcedff42.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Kusto/clusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Kusto/clusters/templates/policy-arm/IngestionLatencyInSeconds_8493c362-2524-4079-9025-8f5ffee62936.json
+++ b/services/Kusto/clusters/templates/policy-arm/IngestionLatencyInSeconds_8493c362-2524-4079-9025-8f5ffee62936.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Kusto/clusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Kusto/clusters/templates/policy-arm/IngestionResult_6c4213c5-743f-48b8-b957-dd26fbf8809e.json
+++ b/services/Kusto/clusters/templates/policy-arm/IngestionResult_6c4213c5-743f-48b8-b957-dd26fbf8809e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Kusto/clusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Kusto/clusters/templates/policy-arm/KeepAlive_188fc0b5-a686-48a7-950f-76f183ba49d6.json
+++ b/services/Kusto/clusters/templates/policy-arm/KeepAlive_188fc0b5-a686-48a7-950f-76f183ba49d6.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Kusto/clusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Kusto/clusters/templates/policy-arm/QueryResult_b131dc45-d6ac-4521-8206-a365ac2dbe52.json
+++ b/services/Kusto/clusters/templates/policy-arm/QueryResult_b131dc45-d6ac-4521-8206-a365ac2dbe52.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Kusto/clusters/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Kusto/clusters/templates/policy/BlobsDropped_422c292e-54e3-4e7d-93e2-bcd1bf65dae6.json
+++ b/services/Kusto/clusters/templates/policy/BlobsDropped_422c292e-54e3-4e7d-93e2-bcd1bf65dae6.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Kusto/clusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Kusto/clusters/templates/policy/CPU_cae6ec0a-a26d-494b-94b2-3d93dcedff42.json
+++ b/services/Kusto/clusters/templates/policy/CPU_cae6ec0a-a26d-494b-94b2-3d93dcedff42.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Kusto/clusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Kusto/clusters/templates/policy/IngestionLatencyInSeconds_8493c362-2524-4079-9025-8f5ffee62936.json
+++ b/services/Kusto/clusters/templates/policy/IngestionLatencyInSeconds_8493c362-2524-4079-9025-8f5ffee62936.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Kusto/clusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Kusto/clusters/templates/policy/IngestionResult_6c4213c5-743f-48b8-b957-dd26fbf8809e.json
+++ b/services/Kusto/clusters/templates/policy/IngestionResult_6c4213c5-743f-48b8-b957-dd26fbf8809e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Kusto/clusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Kusto/clusters/templates/policy/KeepAlive_188fc0b5-a686-48a7-950f-76f183ba49d6.json
+++ b/services/Kusto/clusters/templates/policy/KeepAlive_188fc0b5-a686-48a7-950f-76f183ba49d6.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Kusto/clusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Kusto/clusters/templates/policy/QueryResult_b131dc45-d6ac-4521-8206-a365ac2dbe52.json
+++ b/services/Kusto/clusters/templates/policy/QueryResult_b131dc45-d6ac-4521-8206-a365ac2dbe52.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Kusto/clusters/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/ActionLatency_d8bf77d2-8572-4392-8097-5e84f136513d.json
+++ b/services/Logic/workflows/templates/policy-arm/ActionLatency_d8bf77d2-8572-4392-8097-5e84f136513d.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/ActionThrottledEvents_5aa5790b-2bff-40b0-9099-38485b9a9e0a.json
+++ b/services/Logic/workflows/templates/policy-arm/ActionThrottledEvents_5aa5790b-2bff-40b0-9099-38485b9a9e0a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/ActionsFailed_514f695a-4f11-4a28-9516-f7f3b5b1c53b.json
+++ b/services/Logic/workflows/templates/policy-arm/ActionsFailed_514f695a-4f11-4a28-9516-f7f3b5b1c53b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/RunFailurePercentage_c4864d80-dd28-4344-a135-03b600920c06.json
+++ b/services/Logic/workflows/templates/policy-arm/RunFailurePercentage_c4864d80-dd28-4344-a135-03b600920c06.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/RunLatency_eb44cbdc-a259-4354-9b54-2bc72f811440.json
+++ b/services/Logic/workflows/templates/policy-arm/RunLatency_eb44cbdc-a259-4354-9b54-2bc72f811440.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/RunStartThrottledEvents_6524b22c-661e-48cd-87e7-7ee9ddea7b8b.json
+++ b/services/Logic/workflows/templates/policy-arm/RunStartThrottledEvents_6524b22c-661e-48cd-87e7-7ee9ddea7b8b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/RunSuccessLatency_346ba728-f7a1-4ca4-8486-786d6ebb9f9a.json
+++ b/services/Logic/workflows/templates/policy-arm/RunSuccessLatency_346ba728-f7a1-4ca4-8486-786d6ebb9f9a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/RunThrottledEvents_9d324d21-ab2b-48b7-a637-4b1d9891d6b5.json
+++ b/services/Logic/workflows/templates/policy-arm/RunThrottledEvents_9d324d21-ab2b-48b7-a637-4b1d9891d6b5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/RunsCancelled_a4b5f1f3-aa12-4ed5-8a9d-a135204d22de.json
+++ b/services/Logic/workflows/templates/policy-arm/RunsCancelled_a4b5f1f3-aa12-4ed5-8a9d-a135204d22de.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/RunsCompleted_5d020d4d-9359-4ecd-934a-409d0e4a5abd.json
+++ b/services/Logic/workflows/templates/policy-arm/RunsCompleted_5d020d4d-9359-4ecd-934a-409d0e4a5abd.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/RunsFailed_350cc22f-d202-4c7c-9239-cbdb3b71e14b.json
+++ b/services/Logic/workflows/templates/policy-arm/RunsFailed_350cc22f-d202-4c7c-9239-cbdb3b71e14b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/RunsStarted_8f7a8cb8-feef-4eaa-9e74-18693ce9969e.json
+++ b/services/Logic/workflows/templates/policy-arm/RunsStarted_8f7a8cb8-feef-4eaa-9e74-18693ce9969e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/RunsSucceeded_16c2d231-f28b-4146-9aa3-57d419eb8780.json
+++ b/services/Logic/workflows/templates/policy-arm/RunsSucceeded_16c2d231-f28b-4146-9aa3-57d419eb8780.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/TotalBillableExecutions_85bb464e-d9ce-496a-a66d-4c6d28d808df.json
+++ b/services/Logic/workflows/templates/policy-arm/TotalBillableExecutions_85bb464e-d9ce-496a-a66d-4c6d28d808df.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/TriggerLatency_114f7c8e-e285-487d-9e50-7fe160769167.json
+++ b/services/Logic/workflows/templates/policy-arm/TriggerLatency_114f7c8e-e285-487d-9e50-7fe160769167.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/TriggerThrottledEvents_42ae6a24-d545-4bbd-a7f9-8a3b6f977366.json
+++ b/services/Logic/workflows/templates/policy-arm/TriggerThrottledEvents_42ae6a24-d545-4bbd-a7f9-8a3b6f977366.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/TriggersFailed_0378fd1f-976e-4a32-aa2b-25003e7d6ee5.json
+++ b/services/Logic/workflows/templates/policy-arm/TriggersFailed_0378fd1f-976e-4a32-aa2b-25003e7d6ee5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy-arm/TriggersSkipped_cb35fd68-9568-42f9-b527-44e77726b100.json
+++ b/services/Logic/workflows/templates/policy-arm/TriggersSkipped_cb35fd68-9568-42f9-b527-44e77726b100.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/ActionLatency_d8bf77d2-8572-4392-8097-5e84f136513d.json
+++ b/services/Logic/workflows/templates/policy/ActionLatency_d8bf77d2-8572-4392-8097-5e84f136513d.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/ActionThrottledEvents_5aa5790b-2bff-40b0-9099-38485b9a9e0a.json
+++ b/services/Logic/workflows/templates/policy/ActionThrottledEvents_5aa5790b-2bff-40b0-9099-38485b9a9e0a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/ActionsFailed_514f695a-4f11-4a28-9516-f7f3b5b1c53b.json
+++ b/services/Logic/workflows/templates/policy/ActionsFailed_514f695a-4f11-4a28-9516-f7f3b5b1c53b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/RunFailurePercentage_c4864d80-dd28-4344-a135-03b600920c06.json
+++ b/services/Logic/workflows/templates/policy/RunFailurePercentage_c4864d80-dd28-4344-a135-03b600920c06.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/RunLatency_eb44cbdc-a259-4354-9b54-2bc72f811440.json
+++ b/services/Logic/workflows/templates/policy/RunLatency_eb44cbdc-a259-4354-9b54-2bc72f811440.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/RunStartThrottledEvents_6524b22c-661e-48cd-87e7-7ee9ddea7b8b.json
+++ b/services/Logic/workflows/templates/policy/RunStartThrottledEvents_6524b22c-661e-48cd-87e7-7ee9ddea7b8b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/RunSuccessLatency_346ba728-f7a1-4ca4-8486-786d6ebb9f9a.json
+++ b/services/Logic/workflows/templates/policy/RunSuccessLatency_346ba728-f7a1-4ca4-8486-786d6ebb9f9a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/RunThrottledEvents_9d324d21-ab2b-48b7-a637-4b1d9891d6b5.json
+++ b/services/Logic/workflows/templates/policy/RunThrottledEvents_9d324d21-ab2b-48b7-a637-4b1d9891d6b5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/RunsCancelled_a4b5f1f3-aa12-4ed5-8a9d-a135204d22de.json
+++ b/services/Logic/workflows/templates/policy/RunsCancelled_a4b5f1f3-aa12-4ed5-8a9d-a135204d22de.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/RunsCompleted_5d020d4d-9359-4ecd-934a-409d0e4a5abd.json
+++ b/services/Logic/workflows/templates/policy/RunsCompleted_5d020d4d-9359-4ecd-934a-409d0e4a5abd.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/RunsFailed_350cc22f-d202-4c7c-9239-cbdb3b71e14b.json
+++ b/services/Logic/workflows/templates/policy/RunsFailed_350cc22f-d202-4c7c-9239-cbdb3b71e14b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/RunsStarted_8f7a8cb8-feef-4eaa-9e74-18693ce9969e.json
+++ b/services/Logic/workflows/templates/policy/RunsStarted_8f7a8cb8-feef-4eaa-9e74-18693ce9969e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/RunsSucceeded_16c2d231-f28b-4146-9aa3-57d419eb8780.json
+++ b/services/Logic/workflows/templates/policy/RunsSucceeded_16c2d231-f28b-4146-9aa3-57d419eb8780.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/TotalBillableExecutions_85bb464e-d9ce-496a-a66d-4c6d28d808df.json
+++ b/services/Logic/workflows/templates/policy/TotalBillableExecutions_85bb464e-d9ce-496a-a66d-4c6d28d808df.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/TriggerLatency_114f7c8e-e285-487d-9e50-7fe160769167.json
+++ b/services/Logic/workflows/templates/policy/TriggerLatency_114f7c8e-e285-487d-9e50-7fe160769167.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/TriggerThrottledEvents_42ae6a24-d545-4bbd-a7f9-8a3b6f977366.json
+++ b/services/Logic/workflows/templates/policy/TriggerThrottledEvents_42ae6a24-d545-4bbd-a7f9-8a3b6f977366.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/TriggersFailed_0378fd1f-976e-4a32-aa2b-25003e7d6ee5.json
+++ b/services/Logic/workflows/templates/policy/TriggersFailed_0378fd1f-976e-4a32-aa2b-25003e7d6ee5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Logic/workflows/templates/policy/TriggersSkipped_cb35fd68-9568-42f9-b527-44e77726b100.json
+++ b/services/Logic/workflows/templates/policy/TriggersSkipped_cb35fd68-9568-42f9-b527-44e77726b100.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Logic/workflows/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/MachineLearningServices/workspaces/templates/policy-arm/FailedRuns_c897902c-40a5-497b-a0ce-86c3eda7c61d.json
+++ b/services/MachineLearningServices/workspaces/templates/policy-arm/FailedRuns_c897902c-40a5-497b-a0ce-86c3eda7c61d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.MachineLearningServices/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/MachineLearningServices/workspaces/templates/policy-arm/ModelDeployFailed_0337a76f-238e-4d4d-9cd1-48b205874dbb.json
+++ b/services/MachineLearningServices/workspaces/templates/policy-arm/ModelDeployFailed_0337a76f-238e-4d4d-9cd1-48b205874dbb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.MachineLearningServices/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/MachineLearningServices/workspaces/templates/policy-arm/NotRespondingRuns_d3b80f22-9f1d-3038-86ff-c4dd5ba02d7a.json
+++ b/services/MachineLearningServices/workspaces/templates/policy-arm/NotRespondingRuns_d3b80f22-9f1d-3038-86ff-c4dd5ba02d7a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.MachineLearningServices/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/MachineLearningServices/workspaces/templates/policy-arm/QuotaUtilizationPercentage_be3f1bfc-c21a-4399-9b9f-a33ebdc470cb.json
+++ b/services/MachineLearningServices/workspaces/templates/policy-arm/QuotaUtilizationPercentage_be3f1bfc-c21a-4399-9b9f-a33ebdc470cb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.MachineLearningServices/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/MachineLearningServices/workspaces/templates/policy-arm/UnusableNodes_a171bc0c-676f-464b-a7b5-e50cd6c612a2.json
+++ b/services/MachineLearningServices/workspaces/templates/policy-arm/UnusableNodes_a171bc0c-676f-464b-a7b5-e50cd6c612a2.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.MachineLearningServices/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/MachineLearningServices/workspaces/templates/policy/FailedRuns_c897902c-40a5-497b-a0ce-86c3eda7c61d.json
+++ b/services/MachineLearningServices/workspaces/templates/policy/FailedRuns_c897902c-40a5-497b-a0ce-86c3eda7c61d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.MachineLearningServices/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/MachineLearningServices/workspaces/templates/policy/ModelDeployFailed_0337a76f-238e-4d4d-9cd1-48b205874dbb.json
+++ b/services/MachineLearningServices/workspaces/templates/policy/ModelDeployFailed_0337a76f-238e-4d4d-9cd1-48b205874dbb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.MachineLearningServices/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/MachineLearningServices/workspaces/templates/policy/NotRespondingRuns_d3b80f22-9f1d-3038-86ff-c4dd5ba02d7a.json
+++ b/services/MachineLearningServices/workspaces/templates/policy/NotRespondingRuns_d3b80f22-9f1d-3038-86ff-c4dd5ba02d7a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.MachineLearningServices/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/MachineLearningServices/workspaces/templates/policy/QuotaUtilizationPercentage_be3f1bfc-c21a-4399-9b9f-a33ebdc470cb.json
+++ b/services/MachineLearningServices/workspaces/templates/policy/QuotaUtilizationPercentage_be3f1bfc-c21a-4399-9b9f-a33ebdc470cb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.MachineLearningServices/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/MachineLearningServices/workspaces/templates/policy/UnusableNodes_a171bc0c-676f-464b-a7b5-e50cd6c612a2.json
+++ b/services/MachineLearningServices/workspaces/templates/policy/UnusableNodes_a171bc0c-676f-464b-a7b5-e50cd6c612a2.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.MachineLearningServices/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Media/mediaservices/templates/policy-arm/AssetQuotaUsedPercentage_c0f647d6-d7f4-46ab-8591-b2f2b481e8e8.json
+++ b/services/Media/mediaservices/templates/policy-arm/AssetQuotaUsedPercentage_c0f647d6-d7f4-46ab-8591-b2f2b481e8e8.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Media/mediaservices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Media/mediaservices/templates/policy-arm/ContentKeyPolicyQuotaUsedPercentage_65d02c68-e50f-4a0e-9de9-0d52edea4af0.json
+++ b/services/Media/mediaservices/templates/policy-arm/ContentKeyPolicyQuotaUsedPercentage_65d02c68-e50f-4a0e-9de9-0d52edea4af0.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Media/mediaservices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Media/mediaservices/templates/policy-arm/StreamingPolicyQuotaUsedPercentage_9f91c6f3-e93e-4510-b72b-8678f6d38014.json
+++ b/services/Media/mediaservices/templates/policy-arm/StreamingPolicyQuotaUsedPercentage_9f91c6f3-e93e-4510-b72b-8678f6d38014.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Media/mediaservices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Media/mediaservices/templates/policy/AssetQuotaUsedPercentage_c0f647d6-d7f4-46ab-8591-b2f2b481e8e8.json
+++ b/services/Media/mediaservices/templates/policy/AssetQuotaUsedPercentage_c0f647d6-d7f4-46ab-8591-b2f2b481e8e8.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Media/mediaservices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Media/mediaservices/templates/policy/ContentKeyPolicyQuotaUsedPercentage_65d02c68-e50f-4a0e-9de9-0d52edea4af0.json
+++ b/services/Media/mediaservices/templates/policy/ContentKeyPolicyQuotaUsedPercentage_65d02c68-e50f-4a0e-9de9-0d52edea4af0.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Media/mediaservices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Media/mediaservices/templates/policy/StreamingPolicyQuotaUsedPercentage_9f91c6f3-e93e-4510-b72b-8678f6d38014.json
+++ b/services/Media/mediaservices/templates/policy/StreamingPolicyQuotaUsedPercentage_9f91c6f3-e93e-4510-b72b-8678f6d38014.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Media/mediaservices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/NetApp/netAppAccounts/templates/policy-arm/AverageReadLatency_cb7001d3-8a0e-41ed-b281-44fee5379f06.json
+++ b/services/NetApp/netAppAccounts/templates/policy-arm/AverageReadLatency_cb7001d3-8a0e-41ed-b281-44fee5379f06.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/NetApp/netAppAccounts/templates/policy-arm/capacityPoolsvolumes-AverageReadLatency_30b0cb86-ba8b-4eeb-9067-88456ec403ad.json
+++ b/services/NetApp/netAppAccounts/templates/policy-arm/capacityPoolsvolumes-AverageReadLatency_30b0cb86-ba8b-4eeb-9067-88456ec403ad.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/NetApp/netAppAccounts/templates/policy-arm/capacityPoolsvolumes-AverageWriteLatency_075f0066-51f6-4c36-8000-ce7070493674.json
+++ b/services/NetApp/netAppAccounts/templates/policy-arm/capacityPoolsvolumes-AverageWriteLatency_075f0066-51f6-4c36-8000-ce7070493674.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/NetApp/netAppAccounts/templates/policy-arm/capacityPoolsvolumes-CbsVolumeOperationComplete_27768691-301d-4938-bd8a-85598c2b50c6.json
+++ b/services/NetApp/netAppAccounts/templates/policy-arm/capacityPoolsvolumes-CbsVolumeOperationComplete_27768691-301d-4938-bd8a-85598c2b50c6.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/NetApp/netAppAccounts/templates/policy-arm/capacityPoolsvolumes-VolumeAllocatedSize_1be09484-96ee-4399-8ed4-35f5f4b5c23e.json
+++ b/services/NetApp/netAppAccounts/templates/policy-arm/capacityPoolsvolumes-VolumeAllocatedSize_1be09484-96ee-4399-8ed4-35f5f4b5c23e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/NetApp/netAppAccounts/templates/policy-arm/capacityPoolsvolumes-VolumeConsumedSizePercentage_d474e6d2-0b9a-4912-ae61-16dc23126b3f.json
+++ b/services/NetApp/netAppAccounts/templates/policy-arm/capacityPoolsvolumes-VolumeConsumedSizePercentage_d474e6d2-0b9a-4912-ae61-16dc23126b3f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/NetApp/netAppAccounts/templates/policy-arm/capacityPoolsvolumes-VolumeLogicalSize_149f6b6c-4729-4da4-af00-bccbb1cce9ae.json
+++ b/services/NetApp/netAppAccounts/templates/policy-arm/capacityPoolsvolumes-VolumeLogicalSize_149f6b6c-4729-4da4-af00-bccbb1cce9ae.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/NetApp/netAppAccounts/templates/policy/AverageReadLatency_cb7001d3-8a0e-41ed-b281-44fee5379f06.json
+++ b/services/NetApp/netAppAccounts/templates/policy/AverageReadLatency_cb7001d3-8a0e-41ed-b281-44fee5379f06.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/NetApp/netAppAccounts/templates/policy/capacityPoolsvolumes-AverageReadLatency_30b0cb86-ba8b-4eeb-9067-88456ec403ad.json
+++ b/services/NetApp/netAppAccounts/templates/policy/capacityPoolsvolumes-AverageReadLatency_30b0cb86-ba8b-4eeb-9067-88456ec403ad.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/NetApp/netAppAccounts/templates/policy/capacityPoolsvolumes-AverageWriteLatency_075f0066-51f6-4c36-8000-ce7070493674.json
+++ b/services/NetApp/netAppAccounts/templates/policy/capacityPoolsvolumes-AverageWriteLatency_075f0066-51f6-4c36-8000-ce7070493674.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/NetApp/netAppAccounts/templates/policy/capacityPoolsvolumes-CbsVolumeOperationComplete_27768691-301d-4938-bd8a-85598c2b50c6.json
+++ b/services/NetApp/netAppAccounts/templates/policy/capacityPoolsvolumes-CbsVolumeOperationComplete_27768691-301d-4938-bd8a-85598c2b50c6.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/NetApp/netAppAccounts/templates/policy/capacityPoolsvolumes-VolumeAllocatedSize_1be09484-96ee-4399-8ed4-35f5f4b5c23e.json
+++ b/services/NetApp/netAppAccounts/templates/policy/capacityPoolsvolumes-VolumeAllocatedSize_1be09484-96ee-4399-8ed4-35f5f4b5c23e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/NetApp/netAppAccounts/templates/policy/capacityPoolsvolumes-VolumeConsumedSizePercentage_d474e6d2-0b9a-4912-ae61-16dc23126b3f.json
+++ b/services/NetApp/netAppAccounts/templates/policy/capacityPoolsvolumes-VolumeConsumedSizePercentage_d474e6d2-0b9a-4912-ae61-16dc23126b3f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/NetApp/netAppAccounts/templates/policy/capacityPoolsvolumes-VolumeLogicalSize_149f6b6c-4729-4da4-af00-bccbb1cce9ae.json
+++ b/services/NetApp/netAppAccounts/templates/policy/capacityPoolsvolumes-VolumeLogicalSize_149f6b6c-4729-4da4-af00-bccbb1cce9ae.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.NetApp/netAppAccounts/capacityPools/volumes/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/ApplicationGatewayTotalTime_73fa1878-d22d-4e8d-922d-9f146454cc40.json
+++ b/services/Network/applicationGateways/templates/policy-arm/ApplicationGatewayTotalTime_73fa1878-d22d-4e8d-922d-9f146454cc40.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/AzwafSecRule_d5827f03-efb6-4257-96e2-b6e34e3bef7e.json
+++ b/services/Network/applicationGateways/templates/policy-arm/AzwafSecRule_d5827f03-efb6-4257-96e2-b6e34e3bef7e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/BackendConnectTime_e636b3ea-da2d-42f5-aedf-12b69432ac1f.json
+++ b/services/Network/applicationGateways/templates/policy-arm/BackendConnectTime_e636b3ea-da2d-42f5-aedf-12b69432ac1f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/BackendFirstByteResponseTime_3cbcad15-0bb6-423e-87c1-4d40722103d6.json
+++ b/services/Network/applicationGateways/templates/policy-arm/BackendFirstByteResponseTime_3cbcad15-0bb6-423e-87c1-4d40722103d6.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/BackendLastByteResponseTime_57c7b576-d4b2-4aa7-8c58-5c0ccbf94726.json
+++ b/services/Network/applicationGateways/templates/policy-arm/BackendLastByteResponseTime_57c7b576-d4b2-4aa7-8c58-5c0ccbf94726.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/BackendResponseStatus_c319a40c-3750-4fb4-a36d-beb3d09ef2ee.json
+++ b/services/Network/applicationGateways/templates/policy-arm/BackendResponseStatus_c319a40c-3750-4fb4-a36d-beb3d09ef2ee.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/CapacityUnits_d43ca9ef-6211-40ff-972e-fffb17923fc9.json
+++ b/services/Network/applicationGateways/templates/policy-arm/CapacityUnits_d43ca9ef-6211-40ff-972e-fffb17923fc9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/ComputeUnits_e59f4d17-2600-4bcc-ab57-6c695d37a0b2.json
+++ b/services/Network/applicationGateways/templates/policy-arm/ComputeUnits_e59f4d17-2600-4bcc-ab57-6c695d37a0b2.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/CpuUtilization_9c8be4c5-5ba3-47ef-8a0a-97144734a336.json
+++ b/services/Network/applicationGateways/templates/policy-arm/CpuUtilization_9c8be4c5-5ba3-47ef-8a0a-97144734a336.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/CurrentConnections_695b9710-e432-4521-9042-36287f0fc5ba.json
+++ b/services/Network/applicationGateways/templates/policy-arm/CurrentConnections_695b9710-e432-4521-9042-36287f0fc5ba.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/EstimatedBilledCapacityUnits_e77b6820-e115-4e33-97c1-9bb902eec3b2.json
+++ b/services/Network/applicationGateways/templates/policy-arm/EstimatedBilledCapacityUnits_e77b6820-e115-4e33-97c1-9bb902eec3b2.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/FailedRequests_73afde26-bd0c-4c31-8801-5b2444629448.json
+++ b/services/Network/applicationGateways/templates/policy-arm/FailedRequests_73afde26-bd0c-4c31-8801-5b2444629448.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/HealthyHostCount_f03d1a7a-6bd3-42ae-89db-b36fd6ce5633.json
+++ b/services/Network/applicationGateways/templates/policy-arm/HealthyHostCount_f03d1a7a-6bd3-42ae-89db-b36fd6ce5633.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/ResponseStatus_6d77d848-23b1-4ff4-b9de-d421845d9566.json
+++ b/services/Network/applicationGateways/templates/policy-arm/ResponseStatus_6d77d848-23b1-4ff4-b9de-d421845d9566.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/Throughput_7640663c-b2f7-41bf-9419-be5e8cfdf74e.json
+++ b/services/Network/applicationGateways/templates/policy-arm/Throughput_7640663c-b2f7-41bf-9419-be5e8cfdf74e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/TotalRequests_06982a17-4def-405d-bb59-4ecfb6486f9e.json
+++ b/services/Network/applicationGateways/templates/policy-arm/TotalRequests_06982a17-4def-405d-bb59-4ecfb6486f9e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy-arm/UnhealthyHostCount_c88acf4e-2d23-4ac7-93fb-e44ded53ecee.json
+++ b/services/Network/applicationGateways/templates/policy-arm/UnhealthyHostCount_c88acf4e-2d23-4ac7-93fb-e44ded53ecee.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/ApplicationGatewayTotalTime_73fa1878-d22d-4e8d-922d-9f146454cc40.json
+++ b/services/Network/applicationGateways/templates/policy/ApplicationGatewayTotalTime_73fa1878-d22d-4e8d-922d-9f146454cc40.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/AzwafSecRule_d5827f03-efb6-4257-96e2-b6e34e3bef7e.json
+++ b/services/Network/applicationGateways/templates/policy/AzwafSecRule_d5827f03-efb6-4257-96e2-b6e34e3bef7e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/BackendConnectTime_e636b3ea-da2d-42f5-aedf-12b69432ac1f.json
+++ b/services/Network/applicationGateways/templates/policy/BackendConnectTime_e636b3ea-da2d-42f5-aedf-12b69432ac1f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/BackendFirstByteResponseTime_3cbcad15-0bb6-423e-87c1-4d40722103d6.json
+++ b/services/Network/applicationGateways/templates/policy/BackendFirstByteResponseTime_3cbcad15-0bb6-423e-87c1-4d40722103d6.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/BackendLastByteResponseTime_57c7b576-d4b2-4aa7-8c58-5c0ccbf94726.json
+++ b/services/Network/applicationGateways/templates/policy/BackendLastByteResponseTime_57c7b576-d4b2-4aa7-8c58-5c0ccbf94726.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/BackendResponseStatus_c319a40c-3750-4fb4-a36d-beb3d09ef2ee.json
+++ b/services/Network/applicationGateways/templates/policy/BackendResponseStatus_c319a40c-3750-4fb4-a36d-beb3d09ef2ee.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/CapacityUnits_d43ca9ef-6211-40ff-972e-fffb17923fc9.json
+++ b/services/Network/applicationGateways/templates/policy/CapacityUnits_d43ca9ef-6211-40ff-972e-fffb17923fc9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/ComputeUnits_e59f4d17-2600-4bcc-ab57-6c695d37a0b2.json
+++ b/services/Network/applicationGateways/templates/policy/ComputeUnits_e59f4d17-2600-4bcc-ab57-6c695d37a0b2.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/CpuUtilization_9c8be4c5-5ba3-47ef-8a0a-97144734a336.json
+++ b/services/Network/applicationGateways/templates/policy/CpuUtilization_9c8be4c5-5ba3-47ef-8a0a-97144734a336.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/CurrentConnections_695b9710-e432-4521-9042-36287f0fc5ba.json
+++ b/services/Network/applicationGateways/templates/policy/CurrentConnections_695b9710-e432-4521-9042-36287f0fc5ba.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/EstimatedBilledCapacityUnits_e77b6820-e115-4e33-97c1-9bb902eec3b2.json
+++ b/services/Network/applicationGateways/templates/policy/EstimatedBilledCapacityUnits_e77b6820-e115-4e33-97c1-9bb902eec3b2.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/FailedRequests_73afde26-bd0c-4c31-8801-5b2444629448.json
+++ b/services/Network/applicationGateways/templates/policy/FailedRequests_73afde26-bd0c-4c31-8801-5b2444629448.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/HealthyHostCount_f03d1a7a-6bd3-42ae-89db-b36fd6ce5633.json
+++ b/services/Network/applicationGateways/templates/policy/HealthyHostCount_f03d1a7a-6bd3-42ae-89db-b36fd6ce5633.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/ResponseStatus_6d77d848-23b1-4ff4-b9de-d421845d9566.json
+++ b/services/Network/applicationGateways/templates/policy/ResponseStatus_6d77d848-23b1-4ff4-b9de-d421845d9566.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/Throughput_7640663c-b2f7-41bf-9419-be5e8cfdf74e.json
+++ b/services/Network/applicationGateways/templates/policy/Throughput_7640663c-b2f7-41bf-9419-be5e8cfdf74e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/TotalRequests_06982a17-4def-405d-bb59-4ecfb6486f9e.json
+++ b/services/Network/applicationGateways/templates/policy/TotalRequests_06982a17-4def-405d-bb59-4ecfb6486f9e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/applicationGateways/templates/policy/UnhealthyHostCount_c88acf4e-2d23-4ac7-93fb-e44ded53ecee.json
+++ b/services/Network/applicationGateways/templates/policy/UnhealthyHostCount_c88acf4e-2d23-4ac7-93fb-e44ded53ecee.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/azureFirewalls/templates/policy-arm/FirewallHealth_0ff72493-3822-4315-a146-8977a0963e39.json
+++ b/services/Network/azureFirewalls/templates/policy-arm/FirewallHealth_0ff72493-3822-4315-a146-8977a0963e39.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/azureFirewalls/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/azureFirewalls/templates/policy-arm/SNATPortUtilization_b23f1e82-a791-4610-aaa6-2d960b48b81d.json
+++ b/services/Network/azureFirewalls/templates/policy-arm/SNATPortUtilization_b23f1e82-a791-4610-aaa6-2d960b48b81d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/azureFirewalls/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/azureFirewalls/templates/policy-arm/Throughput_e8fdab4c-cc9a-4729-8619-a0f468f4dfdc.json
+++ b/services/Network/azureFirewalls/templates/policy-arm/Throughput_e8fdab4c-cc9a-4729-8619-a0f468f4dfdc.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/azureFirewalls/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/azureFirewalls/templates/policy/FirewallHealth_0ff72493-3822-4315-a146-8977a0963e39.json
+++ b/services/Network/azureFirewalls/templates/policy/FirewallHealth_0ff72493-3822-4315-a146-8977a0963e39.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/azureFirewalls/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/azureFirewalls/templates/policy/SNATPortUtilization_b23f1e82-a791-4610-aaa6-2d960b48b81d.json
+++ b/services/Network/azureFirewalls/templates/policy/SNATPortUtilization_b23f1e82-a791-4610-aaa6-2d960b48b81d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/azureFirewalls/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/azureFirewalls/templates/policy/Throughput_e8fdab4c-cc9a-4729-8619-a0f468f4dfdc.json
+++ b/services/Network/azureFirewalls/templates/policy/Throughput_e8fdab4c-cc9a-4729-8619-a0f468f4dfdc.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/azureFirewalls/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/bastionHosts/templates/policy-arm/BastionCommunicationStatus_afd848a8-8b18-410c-bcc1-1b6f06a5a231.json
+++ b/services/Network/bastionHosts/templates/policy-arm/BastionCommunicationStatus_afd848a8-8b18-410c-bcc1-1b6f06a5a231.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/bastionHosts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/bastionHosts/templates/policy-arm/CPUUsage_0d4040d7-4478-46b5-98e0-14bb2f7b8ecf.json
+++ b/services/Network/bastionHosts/templates/policy-arm/CPUUsage_0d4040d7-4478-46b5-98e0-14bb2f7b8ecf.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/bastionHosts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/bastionHosts/templates/policy-arm/MemoryUsage_2c288e52-422b-4f7e-85cf-feb3d08a1602.json
+++ b/services/Network/bastionHosts/templates/policy-arm/MemoryUsage_2c288e52-422b-4f7e-85cf-feb3d08a1602.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/bastionHosts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/bastionHosts/templates/policy/BastionCommunicationStatus_afd848a8-8b18-410c-bcc1-1b6f06a5a231.json
+++ b/services/Network/bastionHosts/templates/policy/BastionCommunicationStatus_afd848a8-8b18-410c-bcc1-1b6f06a5a231.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/bastionHosts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/bastionHosts/templates/policy/CPUUsage_0d4040d7-4478-46b5-98e0-14bb2f7b8ecf.json
+++ b/services/Network/bastionHosts/templates/policy/CPUUsage_0d4040d7-4478-46b5-98e0-14bb2f7b8ecf.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/bastionHosts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/bastionHosts/templates/policy/MemoryUsage_2c288e52-422b-4f7e-85cf-feb3d08a1602.json
+++ b/services/Network/bastionHosts/templates/policy/MemoryUsage_2c288e52-422b-4f7e-85cf-feb3d08a1602.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/bastionHosts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/connections/templates/policy-arm/BitsInPerSecond_494aa5d6-444d-4c86-9de5-431b3e12a233.json
+++ b/services/Network/connections/templates/policy-arm/BitsInPerSecond_494aa5d6-444d-4c86-9de5-431b3e12a233.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/connections/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/connections/templates/policy-arm/BitsOutPerSecond_b050d767-098e-4947-aa88-2a3090e62eab.json
+++ b/services/Network/connections/templates/policy-arm/BitsOutPerSecond_b050d767-098e-4947-aa88-2a3090e62eab.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/connections/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/connections/templates/policy/BitsInPerSecond_494aa5d6-444d-4c86-9de5-431b3e12a233.json
+++ b/services/Network/connections/templates/policy/BitsInPerSecond_494aa5d6-444d-4c86-9de5-431b3e12a233.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/connections/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/connections/templates/policy/BitsOutPerSecond_b050d767-098e-4947-aa88-2a3090e62eab.json
+++ b/services/Network/connections/templates/policy/BitsOutPerSecond_b050d767-098e-4947-aa88-2a3090e62eab.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/connections/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/dnszones/templates/policy-arm/QueryVolume_0d1709ed-805e-4ca1-8490-f2d6b393e92f.json
+++ b/services/Network/dnszones/templates/policy-arm/QueryVolume_0d1709ed-805e-4ca1-8490-f2d6b393e92f.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/dnszones/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/dnszones/templates/policy-arm/RecordSetCapacityUtilization_dfbcdbb7-fed8-49c5-8a10-ed34d20fc617.json
+++ b/services/Network/dnszones/templates/policy-arm/RecordSetCapacityUtilization_dfbcdbb7-fed8-49c5-8a10-ed34d20fc617.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/dnszones/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/dnszones/templates/policy/QueryVolume_0d1709ed-805e-4ca1-8490-f2d6b393e92f.json
+++ b/services/Network/dnszones/templates/policy/QueryVolume_0d1709ed-805e-4ca1-8490-f2d6b393e92f.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/dnszones/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/dnszones/templates/policy/RecordSetCapacityUtilization_dfbcdbb7-fed8-49c5-8a10-ed34d20fc617.json
+++ b/services/Network/dnszones/templates/policy/RecordSetCapacityUtilization_dfbcdbb7-fed8-49c5-8a10-ed34d20fc617.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/dnszones/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy-arm/ArpAvailability_efc101c0-0623-4928-86a7-6f2d37faf24b.json
+++ b/services/Network/expressRouteCircuits/templates/policy-arm/ArpAvailability_efc101c0-0623-4928-86a7-6f2d37faf24b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy-arm/BgpAvailability_37302f31-86e2-45c8-a39f-d0b41c1271df.json
+++ b/services/Network/expressRouteCircuits/templates/policy-arm/BgpAvailability_37302f31-86e2-45c8-a39f-d0b41c1271df.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy-arm/BitsInPerSecond_2e4ae517-3d35-4677-a4b0-441ca19e7670.json
+++ b/services/Network/expressRouteCircuits/templates/policy-arm/BitsInPerSecond_2e4ae517-3d35-4677-a4b0-441ca19e7670.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy-arm/BitsOutPerSecond_cc428042-1a21-43f7-b5f8-598dea50f4a2.json
+++ b/services/Network/expressRouteCircuits/templates/policy-arm/BitsOutPerSecond_cc428042-1a21-43f7-b5f8-598dea50f4a2.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy-arm/QosDropBitsInPerSecond_d56551a8-1355-4aa3-871e-e20e1ce40f05.json
+++ b/services/Network/expressRouteCircuits/templates/policy-arm/QosDropBitsInPerSecond_d56551a8-1355-4aa3-871e-e20e1ce40f05.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy-arm/QosDropBitsOutPerSecond_5808dbdb-712e-4bd3-b92e-4a08388c32c6.json
+++ b/services/Network/expressRouteCircuits/templates/policy-arm/QosDropBitsOutPerSecond_5808dbdb-712e-4bd3-b92e-4a08388c32c6.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy-arm/fastpathroutescountforcircuit_afc45643-7bd3-4321-9924-ac710bb78f88.json
+++ b/services/Network/expressRouteCircuits/templates/policy-arm/fastpathroutescountforcircuit_afc45643-7bd3-4321-9924-ac710bb78f88.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy-arm/globalreachbitsinpersecond_47fe6c76-47a0-433f-92d6-a23d9f573771.json
+++ b/services/Network/expressRouteCircuits/templates/policy-arm/globalreachbitsinpersecond_47fe6c76-47a0-433f-92d6-a23d9f573771.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy-arm/globalreachbitsoutpersecond_8a586e59-0f53-41bd-8406-174f9f0ecf7e.json
+++ b/services/Network/expressRouteCircuits/templates/policy-arm/globalreachbitsoutpersecond_8a586e59-0f53-41bd-8406-174f9f0ecf7e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy/ArpAvailability_efc101c0-0623-4928-86a7-6f2d37faf24b.json
+++ b/services/Network/expressRouteCircuits/templates/policy/ArpAvailability_efc101c0-0623-4928-86a7-6f2d37faf24b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy/BgpAvailability_37302f31-86e2-45c8-a39f-d0b41c1271df.json
+++ b/services/Network/expressRouteCircuits/templates/policy/BgpAvailability_37302f31-86e2-45c8-a39f-d0b41c1271df.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy/BitsInPerSecond_2e4ae517-3d35-4677-a4b0-441ca19e7670.json
+++ b/services/Network/expressRouteCircuits/templates/policy/BitsInPerSecond_2e4ae517-3d35-4677-a4b0-441ca19e7670.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy/BitsOutPerSecond_cc428042-1a21-43f7-b5f8-598dea50f4a2.json
+++ b/services/Network/expressRouteCircuits/templates/policy/BitsOutPerSecond_cc428042-1a21-43f7-b5f8-598dea50f4a2.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy/QosDropBitsInPerSecond_d56551a8-1355-4aa3-871e-e20e1ce40f05.json
+++ b/services/Network/expressRouteCircuits/templates/policy/QosDropBitsInPerSecond_d56551a8-1355-4aa3-871e-e20e1ce40f05.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy/QosDropBitsOutPerSecond_5808dbdb-712e-4bd3-b92e-4a08388c32c6.json
+++ b/services/Network/expressRouteCircuits/templates/policy/QosDropBitsOutPerSecond_5808dbdb-712e-4bd3-b92e-4a08388c32c6.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy/fastpathroutescountforcircuit_afc45643-7bd3-4321-9924-ac710bb78f88.json
+++ b/services/Network/expressRouteCircuits/templates/policy/fastpathroutescountforcircuit_afc45643-7bd3-4321-9924-ac710bb78f88.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy/globalreachbitsinpersecond_47fe6c76-47a0-433f-92d6-a23d9f573771.json
+++ b/services/Network/expressRouteCircuits/templates/policy/globalreachbitsinpersecond_47fe6c76-47a0-433f-92d6-a23d9f573771.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteCircuits/templates/policy/globalreachbitsoutpersecond_8a586e59-0f53-41bd-8406-174f9f0ecf7e.json
+++ b/services/Network/expressRouteCircuits/templates/policy/globalreachbitsoutpersecond_8a586e59-0f53-41bd-8406-174f9f0ecf7e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteCircuits/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteGateways/templates/policy-arm/ERGatewayConnectionBitsInPerSecond_ff147700-c9e6-4063-bb23-45500c00067a.json
+++ b/services/Network/expressRouteGateways/templates/policy-arm/ERGatewayConnectionBitsInPerSecond_ff147700-c9e6-4063-bb23-45500c00067a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteGateways/templates/policy-arm/ERGatewayConnectionBitsOutPerSecond_4d5c7854-e044-4dd6-971b-df433fa3ad37.json
+++ b/services/Network/expressRouteGateways/templates/policy-arm/ERGatewayConnectionBitsOutPerSecond_4d5c7854-e044-4dd6-971b-df433fa3ad37.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteGateways/templates/policy-arm/ExpressRouteGatewayCpuUtilization_af1ba971-9b73-4b7f-8040-5eff9f5778d5.json
+++ b/services/Network/expressRouteGateways/templates/policy-arm/ExpressRouteGatewayCpuUtilization_af1ba971-9b73-4b7f-8040-5eff9f5778d5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteGateways/templates/policy/ERGatewayConnectionBitsInPerSecond_ff147700-c9e6-4063-bb23-45500c00067a.json
+++ b/services/Network/expressRouteGateways/templates/policy/ERGatewayConnectionBitsInPerSecond_ff147700-c9e6-4063-bb23-45500c00067a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteGateways/templates/policy/ERGatewayConnectionBitsOutPerSecond_4d5c7854-e044-4dd6-971b-df433fa3ad37.json
+++ b/services/Network/expressRouteGateways/templates/policy/ERGatewayConnectionBitsOutPerSecond_4d5c7854-e044-4dd6-971b-df433fa3ad37.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRouteGateways/templates/policy/ExpressRouteGatewayCpuUtilization_af1ba971-9b73-4b7f-8040-5eff9f5778d5.json
+++ b/services/Network/expressRouteGateways/templates/policy/ExpressRouteGatewayCpuUtilization_af1ba971-9b73-4b7f-8040-5eff9f5778d5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRouteGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRoutePorts/templates/policy-arm/LineProtocol_0fac138d-cf48-4dc2-ac02-053d0b24e620.json
+++ b/services/Network/expressRoutePorts/templates/policy-arm/LineProtocol_0fac138d-cf48-4dc2-ac02-053d0b24e620.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRoutePorts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRoutePorts/templates/policy-arm/PortBitsInPerSecond_08dad105-6416-4348-9feb-339f73e24262.json
+++ b/services/Network/expressRoutePorts/templates/policy-arm/PortBitsInPerSecond_08dad105-6416-4348-9feb-339f73e24262.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRoutePorts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRoutePorts/templates/policy-arm/PortBitsOutPerSecond_ca29484c-b6e5-467e-984d-567e262380d7.json
+++ b/services/Network/expressRoutePorts/templates/policy-arm/PortBitsOutPerSecond_ca29484c-b6e5-467e-984d-567e262380d7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRoutePorts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRoutePorts/templates/policy-arm/RxLightLevel-High_ceaeccae-ffa5-4c8c-8415-c7be8266977d.json
+++ b/services/Network/expressRoutePorts/templates/policy-arm/RxLightLevel-High_ceaeccae-ffa5-4c8c-8415-c7be8266977d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRoutePorts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRoutePorts/templates/policy-arm/RxLightLevel-Low_bf37971c-60f4-4652-a059-7607b1d6d31b.json
+++ b/services/Network/expressRoutePorts/templates/policy-arm/RxLightLevel-Low_bf37971c-60f4-4652-a059-7607b1d6d31b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRoutePorts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRoutePorts/templates/policy-arm/TxLightLevel-High_dee0e83f-8d5c-4735-9730-1a850354e4b1.json
+++ b/services/Network/expressRoutePorts/templates/policy-arm/TxLightLevel-High_dee0e83f-8d5c-4735-9730-1a850354e4b1.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRoutePorts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRoutePorts/templates/policy-arm/TxLightLevel-Low_378a85f8-f24c-4ce6-bfb0-eb5ccbd61768.json
+++ b/services/Network/expressRoutePorts/templates/policy-arm/TxLightLevel-Low_378a85f8-f24c-4ce6-bfb0-eb5ccbd61768.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRoutePorts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRoutePorts/templates/policy/LineProtocol_0fac138d-cf48-4dc2-ac02-053d0b24e620.json
+++ b/services/Network/expressRoutePorts/templates/policy/LineProtocol_0fac138d-cf48-4dc2-ac02-053d0b24e620.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRoutePorts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRoutePorts/templates/policy/PortBitsInPerSecond_08dad105-6416-4348-9feb-339f73e24262.json
+++ b/services/Network/expressRoutePorts/templates/policy/PortBitsInPerSecond_08dad105-6416-4348-9feb-339f73e24262.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRoutePorts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRoutePorts/templates/policy/PortBitsOutPerSecond_ca29484c-b6e5-467e-984d-567e262380d7.json
+++ b/services/Network/expressRoutePorts/templates/policy/PortBitsOutPerSecond_ca29484c-b6e5-467e-984d-567e262380d7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRoutePorts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRoutePorts/templates/policy/RxLightLevel-High_ceaeccae-ffa5-4c8c-8415-c7be8266977d.json
+++ b/services/Network/expressRoutePorts/templates/policy/RxLightLevel-High_ceaeccae-ffa5-4c8c-8415-c7be8266977d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRoutePorts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRoutePorts/templates/policy/RxLightLevel-Low_bf37971c-60f4-4652-a059-7607b1d6d31b.json
+++ b/services/Network/expressRoutePorts/templates/policy/RxLightLevel-Low_bf37971c-60f4-4652-a059-7607b1d6d31b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRoutePorts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRoutePorts/templates/policy/TxLightLevel-High_dee0e83f-8d5c-4735-9730-1a850354e4b1.json
+++ b/services/Network/expressRoutePorts/templates/policy/TxLightLevel-High_dee0e83f-8d5c-4735-9730-1a850354e4b1.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRoutePorts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/expressRoutePorts/templates/policy/TxLightLevel-Low_378a85f8-f24c-4ce6-bfb0-eb5ccbd61768.json
+++ b/services/Network/expressRoutePorts/templates/policy/TxLightLevel-Low_378a85f8-f24c-4ce6-bfb0-eb5ccbd61768.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/expressRoutePorts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/frontDoors/templates/policy-arm/BackendHealthPercentage_15a67b66-30eb-4d0f-aa98-7350304347d0.json
+++ b/services/Network/frontDoors/templates/policy-arm/BackendHealthPercentage_15a67b66-30eb-4d0f-aa98-7350304347d0.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/frontdoors/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/frontDoors/templates/policy-arm/BackendRequestLatency_a4de0a96-9e79-4a03-a91c-cbd09ea3d29a.json
+++ b/services/Network/frontDoors/templates/policy-arm/BackendRequestLatency_a4de0a96-9e79-4a03-a91c-cbd09ea3d29a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/frontdoors/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/frontDoors/templates/policy-arm/RequestCount_5ec4f863-ec6f-4fe8-b258-a53b3183138a.json
+++ b/services/Network/frontDoors/templates/policy-arm/RequestCount_5ec4f863-ec6f-4fe8-b258-a53b3183138a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/frontdoors/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/frontDoors/templates/policy-arm/TotalLatency_1987b5a9-bbc3-43c6-af35-cd69e61fe043.json
+++ b/services/Network/frontDoors/templates/policy-arm/TotalLatency_1987b5a9-bbc3-43c6-af35-cd69e61fe043.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/frontdoors/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/frontDoors/templates/policy/BackendHealthPercentage_15a67b66-30eb-4d0f-aa98-7350304347d0.json
+++ b/services/Network/frontDoors/templates/policy/BackendHealthPercentage_15a67b66-30eb-4d0f-aa98-7350304347d0.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/frontdoors/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/frontDoors/templates/policy/BackendRequestLatency_a4de0a96-9e79-4a03-a91c-cbd09ea3d29a.json
+++ b/services/Network/frontDoors/templates/policy/BackendRequestLatency_a4de0a96-9e79-4a03-a91c-cbd09ea3d29a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/frontdoors/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/frontDoors/templates/policy/RequestCount_5ec4f863-ec6f-4fe8-b258-a53b3183138a.json
+++ b/services/Network/frontDoors/templates/policy/RequestCount_5ec4f863-ec6f-4fe8-b258-a53b3183138a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/frontdoors/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/frontDoors/templates/policy/TotalLatency_1987b5a9-bbc3-43c6-af35-cd69e61fe043.json
+++ b/services/Network/frontDoors/templates/policy/TotalLatency_1987b5a9-bbc3-43c6-af35-cd69e61fe043.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/frontdoors/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy-arm/AllocatedSnatPorts_5b64d91c-54de-4f8c-a5d6-054967f4ceaf.json
+++ b/services/Network/loadBalancers/templates/policy-arm/AllocatedSnatPorts_5b64d91c-54de-4f8c-a5d6-054967f4ceaf.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy-arm/ByteCount_d15179b2-4b57-41e4-997b-dc7c380963d9.json
+++ b/services/Network/loadBalancers/templates/policy-arm/ByteCount_d15179b2-4b57-41e4-997b-dc7c380963d9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy-arm/DipAvailability_a39efd3b-04ef-48d4-a862-053092bdd6e5.json
+++ b/services/Network/loadBalancers/templates/policy-arm/DipAvailability_a39efd3b-04ef-48d4-a862-053092bdd6e5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy-arm/GlobalBackendAvailability_055c20da-0d21-4c6a-a80b-f2c4b3887804.json
+++ b/services/Network/loadBalancers/templates/policy-arm/GlobalBackendAvailability_055c20da-0d21-4c6a-a80b-f2c4b3887804.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy-arm/PacketCount_d766dc3e-42cc-42a7-ba4f-3c1d7fa295c5.json
+++ b/services/Network/loadBalancers/templates/policy-arm/PacketCount_d766dc3e-42cc-42a7-ba4f-3c1d7fa295c5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy-arm/SYNCount_94c90db6-8fd7-460c-b704-c2a429913376.json
+++ b/services/Network/loadBalancers/templates/policy-arm/SYNCount_94c90db6-8fd7-460c-b704-c2a429913376.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy-arm/SnatConnectionCount_39d3123b-daaa-4f70-97a3-8a4f326104af.json
+++ b/services/Network/loadBalancers/templates/policy-arm/SnatConnectionCount_39d3123b-daaa-4f70-97a3-8a4f326104af.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy-arm/UsedSNATPorts_a92cb746-f19f-450b-b413-8b9710b0176b.json
+++ b/services/Network/loadBalancers/templates/policy-arm/UsedSNATPorts_a92cb746-f19f-450b-b413-8b9710b0176b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy-arm/VipAvailability_b239797f-e627-4e48-8609-94db72098c3d.json
+++ b/services/Network/loadBalancers/templates/policy-arm/VipAvailability_b239797f-e627-4e48-8609-94db72098c3d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy/AllocatedSnatPorts_5b64d91c-54de-4f8c-a5d6-054967f4ceaf.json
+++ b/services/Network/loadBalancers/templates/policy/AllocatedSnatPorts_5b64d91c-54de-4f8c-a5d6-054967f4ceaf.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy/Bytecount_d15179b2-4b57-41e4-997b-dc7c380963d9.json
+++ b/services/Network/loadBalancers/templates/policy/Bytecount_d15179b2-4b57-41e4-997b-dc7c380963d9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy/DipAvailability_a39efd3b-04ef-48d4-a862-053092bdd6e5.json
+++ b/services/Network/loadBalancers/templates/policy/DipAvailability_a39efd3b-04ef-48d4-a862-053092bdd6e5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy/GlobalBackendAvailability_055c20da-0d21-4c6a-a80b-f2c4b3887804.json
+++ b/services/Network/loadBalancers/templates/policy/GlobalBackendAvailability_055c20da-0d21-4c6a-a80b-f2c4b3887804.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy/PacketCount_d766dc3e-42cc-42a7-ba4f-3c1d7fa295c5.json
+++ b/services/Network/loadBalancers/templates/policy/PacketCount_d766dc3e-42cc-42a7-ba4f-3c1d7fa295c5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy/SYNCount_94c90db6-8fd7-460c-b704-c2a429913376.json
+++ b/services/Network/loadBalancers/templates/policy/SYNCount_94c90db6-8fd7-460c-b704-c2a429913376.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy/SnatConnectionCount_39d3123b-daaa-4f70-97a3-8a4f326104af.json
+++ b/services/Network/loadBalancers/templates/policy/SnatConnectionCount_39d3123b-daaa-4f70-97a3-8a4f326104af.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy/UsedSNATPorts_a92cb746-f19f-450b-b413-8b9710b0176b.json
+++ b/services/Network/loadBalancers/templates/policy/UsedSNATPorts_a92cb746-f19f-450b-b413-8b9710b0176b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/loadBalancers/templates/policy/VipAvailability_b239797f-e627-4e48-8609-94db72098c3d.json
+++ b/services/Network/loadBalancers/templates/policy/VipAvailability_b239797f-e627-4e48-8609-94db72098c3d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/natGateways/templates/policy-arm/ByteCount_e1808855-9a4d-464d-b75a-a41183c520bd.json
+++ b/services/Network/natGateways/templates/policy-arm/ByteCount_e1808855-9a4d-464d-b75a-a41183c520bd.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/natGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/natGateways/templates/policy-arm/DatapathAvailability_7cb8821d-c178-4c02-ba8a-1c6fcbcde2e8.json
+++ b/services/Network/natGateways/templates/policy-arm/DatapathAvailability_7cb8821d-c178-4c02-ba8a-1c6fcbcde2e8.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/natGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/natGateways/templates/policy-arm/PacketDropCount_53bb49ec-ed5b-40c3-999b-efefa9be4536.json
+++ b/services/Network/natGateways/templates/policy-arm/PacketDropCount_53bb49ec-ed5b-40c3-999b-efefa9be4536.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/natGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/natGateways/templates/policy-arm/SNATConnectionCount_4c2e410b-644e-4331-a55c-19bfdc3e4754.json
+++ b/services/Network/natGateways/templates/policy-arm/SNATConnectionCount_4c2e410b-644e-4331-a55c-19bfdc3e4754.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/natGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/natGateways/templates/policy-arm/TotalConnectionCount_c57f27b1-151c-4d27-a77e-b85547d817f7.json
+++ b/services/Network/natGateways/templates/policy-arm/TotalConnectionCount_c57f27b1-151c-4d27-a77e-b85547d817f7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/natGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/natGateways/templates/policy/ByteCount_e1808855-9a4d-464d-b75a-a41183c520bd.json
+++ b/services/Network/natGateways/templates/policy/ByteCount_e1808855-9a4d-464d-b75a-a41183c520bd.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/natGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/natGateways/templates/policy/DatapathAvailability_7cb8821d-c178-4c02-ba8a-1c6fcbcde2e8.json
+++ b/services/Network/natGateways/templates/policy/DatapathAvailability_7cb8821d-c178-4c02-ba8a-1c6fcbcde2e8.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/natGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/natGateways/templates/policy/PacketDropCount_53bb49ec-ed5b-40c3-999b-efefa9be4536.json
+++ b/services/Network/natGateways/templates/policy/PacketDropCount_53bb49ec-ed5b-40c3-999b-efefa9be4536.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/natGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/natGateways/templates/policy/SNATConnectionCount_4c2e410b-644e-4331-a55c-19bfdc3e4754.json
+++ b/services/Network/natGateways/templates/policy/SNATConnectionCount_4c2e410b-644e-4331-a55c-19bfdc3e4754.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/natGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/natGateways/templates/policy/TotalConnectionCount_c57f27b1-151c-4d27-a77e-b85547d817f7.json
+++ b/services/Network/natGateways/templates/policy/TotalConnectionCount_c57f27b1-151c-4d27-a77e-b85547d817f7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/natGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/networkWatchers/templates/policy-arm/connectionMonitors-ChecksFailedPercent_61cbc62a-1382-4581-850f-4ea69d8a9615.json
+++ b/services/Network/networkWatchers/templates/policy-arm/connectionMonitors-ChecksFailedPercent_61cbc62a-1382-4581-850f-4ea69d8a9615.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/networkWatchers/connectionMonitors/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/networkWatchers/templates/policy-arm/connectionMonitors-ProbesFailedPercent_7659c9f8-c257-4f0b-a8d9-1ceae6177ff5.json
+++ b/services/Network/networkWatchers/templates/policy-arm/connectionMonitors-ProbesFailedPercent_7659c9f8-c257-4f0b-a8d9-1ceae6177ff5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/networkWatchers/connectionMonitors/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/networkWatchers/templates/policy-arm/connectionMonitors-RoundTripTimeMs_1744119b-cabb-4ac4-97c6-a61249a6c5be.json
+++ b/services/Network/networkWatchers/templates/policy-arm/connectionMonitors-RoundTripTimeMs_1744119b-cabb-4ac4-97c6-a61249a6c5be.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/networkWatchers/connectionMonitors/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/networkWatchers/templates/policy-arm/connectionMonitors-TestResult_370ff9a8-11ea-469a-9f52-b1c39d61c39d.json
+++ b/services/Network/networkWatchers/templates/policy-arm/connectionMonitors-TestResult_370ff9a8-11ea-469a-9f52-b1c39d61c39d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/networkWatchers/connectionMonitors/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/networkWatchers/templates/policy/connectionMonitors-ChecksFailedPercent_61cbc62a-1382-4581-850f-4ea69d8a9615.json
+++ b/services/Network/networkWatchers/templates/policy/connectionMonitors-ChecksFailedPercent_61cbc62a-1382-4581-850f-4ea69d8a9615.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/networkWatchers/connectionMonitors/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/networkWatchers/templates/policy/connectionMonitors-ProbesFailedPercent_7659c9f8-c257-4f0b-a8d9-1ceae6177ff5.json
+++ b/services/Network/networkWatchers/templates/policy/connectionMonitors-ProbesFailedPercent_7659c9f8-c257-4f0b-a8d9-1ceae6177ff5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/networkWatchers/connectionMonitors/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/networkWatchers/templates/policy/connectionMonitors-RoundTripTimeMs_1744119b-cabb-4ac4-97c6-a61249a6c5be.json
+++ b/services/Network/networkWatchers/templates/policy/connectionMonitors-RoundTripTimeMs_1744119b-cabb-4ac4-97c6-a61249a6c5be.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/networkWatchers/connectionMonitors/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/networkWatchers/templates/policy/connectionMonitors-TestResult_370ff9a8-11ea-469a-9f52-b1c39d61c39d.json
+++ b/services/Network/networkWatchers/templates/policy/connectionMonitors-TestResult_370ff9a8-11ea-469a-9f52-b1c39d61c39d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/networkWatchers/connectionMonitors/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/privateDnsZones/templates/policy-arm/QueryVolume_4d219611-6487-4fcf-9bac-29cd9e5046a9.json
+++ b/services/Network/privateDnsZones/templates/policy-arm/QueryVolume_4d219611-6487-4fcf-9bac-29cd9e5046a9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/privateDnsZones/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/privateDnsZones/templates/policy-arm/RecordSetCapacityUtilization_95473b2f-74ea-4929-bf22-f6f3be4ccbd5.json
+++ b/services/Network/privateDnsZones/templates/policy-arm/RecordSetCapacityUtilization_95473b2f-74ea-4929-bf22-f6f3be4ccbd5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/privateDnsZones/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/privateDnsZones/templates/policy-arm/RecordSetCount_b410b69e-8bd5-44fe-899d-f4d5dce9931a.json
+++ b/services/Network/privateDnsZones/templates/policy-arm/RecordSetCount_b410b69e-8bd5-44fe-899d-f4d5dce9931a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/privateDnsZones/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/privateDnsZones/templates/policy-arm/VirtualNetworkLinkCapacityUtilization_e71f87d1-81bb-4ee6-802d-9da4ab1cb3e3.json
+++ b/services/Network/privateDnsZones/templates/policy-arm/VirtualNetworkLinkCapacityUtilization_e71f87d1-81bb-4ee6-802d-9da4ab1cb3e3.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/privateDnsZones/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/privateDnsZones/templates/policy-arm/VirtualNetworkWithRegistrationCapacityUtilization_c064753f-ea6a-4940-b603-975adb5127ae.json
+++ b/services/Network/privateDnsZones/templates/policy-arm/VirtualNetworkWithRegistrationCapacityUtilization_c064753f-ea6a-4940-b603-975adb5127ae.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/privateDnsZones/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/privateDnsZones/templates/policy/QueryVolume_4d219611-6487-4fcf-9bac-29cd9e5046a9.json
+++ b/services/Network/privateDnsZones/templates/policy/QueryVolume_4d219611-6487-4fcf-9bac-29cd9e5046a9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/privateDnsZones/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/privateDnsZones/templates/policy/RecordSetCapacityUtilization_95473b2f-74ea-4929-bf22-f6f3be4ccbd5.json
+++ b/services/Network/privateDnsZones/templates/policy/RecordSetCapacityUtilization_95473b2f-74ea-4929-bf22-f6f3be4ccbd5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/privateDnsZones/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/privateDnsZones/templates/policy/RecordSetCount_b410b69e-8bd5-44fe-899d-f4d5dce9931a.json
+++ b/services/Network/privateDnsZones/templates/policy/RecordSetCount_b410b69e-8bd5-44fe-899d-f4d5dce9931a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/privateDnsZones/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/privateDnsZones/templates/policy/VirtualNetworkLinkCapacityUtilization_e71f87d1-81bb-4ee6-802d-9da4ab1cb3e3.json
+++ b/services/Network/privateDnsZones/templates/policy/VirtualNetworkLinkCapacityUtilization_e71f87d1-81bb-4ee6-802d-9da4ab1cb3e3.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/privateDnsZones/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/privateDnsZones/templates/policy/VirtualNetworkWithRegistrationCapacityUtilization_c064753f-ea6a-4940-b603-975adb5127ae.json
+++ b/services/Network/privateDnsZones/templates/policy/VirtualNetworkWithRegistrationCapacityUtilization_c064753f-ea6a-4940-b603-975adb5127ae.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/privateDnsZones/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy-arm/BytesInDDoS_652acaf1-c5a1-4a88-b3bb-822a14dece19.json
+++ b/services/Network/publicIPAddresses/templates/policy-arm/BytesInDDoS_652acaf1-c5a1-4a88-b3bb-822a14dece19.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy-arm/IfUnderDDoSAttack_cb9a5dd7-4ae2-4adf-ab11-95363032ee5d.json
+++ b/services/Network/publicIPAddresses/templates/policy-arm/IfUnderDDoSAttack_cb9a5dd7-4ae2-4adf-ab11-95363032ee5d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy-arm/PacketsInDDoS_a78addf1-4632-4fc2-9afc-d1fb75049872.json
+++ b/services/Network/publicIPAddresses/templates/policy-arm/PacketsInDDoS_a78addf1-4632-4fc2-9afc-d1fb75049872.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy-arm/TCPBytesInDDoS_54d85ec1-6c8d-4372-bdab-f6f0b5cc12c4.json
+++ b/services/Network/publicIPAddresses/templates/policy-arm/TCPBytesInDDoS_54d85ec1-6c8d-4372-bdab-f6f0b5cc12c4.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy-arm/TCPPacketsInDDoS_529b0b1f-46fc-423f-94ab-dd71dd7894e2.json
+++ b/services/Network/publicIPAddresses/templates/policy-arm/TCPPacketsInDDoS_529b0b1f-46fc-423f-94ab-dd71dd7894e2.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy-arm/UDPBytesInDDoS_8020f41e-ca61-43b4-88ca-f520057dfa92.json
+++ b/services/Network/publicIPAddresses/templates/policy-arm/UDPBytesInDDoS_8020f41e-ca61-43b4-88ca-f520057dfa92.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy-arm/UDPPacketsInDDoS_27181c58-ca7a-433f-a0ee-a7a33102cb36.json
+++ b/services/Network/publicIPAddresses/templates/policy-arm/UDPPacketsInDDoS_27181c58-ca7a-433f-a0ee-a7a33102cb36.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy-arm/VipAvailability_7f4c355a-5411-4400-826a-b82007bbd83d.json
+++ b/services/Network/publicIPAddresses/templates/policy-arm/VipAvailability_7f4c355a-5411-4400-826a-b82007bbd83d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy/BytesInDDoS_652acaf1-c5a1-4a88-b3bb-822a14dece19.json
+++ b/services/Network/publicIPAddresses/templates/policy/BytesInDDoS_652acaf1-c5a1-4a88-b3bb-822a14dece19.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy/IfUnderDDoSAttack_cb9a5dd7-4ae2-4adf-ab11-95363032ee5d.json
+++ b/services/Network/publicIPAddresses/templates/policy/IfUnderDDoSAttack_cb9a5dd7-4ae2-4adf-ab11-95363032ee5d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy/PacketsInDDoS_a78addf1-4632-4fc2-9afc-d1fb75049872.json
+++ b/services/Network/publicIPAddresses/templates/policy/PacketsInDDoS_a78addf1-4632-4fc2-9afc-d1fb75049872.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy/TCPBytesInDDoS_54d85ec1-6c8d-4372-bdab-f6f0b5cc12c4.json
+++ b/services/Network/publicIPAddresses/templates/policy/TCPBytesInDDoS_54d85ec1-6c8d-4372-bdab-f6f0b5cc12c4.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy/TCPPacketsInDDoS_529b0b1f-46fc-423f-94ab-dd71dd7894e2.json
+++ b/services/Network/publicIPAddresses/templates/policy/TCPPacketsInDDoS_529b0b1f-46fc-423f-94ab-dd71dd7894e2.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy/UDPBytesInDDoS_8020f41e-ca61-43b4-88ca-f520057dfa92.json
+++ b/services/Network/publicIPAddresses/templates/policy/UDPBytesInDDoS_8020f41e-ca61-43b4-88ca-f520057dfa92.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy/UDPPacketsInDDoS_27181c58-ca7a-433f-a0ee-a7a33102cb36.json
+++ b/services/Network/publicIPAddresses/templates/policy/UDPPacketsInDDoS_27181c58-ca7a-433f-a0ee-a7a33102cb36.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/publicIPAddresses/templates/policy/VipAvailability_7f4c355a-5411-4400-826a-b82007bbd83d.json
+++ b/services/Network/publicIPAddresses/templates/policy/VipAvailability_7f4c355a-5411-4400-826a-b82007bbd83d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/trafficmanagerprofiles/templates/policy-arm/ProbeAgentCurrentEndpointStateByProfileResourceId_dd3f294f-d12e-4e34-8f6a-c304d3d977e2.json
+++ b/services/Network/trafficmanagerprofiles/templates/policy-arm/ProbeAgentCurrentEndpointStateByProfileResourceId_dd3f294f-d12e-4e34-8f6a-c304d3d977e2.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/trafficmanagerprofiles/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/trafficmanagerprofiles/templates/policy-arm/QpsByEndpoint_f4699243-1ba2-49a8-85f8-c4a22a563925.json
+++ b/services/Network/trafficmanagerprofiles/templates/policy-arm/QpsByEndpoint_f4699243-1ba2-49a8-85f8-c4a22a563925.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/trafficmanagerprofiles/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/trafficmanagerprofiles/templates/policy/ProbeAgentCurrentEndpointStateByProfileResourceId_dd3f294f-d12e-4e34-8f6a-c304d3d977e2.json
+++ b/services/Network/trafficmanagerprofiles/templates/policy/ProbeAgentCurrentEndpointStateByProfileResourceId_dd3f294f-d12e-4e34-8f6a-c304d3d977e2.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/trafficmanagerprofiles/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/trafficmanagerprofiles/templates/policy/QpsByEndpoint_f4699243-1ba2-49a8-85f8-c4a22a563925.json
+++ b/services/Network/trafficmanagerprofiles/templates/policy/QpsByEndpoint_f4699243-1ba2-49a8-85f8-c4a22a563925.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/trafficmanagerprofiles/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/AverageBandwidth_88642ff7-6c08-486a-9bf2-37764d5bf6a3.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/AverageBandwidth_88642ff7-6c08-486a-9bf2-37764d5bf6a3.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/ExpressRouteGatewayBitsPerSecond_4c3c25d2-7473-4d0c-9174-609162571859.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/ExpressRouteGatewayBitsPerSecond_4c3c25d2-7473-4d0c-9174-609162571859.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/ExpressRouteGatewayCpuUtilization_56491bc7-1267-42a2-92c6-fe9efe822ff1.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/ExpressRouteGatewayCpuUtilization_56491bc7-1267-42a2-92c6-fe9efe822ff1.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelAverageBandwidth_09bb7f01-a715-437d-b692-325f89e1869e.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelAverageBandwidth_09bb7f01-a715-437d-b692-325f89e1869e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelEgressBytes_092f6e09-1eb5-436d-b7c2-eadb70318920.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelEgressBytes_092f6e09-1eb5-436d-b7c2-eadb70318920.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelEgressPacketDropCount_6f02e3e8-9bfa-4312-a352-6506139e3dba.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelEgressPacketDropCount_6f02e3e8-9bfa-4312-a352-6506139e3dba.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelEgressPacketDropTSMismatch_ca909c09-89c4-467e-bdca-9140e72d6c82.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelEgressPacketDropTSMismatch_ca909c09-89c4-467e-bdca-9140e72d6c82.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelIngressBytes_a34fa329-da3e-4947-8d06-9bd2bee6c8a7.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelIngressBytes_a34fa329-da3e-4947-8d06-9bd2bee6c8a7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelIngressPacketDropCount_b511650f-535c-45d1-a089-0ea402245deb.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelIngressPacketDropCount_b511650f-535c-45d1-a089-0ea402245deb.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelIngressPacketDropTSMismatch_1cc4a539-e4bf-40e8-a280-f4e9e178fb51.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelIngressPacketDropTSMismatch_1cc4a539-e4bf-40e8-a280-f4e9e178fb51.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy/AverageBandwidth_88642ff7-6c08-486a-9bf2-37764d5bf6a3.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/AverageBandwidth_88642ff7-6c08-486a-9bf2-37764d5bf6a3.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy/ExpressRouteGatewayBitsPerSecond_4c3c25d2-7473-4d0c-9174-609162571859.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/ExpressRouteGatewayBitsPerSecond_4c3c25d2-7473-4d0c-9174-609162571859.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy/ExpressRouteGatewayCpuUtilization_56491bc7-1267-42a2-92c6-fe9efe822ff1.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/ExpressRouteGatewayCpuUtilization_56491bc7-1267-42a2-92c6-fe9efe822ff1.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy/TunnelAverageBandwidth_09bb7f01-a715-437d-b692-325f89e1869e.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/TunnelAverageBandwidth_09bb7f01-a715-437d-b692-325f89e1869e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy/TunnelEgressBytes_092f6e09-1eb5-436d-b7c2-eadb70318920.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/TunnelEgressBytes_092f6e09-1eb5-436d-b7c2-eadb70318920.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy/TunnelEgressPacketDropCount_6f02e3e8-9bfa-4312-a352-6506139e3dba.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/TunnelEgressPacketDropCount_6f02e3e8-9bfa-4312-a352-6506139e3dba.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy/TunnelEgressPacketDropTSMismatch_ca909c09-89c4-467e-bdca-9140e72d6c82.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/TunnelEgressPacketDropTSMismatch_ca909c09-89c4-467e-bdca-9140e72d6c82.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy/TunnelIngressBytes_a34fa329-da3e-4947-8d06-9bd2bee6c8a7.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/TunnelIngressBytes_a34fa329-da3e-4947-8d06-9bd2bee6c8a7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy/TunnelIngressPacketDropCount_b511650f-535c-45d1-a089-0ea402245deb.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/TunnelIngressPacketDropCount_b511650f-535c-45d1-a089-0ea402245deb.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworkGateways/templates/policy/TunnelIngressPacketDropTSMismatch_1cc4a539-e4bf-40e8-a280-f4e9e178fb51.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/TunnelIngressPacketDropTSMismatch_1cc4a539-e4bf-40e8-a280-f4e9e178fb51.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworkGateways/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworks/templates/policy-arm/IfUnderDDoSAttack_72dea6f4-858c-423f-8189-406aac7d20ac.json
+++ b/services/Network/virtualNetworks/templates/policy-arm/IfUnderDDoSAttack_72dea6f4-858c-423f-8189-406aac7d20ac.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworks/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/virtualNetworks/templates/policy/IfUnderDDoSAttack_72dea6f4-858c-423f-8189-406aac7d20ac.json
+++ b/services/Network/virtualNetworks/templates/policy/IfUnderDDoSAttack_72dea6f4-858c-423f-8189-406aac7d20ac.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworks/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy-arm/BGPPeerStatus_b0ea832c-aae8-42c0-ad83-0bb13d66d56e.json
+++ b/services/Network/vpnGateways/templates/policy-arm/BGPPeerStatus_b0ea832c-aae8-42c0-ad83-0bb13d66d56e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy-arm/TunnelAverageBandwidth_d74fd111-125f-45b8-8bbc-e23bd40aa869.json
+++ b/services/Network/vpnGateways/templates/policy-arm/TunnelAverageBandwidth_d74fd111-125f-45b8-8bbc-e23bd40aa869.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy-arm/TunnelEgressBytes_cd3b834d-f34f-4a67-af01-b1c5d32195a9.json
+++ b/services/Network/vpnGateways/templates/policy-arm/TunnelEgressBytes_cd3b834d-f34f-4a67-af01-b1c5d32195a9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy-arm/TunnelEgressPacketDropCount_c5ae6d80-59db-4087-8e9b-0df36c54ebe9.json
+++ b/services/Network/vpnGateways/templates/policy-arm/TunnelEgressPacketDropCount_c5ae6d80-59db-4087-8e9b-0df36c54ebe9.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy-arm/TunnelEgressPacketDropTSMismatch_7b361791-127e-4a6f-9c1b-c8d9f41ec223.json
+++ b/services/Network/vpnGateways/templates/policy-arm/TunnelEgressPacketDropTSMismatch_7b361791-127e-4a6f-9c1b-c8d9f41ec223.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy-arm/TunnelIngressBytes_a05d97b8-37b9-4100-a860-d57363aaaf5f.json
+++ b/services/Network/vpnGateways/templates/policy-arm/TunnelIngressBytes_a05d97b8-37b9-4100-a860-d57363aaaf5f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy-arm/TunnelIngressPacketDropCount_c2c9a09d-7fad-4c67-9a29-4c2c376a7214.json
+++ b/services/Network/vpnGateways/templates/policy-arm/TunnelIngressPacketDropCount_c2c9a09d-7fad-4c67-9a29-4c2c376a7214.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy-arm/TunnelIngressPacketDropTSMismatch_7affb4da-2058-4f12-b15b-ca58e92b63e5.json
+++ b/services/Network/vpnGateways/templates/policy-arm/TunnelIngressPacketDropTSMismatch_7affb4da-2058-4f12-b15b-ca58e92b63e5.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy/BgpPeerStatus_b0ea832c-aae8-42c0-ad83-0bb13d66d56e.json
+++ b/services/Network/vpnGateways/templates/policy/BgpPeerStatus_b0ea832c-aae8-42c0-ad83-0bb13d66d56e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy/TunnelAverageBandwidth_d74fd111-125f-45b8-8bbc-e23bd40aa869.json
+++ b/services/Network/vpnGateways/templates/policy/TunnelAverageBandwidth_d74fd111-125f-45b8-8bbc-e23bd40aa869.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy/TunnelEgressBytes_cd3b834d-f34f-4a67-af01-b1c5d32195a9.json
+++ b/services/Network/vpnGateways/templates/policy/TunnelEgressBytes_cd3b834d-f34f-4a67-af01-b1c5d32195a9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy/TunnelEgressPacketDropCount_c5ae6d80-59db-4087-8e9b-0df36c54ebe9.json
+++ b/services/Network/vpnGateways/templates/policy/TunnelEgressPacketDropCount_c5ae6d80-59db-4087-8e9b-0df36c54ebe9.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy/TunnelEgressPacketDropTSMismatch_7b361791-127e-4a6f-9c1b-c8d9f41ec223.json
+++ b/services/Network/vpnGateways/templates/policy/TunnelEgressPacketDropTSMismatch_7b361791-127e-4a6f-9c1b-c8d9f41ec223.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy/TunnelIngressBytes_a05d97b8-37b9-4100-a860-d57363aaaf5f.json
+++ b/services/Network/vpnGateways/templates/policy/TunnelIngressBytes_a05d97b8-37b9-4100-a860-d57363aaaf5f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy/TunnelIngressPacketDropCount_c2c9a09d-7fad-4c67-9a29-4c2c376a7214.json
+++ b/services/Network/vpnGateways/templates/policy/TunnelIngressPacketDropCount_c2c9a09d-7fad-4c67-9a29-4c2c376a7214.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Network/vpnGateways/templates/policy/TunnelIngressPacketDropTSMismatch_7affb4da-2058-4f12-b15b-ca58e92b63e5.json
+++ b/services/Network/vpnGateways/templates/policy/TunnelIngressPacketDropTSMismatch_7affb4da-2058-4f12-b15b-ca58e92b63e5.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/vpnGateways/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvailableMBytesMemory_99ba0b14-4b3c-49b5-8763-3161b9aae538.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvailableMBytesMemory_99ba0b14-4b3c-49b5-8763-3161b9aae538.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvailableMBytes_b0c5e86f-eb2d-41ea-a4a0-9819ad841c70.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvailableMBytes_b0c5e86f-eb2d-41ea-a4a0-9819ad841c70.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvailableMemory_91044c16-83bc-457f-80a9-360bad5dedb4.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvailableMemory_91044c16-83bc-457f-80a9-360bad5dedb4.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvgDisksecRead_8b472051-ff68-4059-9e50-243bfb64bae4.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvgDisksecRead_8b472051-ff68-4059-9e50-243bfb64bae4.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvgDisksecWrite_aad0e64e-3cda-45bf-b6bd-8cff29ee35e5.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageAvgDisksecWrite_aad0e64e-3cda-45bf-b6bd-8cff29ee35e5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageBytesReceivedsec_60ec2790-dc83-419c-bdb5-38da9a477c68.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageBytesReceivedsec_60ec2790-dc83-419c-bdb5-38da9a477c68.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageBytesSentsec_de6d5087-bc5a-474f-9319-248a3c03ab44.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageBytesSentsec_de6d5087-bc5a-474f-9319-248a3c03ab44.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageCommittedBytesInUse_a70e406c-a0ae-4e0f-99cd-8b0836812c59.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageCommittedBytesInUse_a70e406c-a0ae-4e0f-99cd-8b0836812c59.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageCurrentDiskQueueLength_08a4f049-9bb8-45d0-9dfb-320f385cc71f.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageCurrentDiskQueueLength_08a4f049-9bb8-45d0-9dfb-320f385cc71f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageDiskTransferssec_30b462dd-d026-4122-9bcf-3a114517e04c.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageDiskTransferssec_30b462dd-d026-4122-9bcf-3a114517e04c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageFreeMegabytes_969677fe-d1e0-42f6-92af-c9269780411b.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageFreeMegabytes_969677fe-d1e0-42f6-92af-c9269780411b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageFreeSpace_db621663-ec0a-4fa3-82a7-b6b110726568.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageFreeSpace_db621663-ec0a-4fa3-82a7-b6b110726568.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageIOWaitTime_1116a5eb-9e12-415a-af46-fad552421d36.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageIOWaitTime_1116a5eb-9e12-415a-af46-fad552421d36.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageIdleTime_732c0a7b-ac17-47cb-bf78-2ebaa839fa0d.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageIdleTime_732c0a7b-ac17-47cb-bf78-2ebaa839fa0d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AveragePagessec_88b7198b-32a5-4ae2-aaa5-7925066cc08c.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AveragePagessec_88b7198b-32a5-4ae2-aaa5-7925066cc08c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageProcessorTime_0c416177-e7ce-40d5-8f15-8566b3d7c03c.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageProcessorTime_0c416177-e7ce-40d5-8f15-8566b3d7c03c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageTotalBytesReceived_593b6885-3fb8-4562-89f1-8b0b68649185.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageTotalBytesReceived_593b6885-3fb8-4562-89f1-8b0b68649185.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageTotalBytesTransmitted_76583e85-8be6-4d02-8e09-aff0ce8574f8.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageTotalBytesTransmitted_76583e85-8be6-4d02-8e09-aff0ce8574f8.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedInodes_af5d055f-0e1f-4c48-808a-d21f8268357d.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedInodes_af5d055f-0e1f-4c48-808a-d21f8268357d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedMemory_171e5b5c-78cc-44a1-b7fb-7d750914ed5e.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedMemory_171e5b5c-78cc-44a1-b7fb-7d750914ed5e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedSpace_49ba0df7-18bf-4b3e-9d0f-f8c055762fd5.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedSpace_49ba0df7-18bf-4b3e-9d0f-f8c055762fd5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedSwapSpace_04f64694-48a2-48ee-9455-ccce8e59b66f.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageUsedSwapSpace_04f64694-48a2-48ee-9455-ccce8e59b66f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/AverageUserTime_b8140cdb-5492-4177-881f-8668372947a8.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/AverageUserTime_b8140cdb-5492-4177-881f-8668372947a8.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/Event_0b608189-b028-4851-8854-9ce1a48c3dd6.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/Event_0b608189-b028-4851-8854-9ce1a48c3dd6.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy-arm/Heartbeat_83703f70-9ea8-44aa-b88a-a8e56eb42858.json
+++ b/services/OperationalInsights/workspaces/templates/policy-arm/Heartbeat_83703f70-9ea8-44aa-b88a-a8e56eb42858.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageAvailableMBytesMemory_99ba0b14-4b3c-49b5-8763-3161b9aae538.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageAvailableMBytesMemory_99ba0b14-4b3c-49b5-8763-3161b9aae538.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageAvailableMBytes_b0c5e86f-eb2d-41ea-a4a0-9819ad841c70.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageAvailableMBytes_b0c5e86f-eb2d-41ea-a4a0-9819ad841c70.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageAvailableMemory_91044c16-83bc-457f-80a9-360bad5dedb4.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageAvailableMemory_91044c16-83bc-457f-80a9-360bad5dedb4.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageAvgDisksecRead_8b472051-ff68-4059-9e50-243bfb64bae4.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageAvgDisksecRead_8b472051-ff68-4059-9e50-243bfb64bae4.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageAvgDisksecWrite_aad0e64e-3cda-45bf-b6bd-8cff29ee35e5.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageAvgDisksecWrite_aad0e64e-3cda-45bf-b6bd-8cff29ee35e5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageBytesReceivedsec_60ec2790-dc83-419c-bdb5-38da9a477c68.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageBytesReceivedsec_60ec2790-dc83-419c-bdb5-38da9a477c68.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageBytesSentsec_de6d5087-bc5a-474f-9319-248a3c03ab44.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageBytesSentsec_de6d5087-bc5a-474f-9319-248a3c03ab44.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageCommittedBytesInUse_a70e406c-a0ae-4e0f-99cd-8b0836812c59.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageCommittedBytesInUse_a70e406c-a0ae-4e0f-99cd-8b0836812c59.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageCurrentDiskQueueLength_08a4f049-9bb8-45d0-9dfb-320f385cc71f.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageCurrentDiskQueueLength_08a4f049-9bb8-45d0-9dfb-320f385cc71f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageDiskTransferssec_30b462dd-d026-4122-9bcf-3a114517e04c.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageDiskTransferssec_30b462dd-d026-4122-9bcf-3a114517e04c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageFreeMegabytes_969677fe-d1e0-42f6-92af-c9269780411b.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageFreeMegabytes_969677fe-d1e0-42f6-92af-c9269780411b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageFreeSpace_db621663-ec0a-4fa3-82a7-b6b110726568.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageFreeSpace_db621663-ec0a-4fa3-82a7-b6b110726568.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageIOWaitTime_1116a5eb-9e12-415a-af46-fad552421d36.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageIOWaitTime_1116a5eb-9e12-415a-af46-fad552421d36.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageIdleTime_732c0a7b-ac17-47cb-bf78-2ebaa839fa0d.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageIdleTime_732c0a7b-ac17-47cb-bf78-2ebaa839fa0d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AveragePagessec_88b7198b-32a5-4ae2-aaa5-7925066cc08c.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AveragePagessec_88b7198b-32a5-4ae2-aaa5-7925066cc08c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageProcessorTime_0c416177-e7ce-40d5-8f15-8566b3d7c03c.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageProcessorTime_0c416177-e7ce-40d5-8f15-8566b3d7c03c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageTotalBytesReceived_593b6885-3fb8-4562-89f1-8b0b68649185.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageTotalBytesReceived_593b6885-3fb8-4562-89f1-8b0b68649185.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageTotalBytesTransmitted_76583e85-8be6-4d02-8e09-aff0ce8574f8.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageTotalBytesTransmitted_76583e85-8be6-4d02-8e09-aff0ce8574f8.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageUsedInodes_af5d055f-0e1f-4c48-808a-d21f8268357d.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageUsedInodes_af5d055f-0e1f-4c48-808a-d21f8268357d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageUsedMemory_171e5b5c-78cc-44a1-b7fb-7d750914ed5e.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageUsedMemory_171e5b5c-78cc-44a1-b7fb-7d750914ed5e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageUsedSpace_49ba0df7-18bf-4b3e-9d0f-f8c055762fd5.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageUsedSpace_49ba0df7-18bf-4b3e-9d0f-f8c055762fd5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageUsedSwapSpace_04f64694-48a2-48ee-9455-ccce8e59b66f.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageUsedSwapSpace_04f64694-48a2-48ee-9455-ccce8e59b66f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/AverageUserTime_b8140cdb-5492-4177-881f-8668372947a8.json
+++ b/services/OperationalInsights/workspaces/templates/policy/AverageUserTime_b8140cdb-5492-4177-881f-8668372947a8.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/Event_0b608189-b028-4851-8854-9ce1a48c3dd6.json
+++ b/services/OperationalInsights/workspaces/templates/policy/Event_0b608189-b028-4851-8854-9ce1a48c3dd6.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/OperationalInsights/workspaces/templates/policy/Heartbeat_83703f70-9ea8-44aa-b88a-a8e56eb42858.json
+++ b/services/OperationalInsights/workspaces/templates/policy/Heartbeat_83703f70-9ea8-44aa-b88a-a8e56eb42858.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/PowerBIDedicated/capacities/templates/policy-arm/cpumetric_2993107e-d54f-4fc4-af7a-6a9bc6b4ea46.json
+++ b/services/PowerBIDedicated/capacities/templates/policy-arm/cpumetric_2993107e-d54f-4fc4-af7a-6a9bc6b4ea46.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.PowerBIDedicated/capacities/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/PowerBIDedicated/capacities/templates/policy/cpumetric_2993107e-d54f-4fc4-af7a-6a9bc6b4ea46.json
+++ b/services/PowerBIDedicated/capacities/templates/policy/cpumetric_2993107e-d54f-4fc4-af7a-6a9bc6b4ea46.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.PowerBIDedicated/capacities/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/RecoveryServices/vaults/templates/policy-arm/BackupHealthEvent_8f9b2819-9c51-4f30-91fd-195b7bc5d7a5.json
+++ b/services/RecoveryServices/vaults/templates/policy-arm/BackupHealthEvent_8f9b2819-9c51-4f30-91fd-195b7bc5d7a5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.RecoveryServices/vaults/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/RecoveryServices/vaults/templates/policy-arm/RestoreHealthEvent_805aa9c8-4d52-411d-9811-cc02b33952e3.json
+++ b/services/RecoveryServices/vaults/templates/policy-arm/RestoreHealthEvent_805aa9c8-4d52-411d-9811-cc02b33952e3.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.RecoveryServices/vaults/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/RecoveryServices/vaults/templates/policy/BackupHealthEvent_8f9b2819-9c51-4f30-91fd-195b7bc5d7a5.json
+++ b/services/RecoveryServices/vaults/templates/policy/BackupHealthEvent_8f9b2819-9c51-4f30-91fd-195b7bc5d7a5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.RecoveryServices/vaults/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/RecoveryServices/vaults/templates/policy/RestoreHealthEvent_805aa9c8-4d52-411d-9811-cc02b33952e3.json
+++ b/services/RecoveryServices/vaults/templates/policy/RestoreHealthEvent_805aa9c8-4d52-411d-9811-cc02b33952e3.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.RecoveryServices/vaults/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Relay/namespaces/templates/policy-arm/ActiveListeners_25a1c11a-3ec4-47aa-b67e-f359fd14483a.json
+++ b/services/Relay/namespaces/templates/policy-arm/ActiveListeners_25a1c11a-3ec4-47aa-b67e-f359fd14483a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Relay/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Relay/namespaces/templates/policy/ActiveListeners_25a1c11a-3ec4-47aa-b67e-f359fd14483a.json
+++ b/services/Relay/namespaces/templates/policy/ActiveListeners_25a1c11a-3ec4-47aa-b67e-f359fd14483a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Relay/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Search/searchServices/templates/policy-arm/SearchLatency_d3985fe5-c7f0-47a1-b52e-26098345a433.json
+++ b/services/Search/searchServices/templates/policy-arm/SearchLatency_d3985fe5-c7f0-47a1-b52e-26098345a433.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Search/searchServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Search/searchServices/templates/policy-arm/ThrottledSearchQueriesPercentage_7a044f2f-f38f-4f13-82eb-c7f49bf17ad0.json
+++ b/services/Search/searchServices/templates/policy-arm/ThrottledSearchQueriesPercentage_7a044f2f-f38f-4f13-82eb-c7f49bf17ad0.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Search/searchServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Search/searchServices/templates/policy/SearchLatency_d3985fe5-c7f0-47a1-b52e-26098345a433.json
+++ b/services/Search/searchServices/templates/policy/SearchLatency_d3985fe5-c7f0-47a1-b52e-26098345a433.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Search/searchServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Search/searchServices/templates/policy/ThrottledSearchQueriesPercentage_7a044f2f-f38f-4f13-82eb-c7f49bf17ad0.json
+++ b/services/Search/searchServices/templates/policy/ThrottledSearchQueriesPercentage_7a044f2f-f38f-4f13-82eb-c7f49bf17ad0.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Search/searchServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/AbandonMessage_172396a9-27f0-4c01-9510-94ba4a0d4738.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/AbandonMessage_172396a9-27f0-4c01-9510-94ba4a0d4738.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/ActiveConnections_784a29e7-5799-4fde-90ee-b6ebcb2a8747.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/ActiveConnections_784a29e7-5799-4fde-90ee-b6ebcb2a8747.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/ActiveMessages_0b3362f7-b1ff-4d78-8c25-f14ee9300ae1.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/ActiveMessages_0b3362f7-b1ff-4d78-8c25-f14ee9300ae1.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/DeadletteredMessages_868a7fc3-9c5c-4fb4-9289-fbe10dd4db82.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/DeadletteredMessages_868a7fc3-9c5c-4fb4-9289-fbe10dd4db82.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/IncomingMessages_c1095936-da8d-4c63-ac70-cf97d5b1f630.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/IncomingMessages_c1095936-da8d-4c63-ac70-cf97d5b1f630.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/Messages_67872571-d13d-4123-81c5-60404c4eea45.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/Messages_67872571-d13d-4123-81c5-60404c4eea45.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/NamespaceCpuUsage_52ec94f5-0d89-434b-9d51-df92d69ba284.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/NamespaceCpuUsage_52ec94f5-0d89-434b-9d51-df92d69ba284.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/NamespaceMemoryUsage_860d21ea-8c6a-4c78-ac40-f556eb02c3ac.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/NamespaceMemoryUsage_860d21ea-8c6a-4c78-ac40-f556eb02c3ac.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/OutgoingMessages_fdde6805-edf8-4277-adb8-ad2f44e3f977.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/OutgoingMessages_fdde6805-edf8-4277-adb8-ad2f44e3f977.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/ScheduledMessages_5543b815-f2c8-420e-847e-7507a9724557.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/ScheduledMessages_5543b815-f2c8-420e-847e-7507a9724557.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/ServerErrors_c51c3514-1730-42f3-b8ae-f2980bd22d83.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/ServerErrors_c51c3514-1730-42f3-b8ae-f2980bd22d83.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/ServerSendLatency_487c6beb-1468-4167-8eb6-e9b3ad8743b1.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/ServerSendLatency_487c6beb-1468-4167-8eb6-e9b3ad8743b1.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/Size_950586ee-6926-4483-96d4-82838afe1ca6.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/Size_950586ee-6926-4483-96d4-82838afe1ca6.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/ThrottledRequests_19785707-24c9-4852-b92a-31732b86ee04.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/ThrottledRequests_19785707-24c9-4852-b92a-31732b86ee04.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy-arm/UserErrors_a57a1cc4-4ec9-4d8f-a81d-7e18afe54948.json
+++ b/services/ServiceBus/namespaces/templates/policy-arm/UserErrors_a57a1cc4-4ec9-4d8f-a81d-7e18afe54948.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/AbandonMessage_172396a9-27f0-4c01-9510-94ba4a0d4738.json
+++ b/services/ServiceBus/namespaces/templates/policy/AbandonMessage_172396a9-27f0-4c01-9510-94ba4a0d4738.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/ActiveConnections_784a29e7-5799-4fde-90ee-b6ebcb2a8747.json
+++ b/services/ServiceBus/namespaces/templates/policy/ActiveConnections_784a29e7-5799-4fde-90ee-b6ebcb2a8747.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/ActiveMessages_0b3362f7-b1ff-4d78-8c25-f14ee9300ae1.json
+++ b/services/ServiceBus/namespaces/templates/policy/ActiveMessages_0b3362f7-b1ff-4d78-8c25-f14ee9300ae1.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/DeadletteredMessages_868a7fc3-9c5c-4fb4-9289-fbe10dd4db82.json
+++ b/services/ServiceBus/namespaces/templates/policy/DeadletteredMessages_868a7fc3-9c5c-4fb4-9289-fbe10dd4db82.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/IncomingMessages_c1095936-da8d-4c63-ac70-cf97d5b1f630.json
+++ b/services/ServiceBus/namespaces/templates/policy/IncomingMessages_c1095936-da8d-4c63-ac70-cf97d5b1f630.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/Messages_67872571-d13d-4123-81c5-60404c4eea45.json
+++ b/services/ServiceBus/namespaces/templates/policy/Messages_67872571-d13d-4123-81c5-60404c4eea45.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/NamespaceCpuUsage_52ec94f5-0d89-434b-9d51-df92d69ba284.json
+++ b/services/ServiceBus/namespaces/templates/policy/NamespaceCpuUsage_52ec94f5-0d89-434b-9d51-df92d69ba284.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/NamespaceMemoryUsage_860d21ea-8c6a-4c78-ac40-f556eb02c3ac.json
+++ b/services/ServiceBus/namespaces/templates/policy/NamespaceMemoryUsage_860d21ea-8c6a-4c78-ac40-f556eb02c3ac.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/OutgoingMessages_fdde6805-edf8-4277-adb8-ad2f44e3f977.json
+++ b/services/ServiceBus/namespaces/templates/policy/OutgoingMessages_fdde6805-edf8-4277-adb8-ad2f44e3f977.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/ScheduledMessages_5543b815-f2c8-420e-847e-7507a9724557.json
+++ b/services/ServiceBus/namespaces/templates/policy/ScheduledMessages_5543b815-f2c8-420e-847e-7507a9724557.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/ServerErrors_c51c3514-1730-42f3-b8ae-f2980bd22d83.json
+++ b/services/ServiceBus/namespaces/templates/policy/ServerErrors_c51c3514-1730-42f3-b8ae-f2980bd22d83.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/ServerSendLatency_487c6beb-1468-4167-8eb6-e9b3ad8743b1.json
+++ b/services/ServiceBus/namespaces/templates/policy/ServerSendLatency_487c6beb-1468-4167-8eb6-e9b3ad8743b1.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/Size_950586ee-6926-4483-96d4-82838afe1ca6.json
+++ b/services/ServiceBus/namespaces/templates/policy/Size_950586ee-6926-4483-96d4-82838afe1ca6.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/ThrottledRequests_19785707-24c9-4852-b92a-31732b86ee04.json
+++ b/services/ServiceBus/namespaces/templates/policy/ThrottledRequests_19785707-24c9-4852-b92a-31732b86ee04.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/ServiceBus/namespaces/templates/policy/UserErrors_a57a1cc4-4ec9-4d8f-a81d-7e18afe54948.json
+++ b/services/ServiceBus/namespaces/templates/policy/UserErrors_a57a1cc4-4ec9-4d8f-a81d-7e18afe54948.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.ServiceBus/namespaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/SignalRService/SignalR/templates/policy-arm/ConnectionCount_b7581df7-f127-405e-9408-9d484122be74.json
+++ b/services/SignalRService/SignalR/templates/policy-arm/ConnectionCount_b7581df7-f127-405e-9408-9d484122be74.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.SignalRService/SignalR/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/SignalRService/SignalR/templates/policy-arm/ConnectionQuotaUtilization_c7567682-8723-4426-8c27-848a9cc634d0.json
+++ b/services/SignalRService/SignalR/templates/policy-arm/ConnectionQuotaUtilization_c7567682-8723-4426-8c27-848a9cc634d0.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.SignalRService/SignalR/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/SignalRService/SignalR/templates/policy-arm/SystemErrors_58f62f20-b9ba-472c-a2a4-37b53ed3e21d.json
+++ b/services/SignalRService/SignalR/templates/policy-arm/SystemErrors_58f62f20-b9ba-472c-a2a4-37b53ed3e21d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.SignalRService/SignalR/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/SignalRService/SignalR/templates/policy/ConnectionCount_b7581df7-f127-405e-9408-9d484122be74.json
+++ b/services/SignalRService/SignalR/templates/policy/ConnectionCount_b7581df7-f127-405e-9408-9d484122be74.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.SignalRService/SignalR/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/SignalRService/SignalR/templates/policy/ConnectionQuotaUtilization_c7567682-8723-4426-8c27-848a9cc634d0.json
+++ b/services/SignalRService/SignalR/templates/policy/ConnectionQuotaUtilization_c7567682-8723-4426-8c27-848a9cc634d0.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.SignalRService/SignalR/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/SignalRService/SignalR/templates/policy/SystemErrors_58f62f20-b9ba-472c-a2a4-37b53ed3e21d.json
+++ b/services/SignalRService/SignalR/templates/policy/SystemErrors_58f62f20-b9ba-472c-a2a4-37b53ed3e21d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.SignalRService/SignalR/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/managedInstances/templates/policy-arm/avgcpupercent_dfd37715-0d5c-4ec5-98ae-836cd626a27f.json
+++ b/services/Sql/managedInstances/templates/policy-arm/avgcpupercent_dfd37715-0d5c-4ec5-98ae-836cd626a27f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/managedInstances/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/managedInstances/templates/policy-arm/storagespaceusedmb_641ca3dc-a00f-43ac-b6bd-4f5d16f35cac.json
+++ b/services/Sql/managedInstances/templates/policy-arm/storagespaceusedmb_641ca3dc-a00f-43ac-b6bd-4f5d16f35cac.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/managedInstances/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/managedInstances/templates/policy/avgcpupercent_dfd37715-0d5c-4ec5-98ae-836cd626a27f.json
+++ b/services/Sql/managedInstances/templates/policy/avgcpupercent_dfd37715-0d5c-4ec5-98ae-836cd626a27f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/managedInstances/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/managedInstances/templates/policy/storagespaceusedmb_641ca3dc-a00f-43ac-b6bd-4f5d16f35cac.json
+++ b/services/Sql/managedInstances/templates/policy/storagespaceusedmb_641ca3dc-a00f-43ac-b6bd-4f5d16f35cac.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/managedInstances/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-appcpupercent_05591510-5fe2-454a-96d8-bbda8201c6a4.json
+++ b/services/Sql/servers/templates/policy-arm/databases-appcpupercent_05591510-5fe2-454a-96d8-bbda8201c6a4.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-appmemorypercent_c5c95fe9-a4b4-4afa-a07a-a0d18804d416.json
+++ b/services/Sql/servers/templates/policy-arm/databases-appmemorypercent_c5c95fe9-a4b4-4afa-a07a-a0d18804d416.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-blockedbyfirewall_2cda2f3a-8657-431a-a50f-56835aea9a81.json
+++ b/services/Sql/servers/templates/policy-arm/databases-blockedbyfirewall_2cda2f3a-8657-431a-a50f-56835aea9a81.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-connectionfailed_7157dc17-9d5a-4835-a122-1d0d904d61ff.json
+++ b/services/Sql/servers/templates/policy-arm/databases-connectionfailed_7157dc17-9d5a-4835-a122-1d0d904d61ff.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-connectionfailedusererror_d528ffcb-3a99-4356-96d1-981499139ffb.json
+++ b/services/Sql/servers/templates/policy-arm/databases-connectionfailedusererror_d528ffcb-3a99-4356-96d1-981499139ffb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-connectionsuccessful_460b6b29-a602-4409-b748-6b47b232a984.json
+++ b/services/Sql/servers/templates/policy-arm/databases-connectionsuccessful_460b6b29-a602-4409-b748-6b47b232a984.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-cpuused_3ddd3f95-989c-4777-b6b8-728439aae1df.json
+++ b/services/Sql/servers/templates/policy-arm/databases-cpuused_3ddd3f95-989c-4777-b6b8-728439aae1df.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-deadlock_ce44fc81-3610-4165-a107-9dd4b8ab3972.json
+++ b/services/Sql/servers/templates/policy-arm/databases-deadlock_ce44fc81-3610-4165-a107-9dd4b8ab3972.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-dtulimit_50124594-a291-4183-a8e3-195f5e6f5204.json
+++ b/services/Sql/servers/templates/policy-arm/databases-dtulimit_50124594-a291-4183-a8e3-195f5e6f5204.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-dtuused_d26f4c8b-0461-4c57-b230-cbd1a5424db1.json
+++ b/services/Sql/servers/templates/policy-arm/databases-dtuused_d26f4c8b-0461-4c57-b230-cbd1a5424db1.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-dwuconsumptionpercent_70f88865-7a8b-4e03-9252-a9369df503ef.json
+++ b/services/Sql/servers/templates/policy-arm/databases-dwuconsumptionpercent_70f88865-7a8b-4e03-9252-a9369df503ef.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-memoryusagepercent_f5c13b49-8528-457d-9d7d-083b8433bf96.json
+++ b/services/Sql/servers/templates/policy-arm/databases-memoryusagepercent_f5c13b49-8528-457d-9d7d-083b8433bf96.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-sessionscount_07eeae07-010e-47ca-ad90-fa7adb5a6c52.json
+++ b/services/Sql/servers/templates/policy-arm/databases-sessionscount_07eeae07-010e-47ca-ad90-fa7adb5a6c52.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-sqlinstancecpupercent_1a8132b9-fbd2-4ac5-9e08-96358e16b7f7.json
+++ b/services/Sql/servers/templates/policy-arm/databases-sqlinstancecpupercent_1a8132b9-fbd2-4ac5-9e08-96358e16b7f7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-sqlinstancememorypercent_f44a3cb0-6e99-4a5e-a691-c5d7d5bf7e64.json
+++ b/services/Sql/servers/templates/policy-arm/databases-sqlinstancememorypercent_f44a3cb0-6e99-4a5e-a691-c5d7d5bf7e64.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-storage_86922a27-41bb-4834-bc54-0b602b275597.json
+++ b/services/Sql/servers/templates/policy-arm/databases-storage_86922a27-41bb-4834-bc54-0b602b275597.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/databases-tempdbdatasize_0fe27fd1-e4f7-48c1-bbd2-a6953755d5e8.json
+++ b/services/Sql/servers/templates/policy-arm/databases-tempdbdatasize_0fe27fd1-e4f7-48c1-bbd2-a6953755d5e8.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/elasticpools-allocateddatastorage_3743016a-a056-43fe-b53a-36dd9a17626d.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-allocateddatastorage_3743016a-a056-43fe-b53a-36dd9a17626d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/elasticpools-allocateddatastoragepercent_7e9d0710-3243-4cf2-8b73-6be1539b8545.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-allocateddatastoragepercent_7e9d0710-3243-4cf2-8b73-6be1539b8545.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/elasticpools-cpupercent_805c4ae5-a852-43bd-ad1c-0f7f381d8f32.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-cpupercent_805c4ae5-a852-43bd-ad1c-0f7f381d8f32.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/elasticpools-dtuconsumptionpercent_5d9075b5-3c19-4cf6-9c2e-50ba4c175691.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-dtuconsumptionpercent_5d9075b5-3c19-4cf6-9c2e-50ba4c175691.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/elasticpools-eDTUused_16a64053-1905-4d8e-8198-810584cad108.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-eDTUused_16a64053-1905-4d8e-8198-810584cad108.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/elasticpools-logwritepercent_47cd814e-1991-437e-8feb-e589a250d2a3.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-logwritepercent_47cd814e-1991-437e-8feb-e589a250d2a3.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/elasticpools-physicaldatareadpercent_92efc2ea-b6ed-41aa-921c-6d40e7b58c27.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-physicaldatareadpercent_92efc2ea-b6ed-41aa-921c-6d40e7b58c27.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/elasticpools-sessionspercent_6b2e0ce9-d1b8-4061-b3ce-c39f9c5c1763.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-sessionspercent_6b2e0ce9-d1b8-4061-b3ce-c39f9c5c1763.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/elasticpools-sqlserverprocesscorepercent_73ec4301-872a-4bea-928e-420255aae8cb.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-sqlserverprocesscorepercent_73ec4301-872a-4bea-928e-420255aae8cb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/elasticpools-sqlserverprocessmemorypercent_fa056aaf-57c4-4abe-9bc5-23ba413a1f5b.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-sqlserverprocessmemorypercent_fa056aaf-57c4-4abe-9bc5-23ba413a1f5b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/elasticpools-storagepercent_88f3cbc0-bcfb-482f-b6f4-709a335afcad.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-storagepercent_88f3cbc0-bcfb-482f-b6f4-709a335afcad.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/elasticpools-tempdblogusedpercent_af66de51-079c-4d34-af92-f52f887642dc.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-tempdblogusedpercent_af66de51-079c-4d34-af92-f52f887642dc.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/elasticpools-workerspercent_1b37038e-6e5c-4463-97d4-8a632251d70e.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-workerspercent_1b37038e-6e5c-4463-97d4-8a632251d70e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy-arm/elasticpools-xtpstoragepercent_db517009-30ad-4cbc-b282-7f212052c3b4.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-xtpstoragepercent_db517009-30ad-4cbc-b282-7f212052c3b4.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-appcpupercent_05591510-5fe2-454a-96d8-bbda8201c6a4.json
+++ b/services/Sql/servers/templates/policy/databases-appcpupercent_05591510-5fe2-454a-96d8-bbda8201c6a4.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-appmemorypercent_c5c95fe9-a4b4-4afa-a07a-a0d18804d416.json
+++ b/services/Sql/servers/templates/policy/databases-appmemorypercent_c5c95fe9-a4b4-4afa-a07a-a0d18804d416.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-blockedbyfirewall_2cda2f3a-8657-431a-a50f-56835aea9a81.json
+++ b/services/Sql/servers/templates/policy/databases-blockedbyfirewall_2cda2f3a-8657-431a-a50f-56835aea9a81.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-connectionfailed_7157dc17-9d5a-4835-a122-1d0d904d61ff.json
+++ b/services/Sql/servers/templates/policy/databases-connectionfailed_7157dc17-9d5a-4835-a122-1d0d904d61ff.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-connectionfailedusererror_d528ffcb-3a99-4356-96d1-981499139ffb.json
+++ b/services/Sql/servers/templates/policy/databases-connectionfailedusererror_d528ffcb-3a99-4356-96d1-981499139ffb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-connectionsuccessful_460b6b29-a602-4409-b748-6b47b232a984.json
+++ b/services/Sql/servers/templates/policy/databases-connectionsuccessful_460b6b29-a602-4409-b748-6b47b232a984.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-cpuused_3ddd3f95-989c-4777-b6b8-728439aae1df.json
+++ b/services/Sql/servers/templates/policy/databases-cpuused_3ddd3f95-989c-4777-b6b8-728439aae1df.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-deadlock_ce44fc81-3610-4165-a107-9dd4b8ab3972.json
+++ b/services/Sql/servers/templates/policy/databases-deadlock_ce44fc81-3610-4165-a107-9dd4b8ab3972.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-dtulimit_50124594-a291-4183-a8e3-195f5e6f5204.json
+++ b/services/Sql/servers/templates/policy/databases-dtulimit_50124594-a291-4183-a8e3-195f5e6f5204.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-dtuused_d26f4c8b-0461-4c57-b230-cbd1a5424db1.json
+++ b/services/Sql/servers/templates/policy/databases-dtuused_d26f4c8b-0461-4c57-b230-cbd1a5424db1.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-dwuconsumptionpercent_70f88865-7a8b-4e03-9252-a9369df503ef.json
+++ b/services/Sql/servers/templates/policy/databases-dwuconsumptionpercent_70f88865-7a8b-4e03-9252-a9369df503ef.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-memoryusagepercent_f5c13b49-8528-457d-9d7d-083b8433bf96.json
+++ b/services/Sql/servers/templates/policy/databases-memoryusagepercent_f5c13b49-8528-457d-9d7d-083b8433bf96.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-sessionscount_07eeae07-010e-47ca-ad90-fa7adb5a6c52.json
+++ b/services/Sql/servers/templates/policy/databases-sessionscount_07eeae07-010e-47ca-ad90-fa7adb5a6c52.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-sqlinstancecpupercent_1a8132b9-fbd2-4ac5-9e08-96358e16b7f7.json
+++ b/services/Sql/servers/templates/policy/databases-sqlinstancecpupercent_1a8132b9-fbd2-4ac5-9e08-96358e16b7f7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-sqlinstancememorypercent_f44a3cb0-6e99-4a5e-a691-c5d7d5bf7e64.json
+++ b/services/Sql/servers/templates/policy/databases-sqlinstancememorypercent_f44a3cb0-6e99-4a5e-a691-c5d7d5bf7e64.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-storage_86922a27-41bb-4834-bc54-0b602b275597.json
+++ b/services/Sql/servers/templates/policy/databases-storage_86922a27-41bb-4834-bc54-0b602b275597.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/databases-tempdbdatasize_0fe27fd1-e4f7-48c1-bbd2-a6953755d5e8.json
+++ b/services/Sql/servers/templates/policy/databases-tempdbdatasize_0fe27fd1-e4f7-48c1-bbd2-a6953755d5e8.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/databases/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/elasticpools-allocateddatastorage_3743016a-a056-43fe-b53a-36dd9a17626d.json
+++ b/services/Sql/servers/templates/policy/elasticpools-allocateddatastorage_3743016a-a056-43fe-b53a-36dd9a17626d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/elasticpools-allocateddatastoragepercent_7e9d0710-3243-4cf2-8b73-6be1539b8545.json
+++ b/services/Sql/servers/templates/policy/elasticpools-allocateddatastoragepercent_7e9d0710-3243-4cf2-8b73-6be1539b8545.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/elasticpools-cpupercent_805c4ae5-a852-43bd-ad1c-0f7f381d8f32.json
+++ b/services/Sql/servers/templates/policy/elasticpools-cpupercent_805c4ae5-a852-43bd-ad1c-0f7f381d8f32.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/elasticpools-dtuconsumptionpercent_5d9075b5-3c19-4cf6-9c2e-50ba4c175691.json
+++ b/services/Sql/servers/templates/policy/elasticpools-dtuconsumptionpercent_5d9075b5-3c19-4cf6-9c2e-50ba4c175691.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/elasticpools-eDTUused_16a64053-1905-4d8e-8198-810584cad108.json
+++ b/services/Sql/servers/templates/policy/elasticpools-eDTUused_16a64053-1905-4d8e-8198-810584cad108.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/elasticpools-logwritepercent_47cd814e-1991-437e-8feb-e589a250d2a3.json
+++ b/services/Sql/servers/templates/policy/elasticpools-logwritepercent_47cd814e-1991-437e-8feb-e589a250d2a3.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/elasticpools-physicaldatareadpercent_92efc2ea-b6ed-41aa-921c-6d40e7b58c27.json
+++ b/services/Sql/servers/templates/policy/elasticpools-physicaldatareadpercent_92efc2ea-b6ed-41aa-921c-6d40e7b58c27.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/elasticpools-sessionspercent_6b2e0ce9-d1b8-4061-b3ce-c39f9c5c1763.json
+++ b/services/Sql/servers/templates/policy/elasticpools-sessionspercent_6b2e0ce9-d1b8-4061-b3ce-c39f9c5c1763.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/elasticpools-sqlserverprocesscorepercent_73ec4301-872a-4bea-928e-420255aae8cb.json
+++ b/services/Sql/servers/templates/policy/elasticpools-sqlserverprocesscorepercent_73ec4301-872a-4bea-928e-420255aae8cb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/elasticpools-sqlserverprocessmemorypercent_fa056aaf-57c4-4abe-9bc5-23ba413a1f5b.json
+++ b/services/Sql/servers/templates/policy/elasticpools-sqlserverprocessmemorypercent_fa056aaf-57c4-4abe-9bc5-23ba413a1f5b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/elasticpools-storagepercent_88f3cbc0-bcfb-482f-b6f4-709a335afcad.json
+++ b/services/Sql/servers/templates/policy/elasticpools-storagepercent_88f3cbc0-bcfb-482f-b6f4-709a335afcad.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/elasticpools-tempdblogusedpercent_af66de51-079c-4d34-af92-f52f887642dc.json
+++ b/services/Sql/servers/templates/policy/elasticpools-tempdblogusedpercent_af66de51-079c-4d34-af92-f52f887642dc.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/elasticpools-workerspercent_1b37038e-6e5c-4463-97d4-8a632251d70e.json
+++ b/services/Sql/servers/templates/policy/elasticpools-workerspercent_1b37038e-6e5c-4463-97d4-8a632251d70e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Sql/servers/templates/policy/elasticpools-xtpstoragepercent_db517009-30ad-4cbc-b282-7f212052c3b4.json
+++ b/services/Sql/servers/templates/policy/elasticpools-xtpstoragepercent_db517009-30ad-4cbc-b282-7f212052c3b4.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Sql/servers/elasticpools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/Availability_b1a4849b-78a8-437f-8113-7c6f2dc34927.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/Availability_b1a4849b-78a8-437f-8113-7c6f2dc34927.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/Egress_eb186756-b63b-408a-bbaf-ac94c1010287.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/Egress_eb186756-b63b-408a-bbaf-ac94c1010287.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/FileShareCount_a4adc774-7ca4-4a4b-b2fa-514b9fcbbc80.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/FileShareCount_a4adc774-7ca4-4a4b-b2fa-514b9fcbbc80.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/fileServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/Ingress_5d872cb4-7f71-4275-81eb-98c968c0cadd.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/Ingress_5d872cb4-7f71-4275-81eb-98c968c0cadd.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/QueueCount_f75dec98-78a3-4e42-954d-375fe3352857.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/QueueCount_f75dec98-78a3-4e42-954d-375fe3352857.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/queueServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/Throttling_5e544473-d84f-427d-869d-9d982619e4cb.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/Throttling_5e544473-d84f-427d-869d-9d982619e4cb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/fileServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/UsedCapacity_b663a689-6db8-467d-8b5d-8cd34afe4b0e.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/UsedCapacity_b663a689-6db8-467d-8b5d-8cd34afe4b0e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/blobServices-BlobCapacity_8c0aaea9-bcce-4c27-a090-ffe54b7e1d1c.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/blobServices-BlobCapacity_8c0aaea9-bcce-4c27-a090-ffe54b7e1d1c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/blobServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/blobServices-BlobCount_c4d93fac-a6b6-4731-a92a-c499b6fb2bcb.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/blobServices-BlobCount_c4d93fac-a6b6-4731-a92a-c499b6fb2bcb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/blobServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/blobServices-SuccessE2ELatency_0acc30dc-881d-46c9-b634-8cba507a263f.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/blobServices-SuccessE2ELatency_0acc30dc-881d-46c9-b634-8cba507a263f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/blobServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/blobServices-SuccessServerLatency_0a3689c7-b610-4c52-ae84-ab0640f3d6e4.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/blobServices-SuccessServerLatency_0a3689c7-b610-4c52-ae84-ab0640f3d6e4.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/blobServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/fileServices-Availability_45fef979-c27e-425a-a6c3-e5bd28b1eb86.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/fileServices-Availability_45fef979-c27e-425a-a6c3-e5bd28b1eb86.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/fileServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/fileServices-FileCapacity_26e09eae-c784-4e8f-a225-d3f13efff76f.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/fileServices-FileCapacity_26e09eae-c784-4e8f-a225-d3f13efff76f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/fileServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/fileServices-FileShareCapacityQuota_8660f357-83f9-4719-bdf3-bae57af2d967.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/fileServices-FileShareCapacityQuota_8660f357-83f9-4719-bdf3-bae57af2d967.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/fileServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/fileServices-FileShareSnapshotCount_8cbe449d-9264-4ae1-8221-5d97989005a8.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/fileServices-FileShareSnapshotCount_8cbe449d-9264-4ae1-8221-5d97989005a8.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/fileServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/fileServices-Transactions_c81d3e6c-5539-42ad-a95f-9bba504d91f0.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/fileServices-Transactions_c81d3e6c-5539-42ad-a95f-9bba504d91f0.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/fileServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/queueServices-QueueCapacity_7815fc6f-bfb1-4474-9ea6-05e1449a2ed5.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/queueServices-QueueCapacity_7815fc6f-bfb1-4474-9ea6-05e1449a2ed5.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/queueServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy-arm/queueServices-QueueMessageCount_34769aaa-5014-4ced-bb08-9fabfba3d959.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/queueServices-QueueMessageCount_34769aaa-5014-4ced-bb08-9fabfba3d959.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/queueServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/Availability_b1a4849b-78a8-437f-8113-7c6f2dc34927.json
+++ b/services/Storage/storageAccounts/templates/policy/Availability_b1a4849b-78a8-437f-8113-7c6f2dc34927.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/Egress_eb186756-b63b-408a-bbaf-ac94c1010287.json
+++ b/services/Storage/storageAccounts/templates/policy/Egress_eb186756-b63b-408a-bbaf-ac94c1010287.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/FileShareCount_a4adc774-7ca4-4a4b-b2fa-514b9fcbbc80.json
+++ b/services/Storage/storageAccounts/templates/policy/FileShareCount_a4adc774-7ca4-4a4b-b2fa-514b9fcbbc80.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/fileServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/Ingress_5d872cb4-7f71-4275-81eb-98c968c0cadd.json
+++ b/services/Storage/storageAccounts/templates/policy/Ingress_5d872cb4-7f71-4275-81eb-98c968c0cadd.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/QueueCount_f75dec98-78a3-4e42-954d-375fe3352857.json
+++ b/services/Storage/storageAccounts/templates/policy/QueueCount_f75dec98-78a3-4e42-954d-375fe3352857.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/queueServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/Throttling_5e544473-d84f-427d-869d-9d982619e4cb.json
+++ b/services/Storage/storageAccounts/templates/policy/Throttling_5e544473-d84f-427d-869d-9d982619e4cb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/fileServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/UsedCapacity_b663a689-6db8-467d-8b5d-8cd34afe4b0e.json
+++ b/services/Storage/storageAccounts/templates/policy/UsedCapacity_b663a689-6db8-467d-8b5d-8cd34afe4b0e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/blobServices-BlobCapacity_8c0aaea9-bcce-4c27-a090-ffe54b7e1d1c.json
+++ b/services/Storage/storageAccounts/templates/policy/blobServices-BlobCapacity_8c0aaea9-bcce-4c27-a090-ffe54b7e1d1c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/blobServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/blobServices-BlobCount_c4d93fac-a6b6-4731-a92a-c499b6fb2bcb.json
+++ b/services/Storage/storageAccounts/templates/policy/blobServices-BlobCount_c4d93fac-a6b6-4731-a92a-c499b6fb2bcb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/blobServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/blobServices-SuccessE2ELatency_0acc30dc-881d-46c9-b634-8cba507a263f.json
+++ b/services/Storage/storageAccounts/templates/policy/blobServices-SuccessE2ELatency_0acc30dc-881d-46c9-b634-8cba507a263f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/blobServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/blobServices-SuccessServerLatency_0a3689c7-b610-4c52-ae84-ab0640f3d6e4.json
+++ b/services/Storage/storageAccounts/templates/policy/blobServices-SuccessServerLatency_0a3689c7-b610-4c52-ae84-ab0640f3d6e4.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/blobServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/fileServices-Availability_45fef979-c27e-425a-a6c3-e5bd28b1eb86.json
+++ b/services/Storage/storageAccounts/templates/policy/fileServices-Availability_45fef979-c27e-425a-a6c3-e5bd28b1eb86.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/fileServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/fileServices-FileCapacity_26e09eae-c784-4e8f-a225-d3f13efff76f.json
+++ b/services/Storage/storageAccounts/templates/policy/fileServices-FileCapacity_26e09eae-c784-4e8f-a225-d3f13efff76f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/fileServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/fileServices-FileShareCapacityQuota_8660f357-83f9-4719-bdf3-bae57af2d967.json
+++ b/services/Storage/storageAccounts/templates/policy/fileServices-FileShareCapacityQuota_8660f357-83f9-4719-bdf3-bae57af2d967.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/fileServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/fileServices-FileShareSnapshotCount_8cbe449d-9264-4ae1-8221-5d97989005a8.json
+++ b/services/Storage/storageAccounts/templates/policy/fileServices-FileShareSnapshotCount_8cbe449d-9264-4ae1-8221-5d97989005a8.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/fileServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/fileServices-Transactions_c81d3e6c-5539-42ad-a95f-9bba504d91f0.json
+++ b/services/Storage/storageAccounts/templates/policy/fileServices-Transactions_c81d3e6c-5539-42ad-a95f-9bba504d91f0.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/fileServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/queueServices-QueueCapacity_7815fc6f-bfb1-4474-9ea6-05e1449a2ed5.json
+++ b/services/Storage/storageAccounts/templates/policy/queueServices-QueueCapacity_7815fc6f-bfb1-4474-9ea6-05e1449a2ed5.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/queueServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Storage/storageAccounts/templates/policy/queueServices-QueueMessageCount_34769aaa-5014-4ced-bb08-9fabfba3d959.json
+++ b/services/Storage/storageAccounts/templates/policy/queueServices-QueueMessageCount_34769aaa-5014-4ced-bb08-9fabfba3d959.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/queueServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StorageCache/AmlFilesystems/templates/policy-arm/Uptime_7f951991-c6ce-4c72-9f55-7eade2c4f57c.json
+++ b/services/StorageCache/AmlFilesystems/templates/policy-arm/Uptime_7f951991-c6ce-4c72-9f55-7eade2c4f57c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StorageCache/caches/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StorageCache/AmlFilesystems/templates/policy/Uptime_7f951991-c6ce-4c72-9f55-7eade2c4f57c.json
+++ b/services/StorageCache/AmlFilesystems/templates/policy/Uptime_7f951991-c6ce-4c72-9f55-7eade2c4f57c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StorageCache/caches/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StorageSync/storageSyncServices/templates/policy-arm/ServerSyncSessionResult_ea68cbf2-b8a6-4f47-afda-94cab9ce4622.json
+++ b/services/StorageSync/storageSyncServices/templates/policy-arm/ServerSyncSessionResult_ea68cbf2-b8a6-4f47-afda-94cab9ce4622.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StorageSync/storageSyncServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StorageSync/storageSyncServices/templates/policy-arm/StorageSyncServerHeartbeat_eb627157-b9c8-4e8f-a00e-f9eb7df45c78.json
+++ b/services/StorageSync/storageSyncServices/templates/policy-arm/StorageSyncServerHeartbeat_eb627157-b9c8-4e8f-a00e-f9eb7df45c78.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StorageSync/storageSyncServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StorageSync/storageSyncServices/templates/policy-arm/StorageSyncSyncSessionPerItemErrorsCount_0020bd6d-cd35-491e-9c71-f66bd64ed9a9.json
+++ b/services/StorageSync/storageSyncServices/templates/policy-arm/StorageSyncSyncSessionPerItemErrorsCount_0020bd6d-cd35-491e-9c71-f66bd64ed9a9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StorageSync/storageSyncServices/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StorageSync/storageSyncServices/templates/policy/ServerSyncSessionResult_ea68cbf2-b8a6-4f47-afda-94cab9ce4622.json
+++ b/services/StorageSync/storageSyncServices/templates/policy/ServerSyncSessionResult_ea68cbf2-b8a6-4f47-afda-94cab9ce4622.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StorageSync/storageSyncServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StorageSync/storageSyncServices/templates/policy/StorageSyncServerHeartbeat_eb627157-b9c8-4e8f-a00e-f9eb7df45c78.json
+++ b/services/StorageSync/storageSyncServices/templates/policy/StorageSyncServerHeartbeat_eb627157-b9c8-4e8f-a00e-f9eb7df45c78.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StorageSync/storageSyncServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StorageSync/storageSyncServices/templates/policy/StorageSyncSyncSessionPerItemErrorsCount_0020bd6d-cd35-491e-9c71-f66bd64ed9a9.json
+++ b/services/StorageSync/storageSyncServices/templates/policy/StorageSyncSyncSessionPerItemErrorsCount_0020bd6d-cd35-491e-9c71-f66bd64ed9a9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StorageSync/storageSyncServices/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy-arm/AMLCalloutFailedRequests_f0fa5804-9d5f-4e23-91c0-996c561585ef.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy-arm/AMLCalloutFailedRequests_f0fa5804-9d5f-4e23-91c0-996c561585ef.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy-arm/ConversionErrors_7d30aeb3-31e5-4742-aa7e-825c2a6af42a.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy-arm/ConversionErrors_7d30aeb3-31e5-4742-aa7e-825c2a6af42a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy-arm/DeserializationError_381221db-fd9a-4d65-a16f-63e7492b0a49.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy-arm/DeserializationError_381221db-fd9a-4d65-a16f-63e7492b0a49.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy-arm/Errors_ebd9a9cf-7aa1-4c75-8b76-33f94e4bb8ef.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy-arm/Errors_ebd9a9cf-7aa1-4c75-8b76-33f94e4bb8ef.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy-arm/InputEventsSourcesBacklogged_b46ef7a9-6597-4c4f-a5ca-9ca653e1b716.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy-arm/InputEventsSourcesBacklogged_b46ef7a9-6597-4c4f-a5ca-9ca653e1b716.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy-arm/InputEvents_1dc8c746-4caf-4355-9d82-bdeaa1cf95bf.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy-arm/InputEvents_1dc8c746-4caf-4355-9d82-bdeaa1cf95bf.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy-arm/OutputEvents_c0dbcbee-eefd-4ee4-bd25-48d42444c882.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy-arm/OutputEvents_c0dbcbee-eefd-4ee4-bd25-48d42444c882.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy-arm/OutputWatermarkDelaySeconds_289283c0-87ae-475f-b756-306783c7ec4d.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy-arm/OutputWatermarkDelaySeconds_289283c0-87ae-475f-b756-306783c7ec4d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy-arm/ProcessCPUUsagePercentage_ea14eb56-238e-42b2-95ae-4d624d720d10.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy-arm/ProcessCPUUsagePercentage_ea14eb56-238e-42b2-95ae-4d624d720d10.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy-arm/ResourceUtilization_4f2ead64-7412-4695-9855-47f36ade6f7e.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy-arm/ResourceUtilization_4f2ead64-7412-4695-9855-47f36ade6f7e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy/AMLCalloutFailedRequests_f0fa5804-9d5f-4e23-91c0-996c561585ef.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy/AMLCalloutFailedRequests_f0fa5804-9d5f-4e23-91c0-996c561585ef.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy/ConversionErrors_7d30aeb3-31e5-4742-aa7e-825c2a6af42a.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy/ConversionErrors_7d30aeb3-31e5-4742-aa7e-825c2a6af42a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy/DeserializationError_381221db-fd9a-4d65-a16f-63e7492b0a49.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy/DeserializationError_381221db-fd9a-4d65-a16f-63e7492b0a49.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy/Errors_ebd9a9cf-7aa1-4c75-8b76-33f94e4bb8ef.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy/Errors_ebd9a9cf-7aa1-4c75-8b76-33f94e4bb8ef.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy/InputEventsSourcesBacklogged_b46ef7a9-6597-4c4f-a5ca-9ca653e1b716.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy/InputEventsSourcesBacklogged_b46ef7a9-6597-4c4f-a5ca-9ca653e1b716.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy/InputEvents_1dc8c746-4caf-4355-9d82-bdeaa1cf95bf.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy/InputEvents_1dc8c746-4caf-4355-9d82-bdeaa1cf95bf.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy/OutputEvents_c0dbcbee-eefd-4ee4-bd25-48d42444c882.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy/OutputEvents_c0dbcbee-eefd-4ee4-bd25-48d42444c882.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy/OutputWatermarkDelaySeconds_289283c0-87ae-475f-b756-306783c7ec4d.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy/OutputWatermarkDelaySeconds_289283c0-87ae-475f-b756-306783c7ec4d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy/ProcessCPUUsagePercentage_ea14eb56-238e-42b2-95ae-4d624d720d10.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy/ProcessCPUUsagePercentage_ea14eb56-238e-42b2-95ae-4d624d720d10.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/StreamAnalytics/streamingjobs/templates/policy/ResourceUtilization_4f2ead64-7412-4695-9855-47f36ade6f7e.json
+++ b/services/StreamAnalytics/streamingjobs/templates/policy/ResourceUtilization_4f2ead64-7412-4695-9855-47f36ade6f7e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.StreamAnalytics/streamingjobs/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy-arm/BuiltinSqlPoolDataProcessedBytes_8e2a7c77-890c-49d5-aadd-052764135995.json
+++ b/services/Synapse/workspaces/templates/policy-arm/BuiltinSqlPoolDataProcessedBytes_8e2a7c77-890c-49d5-aadd-052764135995.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy-arm/BuiltinSqlPoolLoginAttempts_6cf01e09-24d5-4097-bac1-1d39b0f577c8.json
+++ b/services/Synapse/workspaces/templates/policy-arm/BuiltinSqlPoolLoginAttempts_6cf01e09-24d5-4097-bac1-1d39b0f577c8.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy-arm/IntegrationActivityRunsEnded_21280a1a-d4e5-4ec3-83f5-f8d22ae0340a.json
+++ b/services/Synapse/workspaces/templates/policy-arm/IntegrationActivityRunsEnded_21280a1a-d4e5-4ec3-83f5-f8d22ae0340a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy-arm/IntegrationPipelineRunsEnded_16072e08-8ffb-48c9-afa9-fe2192b4513b.json
+++ b/services/Synapse/workspaces/templates/policy-arm/IntegrationPipelineRunsEnded_16072e08-8ffb-48c9-afa9-fe2192b4513b.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy-arm/IntegrationTriggerRunsEnded_583c6484-b7a3-4908-b4d4-9a8b08d1edf9.json
+++ b/services/Synapse/workspaces/templates/policy-arm/IntegrationTriggerRunsEnded_583c6484-b7a3-4908-b4d4-9a8b08d1edf9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy-arm/sqlPools-CPUPercent_d8d1bc29-bfdb-48a5-89bd-7e34522d8085.json
+++ b/services/Synapse/workspaces/templates/policy-arm/sqlPools-CPUPercent_d8d1bc29-bfdb-48a5-89bd-7e34522d8085.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/sqlPools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy-arm/sqlPools-DWUUsedPercent_64f41eaa-048f-4892-b80f-593e74ef4f84.json
+++ b/services/Synapse/workspaces/templates/policy-arm/sqlPools-DWUUsedPercent_64f41eaa-048f-4892-b80f-593e74ef4f84.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/sqlPools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy-arm/sqlPools-MemoryUsedPercent_4c4d35e8-fdd7-4951-8a71-7b9add69d337.json
+++ b/services/Synapse/workspaces/templates/policy-arm/sqlPools-MemoryUsedPercent_4c4d35e8-fdd7-4951-8a71-7b9add69d337.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/sqlPools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy/BuiltinSqlPoolDataProcessedBytes_8e2a7c77-890c-49d5-aadd-052764135995.json
+++ b/services/Synapse/workspaces/templates/policy/BuiltinSqlPoolDataProcessedBytes_8e2a7c77-890c-49d5-aadd-052764135995.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy/BuiltinSqlPoolLoginAttempts_6cf01e09-24d5-4097-bac1-1d39b0f577c8.json
+++ b/services/Synapse/workspaces/templates/policy/BuiltinSqlPoolLoginAttempts_6cf01e09-24d5-4097-bac1-1d39b0f577c8.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy/IntegrationActivityRunsEnded_21280a1a-d4e5-4ec3-83f5-f8d22ae0340a.json
+++ b/services/Synapse/workspaces/templates/policy/IntegrationActivityRunsEnded_21280a1a-d4e5-4ec3-83f5-f8d22ae0340a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy/IntegrationPipelineRunsEnded_16072e08-8ffb-48c9-afa9-fe2192b4513b.json
+++ b/services/Synapse/workspaces/templates/policy/IntegrationPipelineRunsEnded_16072e08-8ffb-48c9-afa9-fe2192b4513b.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy/IntegrationTriggerRunsEnded_583c6484-b7a3-4908-b4d4-9a8b08d1edf9.json
+++ b/services/Synapse/workspaces/templates/policy/IntegrationTriggerRunsEnded_583c6484-b7a3-4908-b4d4-9a8b08d1edf9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy/sqlPools-CPUPercent_d8d1bc29-bfdb-48a5-89bd-7e34522d8085.json
+++ b/services/Synapse/workspaces/templates/policy/sqlPools-CPUPercent_d8d1bc29-bfdb-48a5-89bd-7e34522d8085.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/sqlPools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy/sqlPools-DWUUsedPercent_64f41eaa-048f-4892-b80f-593e74ef4f84.json
+++ b/services/Synapse/workspaces/templates/policy/sqlPools-DWUUsedPercent_64f41eaa-048f-4892-b80f-593e74ef4f84.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/sqlPools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Synapse/workspaces/templates/policy/sqlPools-MemoryUsedPercent_4c4d35e8-fdd7-4951-8a71-7b9add69d337.json
+++ b/services/Synapse/workspaces/templates/policy/sqlPools-MemoryUsedPercent_4c4d35e8-fdd7-4951-8a71-7b9add69d337.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Synapse/workspaces/sqlPools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/hostingEnvironments/templates/policy-arm/CpuPercentage_f6c1126c-48cf-499a-b0a2-e4fdd80cdf0e.json
+++ b/services/Web/hostingEnvironments/templates/policy-arm/CpuPercentage_f6c1126c-48cf-499a-b0a2-e4fdd80cdf0e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/hostingEnvironments/multiRolePools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/hostingEnvironments/templates/policy-arm/HttpQueueLength_c7ad761f-19bf-4289-ab47-2721c6d387eb.json
+++ b/services/Web/hostingEnvironments/templates/policy-arm/HttpQueueLength_c7ad761f-19bf-4289-ab47-2721c6d387eb.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/hostingEnvironments/multiRolePools/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/hostingEnvironments/templates/policy/CpuPercentage_f6c1126c-48cf-499a-b0a2-e4fdd80cdf0e.json
+++ b/services/Web/hostingEnvironments/templates/policy/CpuPercentage_f6c1126c-48cf-499a-b0a2-e4fdd80cdf0e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/hostingEnvironments/multiRolePools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/hostingEnvironments/templates/policy/HttpQueueLength_c7ad761f-19bf-4289-ab47-2721c6d387eb.json
+++ b/services/Web/hostingEnvironments/templates/policy/HttpQueueLength_c7ad761f-19bf-4289-ab47-2721c6d387eb.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/hostingEnvironments/multiRolePools/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy-arm/BytesReceived_7bdc68c3-7679-482d-82e4-92a8229db9d7.json
+++ b/services/Web/serverFarms/templates/policy-arm/BytesReceived_7bdc68c3-7679-482d-82e4-92a8229db9d7.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy-arm/BytesSent_520cc4d4-2caa-42df-b8b7-86dbc4786ce6.json
+++ b/services/Web/serverFarms/templates/policy-arm/BytesSent_520cc4d4-2caa-42df-b8b7-86dbc4786ce6.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy-arm/CpuPercentage_8748b7d6-ef2a-4548-bf8e-dc6eecd2a651.json
+++ b/services/Web/serverFarms/templates/policy-arm/CpuPercentage_8748b7d6-ef2a-4548-bf8e-dc6eecd2a651.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy-arm/DiskQueueLength_14dbacac-2559-4537-9be9-7d08bdd0888d.json
+++ b/services/Web/serverFarms/templates/policy-arm/DiskQueueLength_14dbacac-2559-4537-9be9-7d08bdd0888d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy-arm/HttpQueueLength_e85efb6a-239a-41e0-8cdd-b1792c41ec41.json
+++ b/services/Web/serverFarms/templates/policy-arm/HttpQueueLength_e85efb6a-239a-41e0-8cdd-b1792c41ec41.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy-arm/MemoryPercentage_b87ecc60-7558-4cb4-8ef9-3185c4c19579.json
+++ b/services/Web/serverFarms/templates/policy-arm/MemoryPercentage_b87ecc60-7558-4cb4-8ef9-3185c4c19579.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy-arm/SocketOutboundAll_96257455-b2cf-4f35-9c64-00eea637471a.json
+++ b/services/Web/serverFarms/templates/policy-arm/SocketOutboundAll_96257455-b2cf-4f35-9c64-00eea637471a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy-arm/TcpEstablished_f03350e9-f936-4ac0-a64f-2d2df1fc9f75.json
+++ b/services/Web/serverFarms/templates/policy-arm/TcpEstablished_f03350e9-f936-4ac0-a64f-2d2df1fc9f75.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy-arm/TcpTimeWait_2a129b1b-36a7-4048-9403-004dc5e6b0b2.json
+++ b/services/Web/serverFarms/templates/policy-arm/TcpTimeWait_2a129b1b-36a7-4048-9403-004dc5e6b0b2.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy/BytesReceived_7bdc68c3-7679-482d-82e4-92a8229db9d7.json
+++ b/services/Web/serverFarms/templates/policy/BytesReceived_7bdc68c3-7679-482d-82e4-92a8229db9d7.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy/BytesSent_520cc4d4-2caa-42df-b8b7-86dbc4786ce6.json
+++ b/services/Web/serverFarms/templates/policy/BytesSent_520cc4d4-2caa-42df-b8b7-86dbc4786ce6.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy/CpuPercentage_8748b7d6-ef2a-4548-bf8e-dc6eecd2a651.json
+++ b/services/Web/serverFarms/templates/policy/CpuPercentage_8748b7d6-ef2a-4548-bf8e-dc6eecd2a651.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy/DiskQueueLength_14dbacac-2559-4537-9be9-7d08bdd0888d.json
+++ b/services/Web/serverFarms/templates/policy/DiskQueueLength_14dbacac-2559-4537-9be9-7d08bdd0888d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy/HttpQueueLength_e85efb6a-239a-41e0-8cdd-b1792c41ec41.json
+++ b/services/Web/serverFarms/templates/policy/HttpQueueLength_e85efb6a-239a-41e0-8cdd-b1792c41ec41.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy/MemoryPercentage_b87ecc60-7558-4cb4-8ef9-3185c4c19579.json
+++ b/services/Web/serverFarms/templates/policy/MemoryPercentage_b87ecc60-7558-4cb4-8ef9-3185c4c19579.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy/SocketOutboundAll_96257455-b2cf-4f35-9c64-00eea637471a.json
+++ b/services/Web/serverFarms/templates/policy/SocketOutboundAll_96257455-b2cf-4f35-9c64-00eea637471a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy/TcpEstablished_f03350e9-f936-4ac0-a64f-2d2df1fc9f75.json
+++ b/services/Web/serverFarms/templates/policy/TcpEstablished_f03350e9-f936-4ac0-a64f-2d2df1fc9f75.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/serverFarms/templates/policy/TcpTimeWait_2a129b1b-36a7-4048-9403-004dc5e6b0b2.json
+++ b/services/Web/serverFarms/templates/policy/TcpTimeWait_2a129b1b-36a7-4048-9403-004dc5e6b0b2.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/serverFarms/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/AppConnections_a74bd8f3-cab7-46e6-ac1e-7527d2385bee.json
+++ b/services/Web/sites/templates/policy-arm/AppConnections_a74bd8f3-cab7-46e6-ac1e-7527d2385bee.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/AverageResponseTime_b16f8234-e6c6-4723-933e-e5f8c179f23d.json
+++ b/services/Web/sites/templates/policy-arm/AverageResponseTime_b16f8234-e6c6-4723-933e-e5f8c179f23d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/BytesReceived_a9177e32-e3fa-425a-a02e-727ff3515ae0.json
+++ b/services/Web/sites/templates/policy-arm/BytesReceived_a9177e32-e3fa-425a-a02e-727ff3515ae0.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/BytesSent_49f62a85-7edf-4afc-9201-7a8939d6a42a.json
+++ b/services/Web/sites/templates/policy-arm/BytesSent_49f62a85-7edf-4afc-9201-7a8939d6a42a.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/CpuTime_48fcc15e-f043-4bb5-a628-6aefc60432c1.json
+++ b/services/Web/sites/templates/policy-arm/CpuTime_48fcc15e-f043-4bb5-a628-6aefc60432c1.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/CurrentAssemblies_b63593ad-6c47-49e3-9b4a-e8b19f0cc7db.json
+++ b/services/Web/sites/templates/policy-arm/CurrentAssemblies_b63593ad-6c47-49e3-9b4a-e8b19f0cc7db.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/FileSystemUsage_b0c0fca3-1832-4a18-8832-5eebd2c1370a.json
+++ b/services/Web/sites/templates/policy-arm/FileSystemUsage_b0c0fca3-1832-4a18-8832-5eebd2c1370a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/FunctionExecutionCount_1e71d59c-b29f-4b43-9f49-7aa0da50c88c.json
+++ b/services/Web/sites/templates/policy-arm/FunctionExecutionCount_1e71d59c-b29f-4b43-9f49-7aa0da50c88c.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/FunctionExecutionUnits_12241b03-3f62-4100-9cf3-7798a7796600.json
+++ b/services/Web/sites/templates/policy-arm/FunctionExecutionUnits_12241b03-3f62-4100-9cf3-7798a7796600.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/Handles_dc560ab2-18ad-49ae-9937-9b9a770faaab.json
+++ b/services/Web/sites/templates/policy-arm/Handles_dc560ab2-18ad-49ae-9937-9b9a770faaab.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/Http2xx_e4fa68d2-55cd-4371-9574-95ae5c34d4ae.json
+++ b/services/Web/sites/templates/policy-arm/Http2xx_e4fa68d2-55cd-4371-9574-95ae5c34d4ae.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/Http3xx_0853a13e-b316-4ea0-98a2-9d722a508d1e.json
+++ b/services/Web/sites/templates/policy-arm/Http3xx_0853a13e-b316-4ea0-98a2-9d722a508d1e.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/Http401_a8024ffc-b3b7-48eb-8f24-ae7da834cde2.json
+++ b/services/Web/sites/templates/policy-arm/Http401_a8024ffc-b3b7-48eb-8f24-ae7da834cde2.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/Http406_02ef5600-fed6-474a-8fbb-5ed088b04d0d.json
+++ b/services/Web/sites/templates/policy-arm/Http406_02ef5600-fed6-474a-8fbb-5ed088b04d0d.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/MemoryWorkingSet_93768520-ab75-4e4e-b39b-a210a32379c0.json
+++ b/services/Web/sites/templates/policy-arm/MemoryWorkingSet_93768520-ab75-4e4e-b39b-a210a32379c0.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/PrivateBytes_3acdc4ab-514c-42c3-82e1-cb41fa338c2f.json
+++ b/services/Web/sites/templates/policy-arm/PrivateBytes_3acdc4ab-514c-42c3-82e1-cb41fa338c2f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/RequestsInApplicationQueue_2e62242b-6d20-44b5-86f9-f9a0de8ffe3f.json
+++ b/services/Web/sites/templates/policy-arm/RequestsInApplicationQueue_2e62242b-6d20-44b5-86f9-f9a0de8ffe3f.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/Requests_fa87c863-2d21-4b9d-897f-452fd35b06c3.json
+++ b/services/Web/sites/templates/policy-arm/Requests_fa87c863-2d21-4b9d-897f-452fd35b06c3.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/Threads_9e412261-433b-45fd-8944-2f891bf14a56.json
+++ b/services/Web/sites/templates/policy-arm/Threads_9e412261-433b-45fd-8944-2f891bf14a56.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/WorkflowRunsFailureRate_89ec4b6f-d1b2-4402-8a1d-48440624fc31.json
+++ b/services/Web/sites/templates/policy-arm/WorkflowRunsFailureRate_89ec4b6f-d1b2-4402-8a1d-48440624fc31.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/WorkflowTriggersFailureRate_8a492278-c49f-4e4c-8fd5-a1680590864a.json
+++ b/services/Web/sites/templates/policy-arm/WorkflowTriggersFailureRate_8a492278-c49f-4e4c-8fd5-a1680590864a.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/slots-AverageMemoryWorkingSet_e6f23a76-11f3-471e-b7d7-ebc787487069.json
+++ b/services/Web/sites/templates/policy-arm/slots-AverageMemoryWorkingSet_e6f23a76-11f3-471e-b7d7-ebc787487069.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/slots/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/slots-HealthCheckStatus_ff5238a3-e40f-47c7-a142-f7a19b7764f9.json
+++ b/services/Web/sites/templates/policy-arm/slots-HealthCheckStatus_ff5238a3-e40f-47c7-a142-f7a19b7764f9.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/slots/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/slots-Http403_67ca6d43-ab88-4fb8-9c18-2862765681e6.json
+++ b/services/Web/sites/templates/policy-arm/slots-Http403_67ca6d43-ab88-4fb8-9c18-2862765681e6.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/slots/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/slots-Http404_265b54e0-33a0-44b3-9f7b-ce53328439e3.json
+++ b/services/Web/sites/templates/policy-arm/slots-Http404_265b54e0-33a0-44b3-9f7b-ce53328439e3.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/slots/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/slots-Http4xx_0bdd95e0-1d48-40e5-85c7-cd8008b966b0.json
+++ b/services/Web/sites/templates/policy-arm/slots-Http4xx_0bdd95e0-1d48-40e5-85c7-cd8008b966b0.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/slots/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/slots-Http5xx_fe7cfeb1-c18f-4822-8e6c-fb73dcd175a8.json
+++ b/services/Web/sites/templates/policy-arm/slots-Http5xx_fe7cfeb1-c18f-4822-8e6c-fb73dcd175a8.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/slots/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy-arm/slots-HttpResponseTime_b4e2bc80-9307-44d8-89f1-04c7133f37fc.json
+++ b/services/Web/sites/templates/policy-arm/slots-HttpResponseTime_b4e2bc80-9307-44d8-89f1-04c7133f37fc.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/slots/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/AppConnections_a74bd8f3-cab7-46e6-ac1e-7527d2385bee.json
+++ b/services/Web/sites/templates/policy/AppConnections_a74bd8f3-cab7-46e6-ac1e-7527d2385bee.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/AverageResponseTime_b16f8234-e6c6-4723-933e-e5f8c179f23d.json
+++ b/services/Web/sites/templates/policy/AverageResponseTime_b16f8234-e6c6-4723-933e-e5f8c179f23d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/BytesReceived_a9177e32-e3fa-425a-a02e-727ff3515ae0.json
+++ b/services/Web/sites/templates/policy/BytesReceived_a9177e32-e3fa-425a-a02e-727ff3515ae0.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/BytesSent_49f62a85-7edf-4afc-9201-7a8939d6a42a.json
+++ b/services/Web/sites/templates/policy/BytesSent_49f62a85-7edf-4afc-9201-7a8939d6a42a.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/CpuTime_48fcc15e-f043-4bb5-a628-6aefc60432c1.json
+++ b/services/Web/sites/templates/policy/CpuTime_48fcc15e-f043-4bb5-a628-6aefc60432c1.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/CurrentAssemblies_b63593ad-6c47-49e3-9b4a-e8b19f0cc7db.json
+++ b/services/Web/sites/templates/policy/CurrentAssemblies_b63593ad-6c47-49e3-9b4a-e8b19f0cc7db.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/FileSystemUsage_b0c0fca3-1832-4a18-8832-5eebd2c1370a.json
+++ b/services/Web/sites/templates/policy/FileSystemUsage_b0c0fca3-1832-4a18-8832-5eebd2c1370a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/FunctionExecutionCount_1e71d59c-b29f-4b43-9f49-7aa0da50c88c.json
+++ b/services/Web/sites/templates/policy/FunctionExecutionCount_1e71d59c-b29f-4b43-9f49-7aa0da50c88c.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/FunctionExecutionUnits_12241b03-3f62-4100-9cf3-7798a7796600.json
+++ b/services/Web/sites/templates/policy/FunctionExecutionUnits_12241b03-3f62-4100-9cf3-7798a7796600.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/Handles_dc560ab2-18ad-49ae-9937-9b9a770faaab.json
+++ b/services/Web/sites/templates/policy/Handles_dc560ab2-18ad-49ae-9937-9b9a770faaab.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/Http2xx_e4fa68d2-55cd-4371-9574-95ae5c34d4ae.json
+++ b/services/Web/sites/templates/policy/Http2xx_e4fa68d2-55cd-4371-9574-95ae5c34d4ae.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/Http3xx_0853a13e-b316-4ea0-98a2-9d722a508d1e.json
+++ b/services/Web/sites/templates/policy/Http3xx_0853a13e-b316-4ea0-98a2-9d722a508d1e.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/Http401_a8024ffc-b3b7-48eb-8f24-ae7da834cde2.json
+++ b/services/Web/sites/templates/policy/Http401_a8024ffc-b3b7-48eb-8f24-ae7da834cde2.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/Http406_02ef5600-fed6-474a-8fbb-5ed088b04d0d.json
+++ b/services/Web/sites/templates/policy/Http406_02ef5600-fed6-474a-8fbb-5ed088b04d0d.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/MemoryWorkingSet_93768520-ab75-4e4e-b39b-a210a32379c0.json
+++ b/services/Web/sites/templates/policy/MemoryWorkingSet_93768520-ab75-4e4e-b39b-a210a32379c0.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/PrivateBytes_3acdc4ab-514c-42c3-82e1-cb41fa338c2f.json
+++ b/services/Web/sites/templates/policy/PrivateBytes_3acdc4ab-514c-42c3-82e1-cb41fa338c2f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/RequestsInApplicationQueue_2e62242b-6d20-44b5-86f9-f9a0de8ffe3f.json
+++ b/services/Web/sites/templates/policy/RequestsInApplicationQueue_2e62242b-6d20-44b5-86f9-f9a0de8ffe3f.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/Requests_fa87c863-2d21-4b9d-897f-452fd35b06c3.json
+++ b/services/Web/sites/templates/policy/Requests_fa87c863-2d21-4b9d-897f-452fd35b06c3.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/Threads_9e412261-433b-45fd-8944-2f891bf14a56.json
+++ b/services/Web/sites/templates/policy/Threads_9e412261-433b-45fd-8944-2f891bf14a56.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/WorkflowRunsFailureRate_89ec4b6f-d1b2-4402-8a1d-48440624fc31.json
+++ b/services/Web/sites/templates/policy/WorkflowRunsFailureRate_89ec4b6f-d1b2-4402-8a1d-48440624fc31.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/WorkflowTriggersFailureRate_8a492278-c49f-4e4c-8fd5-a1680590864a.json
+++ b/services/Web/sites/templates/policy/WorkflowTriggersFailureRate_8a492278-c49f-4e4c-8fd5-a1680590864a.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/slots-AverageMemoryWorkingSet_e6f23a76-11f3-471e-b7d7-ebc787487069.json
+++ b/services/Web/sites/templates/policy/slots-AverageMemoryWorkingSet_e6f23a76-11f3-471e-b7d7-ebc787487069.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/slots/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/slots-HealthCheckStatus_ff5238a3-e40f-47c7-a142-f7a19b7764f9.json
+++ b/services/Web/sites/templates/policy/slots-HealthCheckStatus_ff5238a3-e40f-47c7-a142-f7a19b7764f9.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/slots/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/slots-Http403_67ca6d43-ab88-4fb8-9c18-2862765681e6.json
+++ b/services/Web/sites/templates/policy/slots-Http403_67ca6d43-ab88-4fb8-9c18-2862765681e6.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/slots/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/slots-Http404_265b54e0-33a0-44b3-9f7b-ce53328439e3.json
+++ b/services/Web/sites/templates/policy/slots-Http404_265b54e0-33a0-44b3-9f7b-ce53328439e3.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/slots/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/slots-Http4xx_0bdd95e0-1d48-40e5-85c7-cd8008b966b0.json
+++ b/services/Web/sites/templates/policy/slots-Http4xx_0bdd95e0-1d48-40e5-85c7-cd8008b966b0.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/slots/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/slots-Http5xx_fe7cfeb1-c18f-4822-8e6c-fb73dcd175a8.json
+++ b/services/Web/sites/templates/policy/slots-Http5xx_fe7cfeb1-c18f-4822-8e6c-fb73dcd175a8.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/slots/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/services/Web/sites/templates/policy/slots-HttpResponseTime_b4e2bc80-9307-44d8-89f1-04c7133f37fc.json
+++ b/services/Web/sites/templates/policy/slots-HttpResponseTime_b4e2bc80-9307-44d8-89f1-04c7133f37fc.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Web/sites/slots/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/tooling/generate-templates/policy/metric-dynamic-full-arm.json
+++ b/tooling/generate-templates/policy/metric-dynamic-full-arm.json
@@ -205,7 +205,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/##METRIC_NAMESPACE##/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/tooling/generate-templates/policy/metric-dynamic.json
+++ b/tooling/generate-templates/policy/metric-dynamic.json
@@ -166,7 +166,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/##METRIC_NAMESPACE##/', field('fullName'))]"
+                "equals": "[[field('id')]]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/tooling/generate-templates/policy/metric-static-full-arm.json
+++ b/tooling/generate-templates/policy/metric-static-full-arm.json
@@ -204,7 +204,7 @@
                   },
                   {
                     "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                    "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/##METRIC_NAMESPACE##/', field('fullName'))]"
+                    "equals": "[[field('id')]"
                   },
                   {
                     "field": "Microsoft.Insights/metricAlerts/enabled",

--- a/tooling/generate-templates/policy/metric-static.json
+++ b/tooling/generate-templates/policy/metric-static.json
@@ -165,7 +165,7 @@
               },
               {
                 "field": "Microsoft.Insights/metricalerts/scopes[*]",
-                "equals": "[[concat(subscription().id, '/resourceGroups/', resourceGroup().name, '/providers/##METRIC_NAMESPACE##/', field('fullName'))]"
+                "equals": "[[field('id')]"
               },
               {
                 "field": "Microsoft.Insights/metricAlerts/enabled",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Updated policy templates to check metric alerts "scopes" field correctly. 

## This PR fixes/adds/changes/removes

1. Fixes compliance check failure when checking a resource that has 3 segments.  For example, Microsoft.Sql/servers/databases/
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

### Testing evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
