### PR TITLE
Update VMSS alert thresholds verified by PG

### DIFF
--- a/services/Compute/virtualMachineScaleSets/alerts.yaml
+++ b/services/Compute/virtualMachineScaleSets/alerts.yaml
@@ -56,7 +56,7 @@
   description: The percentage of allocated compute units that are currently in use
     by the Virtual Machine(s)
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -67,8 +67,8 @@
     metricName: Percentage CPU
     metricNamespace: Microsoft.Compute/virtualMachineScaleSets
     severity: 3
-    windowSize: PT5M
-    evaluationFrequency: PT1M
+    windowSize: PT1M
+    evaluationFrequency: PT5M
     timeAggregation: Average
     operator: GreaterThan
     criterionType: StaticThresholdCriterion
@@ -104,7 +104,7 @@
 - name: Data Disk IOPS Consumed Percentage
   description: Percentage of data disk I/Os consumed per minute
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -113,8 +113,8 @@
     metricName: Data Disk IOPS Consumed Percentage
     metricNamespace: Microsoft.Compute/virtualMachineScaleSets
     severity: 3
-    windowSize: PT1H
-    evaluationFrequency: PT30M
+    windowSize: PT30M
+    evaluationFrequency: PT1H
     timeAggregation: Average
     operator: GreaterThan
     criterionType: StaticThresholdCriterion
@@ -176,7 +176,7 @@
   description: Amount of physical memory, in bytes, immediately available for allocation
     to a process or for system use in the Virtual Machine
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -187,8 +187,8 @@
     metricName: Available Memory Bytes
     metricNamespace: Microsoft.Compute/virtualMachineScaleSets
     severity: 2
-    windowSize: PT5M
-    evaluationFrequency: PT1M
+    windowSize: PT1M
+    evaluationFrequency: PT5M
     timeAggregation: Average
     operator: LessThan
     criterionType: StaticThresholdCriterion
@@ -201,7 +201,7 @@
 - name: VmAvailabilityMetric
   description: Measure of Availability of Virtual machines over time.
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -210,8 +210,8 @@
     metricName: VmAvailabilityMetric
     metricNamespace: Microsoft.Compute/virtualMachineScaleSets
     severity: 2
-    windowSize: PT5M
-    evaluationFrequency: PT1M
+    windowSize: PT1M
+    evaluationFrequency: PT5M
     timeAggregation: Average
     operator: LessThan
     criterionType: StaticThresholdCriterion
@@ -225,7 +225,7 @@
   description: The number of bytes received on all network interfaces by the Virtual
     Machine(s) (Incoming Traffic)
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -234,8 +234,8 @@
     metricName: Network In Total
     metricNamespace: Microsoft.Compute/virtualMachineScaleSets
     severity: 3
-    windowSize: PT15M
-    evaluationFrequency: PT5M
+    windowSize: PT5M
+    evaluationFrequency: PT15M
     timeAggregation: Average
     operator: GreaterThan
     criterionType: StaticThresholdCriterion
@@ -254,7 +254,7 @@
   description: The number of bytes out on all network interfaces by the Virtual Machine(s)
     (Outgoing Traffic)
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -263,8 +263,8 @@
     metricName: Network Out Total
     metricNamespace: Microsoft.Compute/virtualMachineScaleSets
     severity: 3
-    windowSize: PT15M
-    evaluationFrequency: PT5M
+    windowSize: PT5M
+    evaluationFrequency: PT15M
     timeAggregation: Average
     operator: GreaterThan
     criterionType: StaticThresholdCriterion
@@ -283,7 +283,7 @@
   description: The number of billable bytes received on all network interfaces by
     the Virtual Machine(s) (Incoming Traffic) (Deprecated)
   type: Metric
-  verified: false
+  verified: true
   visible: true
   tags:
   - auto-generated
@@ -294,8 +294,8 @@
     metricName: Network In
     metricNamespace: Microsoft.Compute/virtualMachineScaleSets
     severity: 2
-    windowSize: PT5M
-    evaluationFrequency: PT1M
+    windowSize: PT1M
+    evaluationFrequency: PT5M
     timeAggregation: Average
     operator: LessThan
     criterionType: StaticThresholdCriterion


### PR DESCRIPTION
Implemented newly PG signed off disks alert rules for VMSS to AMBA based on sign offs excel file. Updated verified property to true for verified alerts.

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. *Updates thresholds for VMSS based on sign offs*
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

### Testing evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
