### PR TITLE
add parameter AGWUnhealthyHostCountThreshold

### DIFF
--- a/patterns/alz/alzArm.param.json
+++ b/patterns/alz/alzArm.param.json
@@ -2160,6 +2160,9 @@
         "AGWUnhealthyHostCountAlertSeverity": {
           "value": "2"
         },
+        "AGWUnhealthyHostCountThreshold": {
+          "value": "20"
+        },
         "AGWUnhealthyHostCountWindowSize": {
           "value": "PT5M"
         },

--- a/patterns/alz/eslzArm.terraform-sync.param.json
+++ b/patterns/alz/eslzArm.terraform-sync.param.json
@@ -2160,6 +2160,9 @@
         "AGWUnhealthyHostCountAlertSeverity": {
           "value": "2"
         },
+        "AGWUnhealthyHostCountThreshold": {
+          "value": "20"
+        },
         "AGWUnhealthyHostCountWindowSize": {
           "value": "PT5M"
         },

--- a/patterns/alz/policyDefinitions/policySets.json
+++ b/patterns/alz/policyDefinitions/policySets.json
@@ -2998,14 +2998,6 @@
               "description": "Severity of the alert"
             }
           },
-          "AGWUnhealthyHostCountThreshold": {
-            "type": "string",
-            "defaultValue": "20",
-            "metadata": {
-              "displayName": "AGW Unhealthy Host Count Threshold",
-              "description": "Threshold for the alert"
-            }
-          },
           "AGWUnhealthyHostCountWindowSize": {
             "type": "string",
             "defaultValue": "PT5M",
@@ -5161,9 +5153,6 @@
               },
               "enabled": {
                 "value": "[[[parameters('AGWUnhealthyHostCountAlertState')]"
-              },
-              "threshold": {
-                "value": "[[[parameters('AGWUnhealthyHostCountThreshold')]"
               }
             }
           },

--- a/patterns/alz/policyDefinitions/policySets.json
+++ b/patterns/alz/policyDefinitions/policySets.json
@@ -2998,6 +2998,14 @@
               "description": "Severity of the alert"
             }
           },
+          "AGWUnhealthyHostCountThreshold": {
+            "type": "string",
+            "defaultValue": "20",
+            "metadata": {
+              "displayName": "AGW Unhealthy Host Count Threshold",
+              "description": "Threshold for the alert"
+            }
+          },
           "AGWUnhealthyHostCountWindowSize": {
             "type": "string",
             "defaultValue": "PT5M",
@@ -5153,6 +5161,9 @@
               },
               "enabled": {
                 "value": "[[[parameters('AGWUnhealthyHostCountAlertState')]"
+              },
+              "threshold": {
+                "value": "[[[parameters('AGWUnhealthyHostCountThreshold')]"
               }
             }
           },

--- a/patterns/alz/policySetDefinitions/Deploy-LandingZone-Alerts.json
+++ b/patterns/alz/policySetDefinitions/Deploy-LandingZone-Alerts.json
@@ -2881,6 +2881,14 @@
           "description": "Severity of the alert"
         }
       },
+      "AGWUnhealthyHostCountThreshold": {
+        "type": "string",
+        "defaultValue": "20",
+        "metadata": {
+          "displayName": "AGW Unhealthy Host Count Threshold",
+          "description": "Threshold for the alert"
+        }
+      },
       "AGWUnhealthyHostCountWindowSize": {
         "type": "string",
         "defaultValue": "PT5M",
@@ -5036,6 +5044,9 @@
           },
           "enabled": {
             "value": "[[parameters('AGWUnhealthyHostCountAlertState')]"
+          },
+          "threshold": {
+            "value": "[[parameters('AGWUnhealthyHostCountThreshold')]"
           }
         }
       },

--- a/patterns/alz/policySetDefinitions/Deploy-LandingZone-Alerts.json
+++ b/patterns/alz/policySetDefinitions/Deploy-LandingZone-Alerts.json
@@ -2881,14 +2881,6 @@
           "description": "Severity of the alert"
         }
       },
-      "AGWUnhealthyHostCountThreshold": {
-        "type": "string",
-        "defaultValue": "20",
-        "metadata": {
-          "displayName": "AGW Unhealthy Host Count Threshold",
-          "description": "Threshold for the alert"
-        }
-      },
       "AGWUnhealthyHostCountWindowSize": {
         "type": "string",
         "defaultValue": "PT5M",
@@ -5044,9 +5036,6 @@
           },
           "enabled": {
             "value": "[[parameters('AGWUnhealthyHostCountAlertState')]"
-          },
-          "threshold": {
-            "value": "[[parameters('AGWUnhealthyHostCountThreshold')]"
           }
         }
       },

--- a/patterns/alz/policySetDefinitions/Deploy-LoadBalancing-Alerts.json
+++ b/patterns/alz/policySetDefinitions/Deploy-LoadBalancing-Alerts.json
@@ -1076,6 +1076,14 @@
           "description": "Alert state for the alert"
         }
       },
+      "AGWUnhealthyHostCountThreshold": {
+        "type": "string",
+        "defaultValue": "20",
+        "metadata": {
+          "displayName": "AGW Unhealthy Host Count Threshold",
+          "description": "Threshold for the alert"
+        }
+      },
       "LBDatapathAvailabilityAlertSeverity": {
         "type": "String",
         "defaultValue": "0",
@@ -2267,6 +2275,9 @@
           },
           "enabled": {
             "value": "[[parameters('AGWUnhealthyHostCountAlertState')]"
+          },
+          "threshold": {
+            "value": "[[parameters('AGWUnhealthyHostCountThreshold')]"
           },
           "MonitorDisableTagName": {
             "value": "[[parameters('ALZMonitorDisableTagName')]"

--- a/patterns/alz/policySetDefinitions/Deploy-LoadBalancing-Alerts.json
+++ b/patterns/alz/policySetDefinitions/Deploy-LoadBalancing-Alerts.json
@@ -6,7 +6,7 @@
     "displayName": "Deploy Azure Monitor Baseline Alerts (AMBA-ALZ) for Load Balancing",
     "description": "This initiative deploys Azure Monitor Baseline Alerts (AMBA-ALZ) to monitor Load Balancing Services such as Load Balancer, Application Gateway, Traffic Manager, and Azure Front Door.",
     "metadata": {
-      "version": "1.1.2",
+      "version": "1.2.0",
       "category": "Monitoring",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
       "alzCloudEnvironments": [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

The policyDefinition `Deploy_AG_UnhealthyHostCount_Alert` already has the parameter `threshold` with a default value of 20, but the ALZ deployment of AMBA does not have a way to change this value for all alerts.

This PR allows this default threshold to be changed through the policySet `Alerting-LoadBalancing` (Deploy-LoadBalancing-Alerts.json)

The default threshold of 20 is not changed.

## This PR fixes/adds/changes/removes

1. Adds new parameter `AGWUnhealthyHostCountThreshold`

### Breaking Changes

1. None

### Testing evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
