### PR TITLE
fix: refine filtering for modified and added policy files in tests

### DIFF
--- a/.github/actions-pester/Test-ModifiedPolicies.Tests.ps1
+++ b/.github/actions-pester/Test-ModifiedPolicies.Tests.ps1
@@ -2,7 +2,7 @@ Describe 'UnitTest-ModifiedPolicies' {
   BeforeAll {
     Import-Module -Name $PSScriptRoot\PolicyPesterTestHelper.psm1 -Force # -Verbose
 
-    $ModifiedFiles = @(Get-PolicyFiles -DiffFilter "M")
+    $ModifiedFiles = @(Get-PolicyFiles -DiffFilter "M") | Where-Object {($_ -notcontains 'templates') -or ($_ -contains 'policy/') -and ($_ -like "*.json")}
     if ($ModifiedFiles -ne $null) {
       Write-Warning "These are the modified policies:"
       $ModifiedFiles | ForEach-Object {
@@ -13,7 +13,7 @@ Describe 'UnitTest-ModifiedPolicies' {
       Write-Information "There are no modified policies"
     }
 
-    $AddedFiles = @(Get-PolicyFiles -DiffFilter "A")
+    $AddedFiles = @(Get-PolicyFiles -DiffFilter "A") | Where-Object {($_ -notcontains 'templates') -or ($_ -contains 'policy/') -and ($_ -like "*.json")}
     if ($AddedFiles -ne $null) {
       Write-Warning "These are the added policies:"
       $AddedFiles | ForEach-Object {
@@ -26,7 +26,6 @@ Describe 'UnitTest-ModifiedPolicies' {
 
     $ModifiedAddedFiles = $ModifiedFiles + $AddedFiles
 
-    $ModifiedAddedFiles = $ModifiedAddedFiles | Where-Object {($_ -notcontains 'templates') -or ($_ -contains 'policy/') -and ($_ -like "*.json")}
   }
 
   Context "Validate policy metadata" {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. *Replace me*
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

### Testing evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
