### PR TITLE
Update storage alert thresholds verified by PG

### DIFF
--- a/services/Storage/storageAccounts/alerts.yaml
+++ b/services/Storage/storageAccounts/alerts.yaml
@@ -16,8 +16,8 @@
     metricName: Availability
     metricNamespace: Microsoft.Storage/storageAccounts
     severity: 1
-    windowSize: PT5M
-    evaluationFrequency: PT5M
+    windowSize: PT1M
+    evaluationFrequency: PT1M
     timeAggregation: Average
     operator: LessThan
     threshold: 100
@@ -138,7 +138,7 @@
     storage accounts and Blob storage accounts, it is the same as BlobCapacity or
     FileCapacity.
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -156,7 +156,7 @@
     timeAggregation: Average
     operator: GreaterThan
     criterionType: StaticThresholdCriterion
-    threshold: 2251800000000000.0
+    threshold: 500000000000000.0
     enabled: true
   references:
   - name: Account Level Metrics
@@ -229,7 +229,7 @@
   description: The amount of storage used by the storage account's Blob service in
     bytes.
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -238,12 +238,12 @@
     metricName: BlobCapacity
     metricNamespace: Microsoft.Storage/storageAccounts/blobServices
     severity: 3
-    windowSize: P1D
-    evaluationFrequency: PT5M
+    windowSize: PT1H
+    evaluationFrequency: PT1H
     timeAggregation: Average
     operator: GreaterThan
     criterionType: StaticThresholdCriterion
-    threshold: 107374182400.0
+    threshold: 500000000000000.0
     enabled: true
   references:
   - name: Blob Storage Metrics
@@ -319,7 +319,7 @@
   description: The number of blob objects stored in the storage account.
   type: Metric
   verified: false
-  visible: true
+  visible: false
   tags:
   - auto-generated
   - agc-277


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Implemented newly PG signed off disks alert rules for Storage  to AMBA based on excel file. Updated verified property to true for verified alerts. Set BlobCount alert to hidden based on recommendation by PG.

## This PR fixes/adds/changes/removes

1. *Updates to thresholds for storage alerts*
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

### Testing evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
