### PR TITLE
Update policy templates and sql/databases alert YAML to support different sku tiers and kinds

### DIFF
--- a/.github/yml-schemas/defaultDynamicMetric.json
+++ b/.github/yml-schemas/defaultDynamicMetric.json
@@ -27,6 +27,12 @@
                         "type": "string"
                     }
                 },
+                "tier": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "tags": {
                     "type": "array",
                     "items": {

--- a/.github/yml-schemas/defaultStaticMetric.json
+++ b/.github/yml-schemas/defaultStaticMetric.json
@@ -27,6 +27,12 @@
                         "type": "string"
                     }
                 },
+                "tier": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "tags": {
                     "type": "array",
                     "items": {

--- a/services/Sql/servers/alerts.yaml
+++ b/services/Sql/servers/alerts.yaml
@@ -3,6 +3,14 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
+  - DataWarehouse
   tags:
   - auto-generated
   - agc-30217
@@ -28,6 +36,13 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-25557
@@ -53,6 +68,14 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
+  - DataWarehouse
   tags:
   - auto-generated
   - agc-13737
@@ -78,6 +101,13 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-5689
@@ -103,6 +133,14 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
+  - DataWarehouse
   tags:
   - auto-generated
   - agc-3978
@@ -131,6 +169,14 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
+  - DataWarehouse
   tags:
   - auto-generated
   - agc-2020
@@ -156,6 +202,10 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
   tags:
   - auto-generated
   - agc-1363
@@ -182,6 +232,13 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-839
@@ -202,6 +259,13 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-604
@@ -222,6 +286,10 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
   tags:
   - auto-generated
   - agc-542
@@ -243,6 +311,13 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-445
@@ -263,6 +338,10 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-415
@@ -283,6 +362,10 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-392
@@ -303,6 +386,10 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-355
@@ -323,6 +410,8 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - DataWarehouse
   tags:
   - auto-generated
   - agc-337
@@ -344,6 +433,13 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-290
@@ -364,6 +460,8 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - DataWarehouse
   tags:
   - auto-generated
   - agc-253
@@ -384,6 +482,12 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
   tags:
   - auto-generated
   - agc-5563
@@ -404,6 +508,13 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-5158
@@ -424,6 +535,10 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
   tags:
   - auto-generated
   - agc-3917
@@ -444,6 +559,12 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
   tags:
   - auto-generated
   - agc-2773
@@ -464,6 +585,13 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-2113
@@ -484,6 +612,13 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-1483
@@ -504,6 +639,13 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-985
@@ -524,6 +666,13 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-552
@@ -546,6 +695,13 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-500
@@ -568,6 +724,13 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-472
@@ -588,6 +751,12 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
   tags:
   - auto-generated
   - agc-331
@@ -608,6 +777,13 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-295
@@ -624,10 +800,17 @@
     enabled: true
   guid: af66de51-079c-4d34-af92-f52f887642dc
 - name: elasticpools - allocated_data_storage
-  description: Data space allocated. Not applicable to hyperscale
+  description: Data space allocated.
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
+  - GeneralPurpose
+  - BusinessCritical
+  - Hyperscale
   tags:
   - auto-generated
   - agc-270
@@ -648,6 +831,10 @@
   type: Metric
   verified: false
   visible: true
+  tier:
+  - Basic
+  - Standard
+  - Premium
   tags:
   - auto-generated
   - agc-256

--- a/services/Sql/servers/alerts.yaml
+++ b/services/Sql/servers/alerts.yaml
@@ -338,9 +338,11 @@
   type: Metric
   verified: false
   visible: true
+  kind:
+  - v12.0,user,vcore,serverless
+  - v12.0,user,vcore,hyperscale,serverless
   tier:
   - GeneralPurpose
-  - BusinessCritical
   - Hyperscale
   tags:
   - auto-generated
@@ -362,9 +364,11 @@
   type: Metric
   verified: false
   visible: true
+  kind:
+  - v12.0,user,vcore,serverless
+  - v12.0,user,vcore,hyperscale,serverless
   tier:
   - GeneralPurpose
-  - BusinessCritical
   - Hyperscale
   tags:
   - auto-generated

--- a/services/Sql/servers/templates/policy-arm/databases-appcpupercent_05591510-5fe2-454a-96d8-bbda8201c6a4.json
+++ b/services/Sql/servers/templates/policy-arm/databases-appcpupercent_05591510-5fe2-454a-96d8-bbda8201c6a4.json
@@ -179,6 +179,14 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "kind",
+                "in": ["v12.0,user,vcore,serverless","v12.0,user,vcore,hyperscale,serverless"]
+              },
+              {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["GeneralPurpose","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-appmemorypercent_c5c95fe9-a4b4-4afa-a07a-a0d18804d416.json
+++ b/services/Sql/servers/templates/policy-arm/databases-appmemorypercent_c5c95fe9-a4b4-4afa-a07a-a0d18804d416.json
@@ -179,6 +179,14 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "kind",
+                "in": ["v12.0,user,vcore,serverless","v12.0,user,vcore,hyperscale,serverless"]
+              },
+              {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["GeneralPurpose","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-blockedbyfirewall_2cda2f3a-8657-431a-a50f-56835aea9a81.json
+++ b/services/Sql/servers/templates/policy-arm/databases-blockedbyfirewall_2cda2f3a-8657-431a-a50f-56835aea9a81.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale","DataWarehouse"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-connectionfailed_7157dc17-9d5a-4835-a122-1d0d904d61ff.json
+++ b/services/Sql/servers/templates/policy-arm/databases-connectionfailed_7157dc17-9d5a-4835-a122-1d0d904d61ff.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale","DataWarehouse"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-connectionfailedusererror_d528ffcb-3a99-4356-96d1-981499139ffb.json
+++ b/services/Sql/servers/templates/policy-arm/databases-connectionfailedusererror_d528ffcb-3a99-4356-96d1-981499139ffb.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale","DataWarehouse"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-connectionsuccessful_460b6b29-a602-4409-b748-6b47b232a984.json
+++ b/services/Sql/servers/templates/policy-arm/databases-connectionsuccessful_460b6b29-a602-4409-b748-6b47b232a984.json
@@ -180,6 +180,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale","DataWarehouse"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-cpuused_3ddd3f95-989c-4777-b6b8-728439aae1df.json
+++ b/services/Sql/servers/templates/policy-arm/databases-cpuused_3ddd3f95-989c-4777-b6b8-728439aae1df.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-deadlock_ce44fc81-3610-4165-a107-9dd4b8ab3972.json
+++ b/services/Sql/servers/templates/policy-arm/databases-deadlock_ce44fc81-3610-4165-a107-9dd4b8ab3972.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-dtulimit_50124594-a291-4183-a8e3-195f5e6f5204.json
+++ b/services/Sql/servers/templates/policy-arm/databases-dtulimit_50124594-a291-4183-a8e3-195f5e6f5204.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["Basic","Standard","Premium"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-dtuused_d26f4c8b-0461-4c57-b230-cbd1a5424db1.json
+++ b/services/Sql/servers/templates/policy-arm/databases-dtuused_d26f4c8b-0461-4c57-b230-cbd1a5424db1.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["Basic","Standard","Premium"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-dwuconsumptionpercent_70f88865-7a8b-4e03-9252-a9369df503ef.json
+++ b/services/Sql/servers/templates/policy-arm/databases-dwuconsumptionpercent_70f88865-7a8b-4e03-9252-a9369df503ef.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["DataWarehouse"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-memoryusagepercent_f5c13b49-8528-457d-9d7d-083b8433bf96.json
+++ b/services/Sql/servers/templates/policy-arm/databases-memoryusagepercent_f5c13b49-8528-457d-9d7d-083b8433bf96.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["DataWarehouse"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-sessionscount_07eeae07-010e-47ca-ad90-fa7adb5a6c52.json
+++ b/services/Sql/servers/templates/policy-arm/databases-sessionscount_07eeae07-010e-47ca-ad90-fa7adb5a6c52.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-sqlinstancecpupercent_1a8132b9-fbd2-4ac5-9e08-96358e16b7f7.json
+++ b/services/Sql/servers/templates/policy-arm/databases-sqlinstancecpupercent_1a8132b9-fbd2-4ac5-9e08-96358e16b7f7.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-sqlinstancememorypercent_f44a3cb0-6e99-4a5e-a691-c5d7d5bf7e64.json
+++ b/services/Sql/servers/templates/policy-arm/databases-sqlinstancememorypercent_f44a3cb0-6e99-4a5e-a691-c5d7d5bf7e64.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-storage_86922a27-41bb-4834-bc54-0b602b275597.json
+++ b/services/Sql/servers/templates/policy-arm/databases-storage_86922a27-41bb-4834-bc54-0b602b275597.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/databases-tempdbdatasize_0fe27fd1-e4f7-48c1-bbd2-a6953755d5e8.json
+++ b/services/Sql/servers/templates/policy-arm/databases-tempdbdatasize_0fe27fd1-e4f7-48c1-bbd2-a6953755d5e8.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "Microsoft.Sql/servers/databases/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/elasticpools-allocateddatastorage_3743016a-a056-43fe-b53a-36dd9a17626d.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-allocateddatastorage_3743016a-a056-43fe-b53a-36dd9a17626d.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/elasticpools"
               },
               {
+                "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/elasticpools-allocateddatastoragepercent_7e9d0710-3243-4cf2-8b73-6be1539b8545.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-allocateddatastoragepercent_7e9d0710-3243-4cf2-8b73-6be1539b8545.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/elasticpools"
               },
               {
+                "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/elasticpools-cpupercent_805c4ae5-a852-43bd-ad1c-0f7f381d8f32.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-cpupercent_805c4ae5-a852-43bd-ad1c-0f7f381d8f32.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/elasticpools"
               },
               {
+                "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/elasticpools-dtuconsumptionpercent_5d9075b5-3c19-4cf6-9c2e-50ba4c175691.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-dtuconsumptionpercent_5d9075b5-3c19-4cf6-9c2e-50ba4c175691.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/elasticpools"
               },
               {
+                "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+                "in": ["Basic","Standard","Premium"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/elasticpools-eDTUused_16a64053-1905-4d8e-8198-810584cad108.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-eDTUused_16a64053-1905-4d8e-8198-810584cad108.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/elasticpools"
               },
               {
+                "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+                "in": ["Basic","Standard","Premium"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/elasticpools-logwritepercent_47cd814e-1991-437e-8feb-e589a250d2a3.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-logwritepercent_47cd814e-1991-437e-8feb-e589a250d2a3.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/elasticpools"
               },
               {
+                "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/elasticpools-physicaldatareadpercent_92efc2ea-b6ed-41aa-921c-6d40e7b58c27.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-physicaldatareadpercent_92efc2ea-b6ed-41aa-921c-6d40e7b58c27.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/elasticpools"
               },
               {
+                "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/elasticpools-sessionspercent_6b2e0ce9-d1b8-4061-b3ce-c39f9c5c1763.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-sessionspercent_6b2e0ce9-d1b8-4061-b3ce-c39f9c5c1763.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/elasticpools"
               },
               {
+                "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/elasticpools-sqlserverprocesscorepercent_73ec4301-872a-4bea-928e-420255aae8cb.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-sqlserverprocesscorepercent_73ec4301-872a-4bea-928e-420255aae8cb.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/elasticpools"
               },
               {
+                "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/elasticpools-sqlserverprocessmemorypercent_fa056aaf-57c4-4abe-9bc5-23ba413a1f5b.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-sqlserverprocessmemorypercent_fa056aaf-57c4-4abe-9bc5-23ba413a1f5b.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/elasticpools"
               },
               {
+                "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/elasticpools-storagepercent_88f3cbc0-bcfb-482f-b6f4-709a335afcad.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-storagepercent_88f3cbc0-bcfb-482f-b6f4-709a335afcad.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/elasticpools"
               },
               {
+                "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/elasticpools-tempdblogusedpercent_af66de51-079c-4d34-af92-f52f887642dc.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-tempdblogusedpercent_af66de51-079c-4d34-af92-f52f887642dc.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/elasticpools"
               },
               {
+                "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/elasticpools-workerspercent_1b37038e-6e5c-4463-97d4-8a632251d70e.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-workerspercent_1b37038e-6e5c-4463-97d4-8a632251d70e.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/elasticpools"
               },
               {
+                "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy-arm/elasticpools-xtpstoragepercent_db517009-30ad-4cbc-b282-7f212052c3b4.json
+++ b/services/Sql/servers/templates/policy-arm/elasticpools-xtpstoragepercent_db517009-30ad-4cbc-b282-7f212052c3b4.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/elasticpools"
               },
               {
+                "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+                "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Sql/servers/templates/policy/databases-appcpupercent_05591510-5fe2-454a-96d8-bbda8201c6a4.json
+++ b/services/Sql/servers/templates/policy/databases-appcpupercent_05591510-5fe2-454a-96d8-bbda8201c6a4.json
@@ -140,6 +140,14 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "kind",
+            "in": ["v12.0,user,vcore,serverless","v12.0,user,vcore,hyperscale,serverless"]
+          },
+          {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["GeneralPurpose","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-appmemorypercent_c5c95fe9-a4b4-4afa-a07a-a0d18804d416.json
+++ b/services/Sql/servers/templates/policy/databases-appmemorypercent_c5c95fe9-a4b4-4afa-a07a-a0d18804d416.json
@@ -140,6 +140,14 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "kind",
+            "in": ["v12.0,user,vcore,serverless","v12.0,user,vcore,hyperscale,serverless"]
+          },
+          {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["GeneralPurpose","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-blockedbyfirewall_2cda2f3a-8657-431a-a50f-56835aea9a81.json
+++ b/services/Sql/servers/templates/policy/databases-blockedbyfirewall_2cda2f3a-8657-431a-a50f-56835aea9a81.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale","DataWarehouse"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-connectionfailed_7157dc17-9d5a-4835-a122-1d0d904d61ff.json
+++ b/services/Sql/servers/templates/policy/databases-connectionfailed_7157dc17-9d5a-4835-a122-1d0d904d61ff.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale","DataWarehouse"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-connectionfailedusererror_d528ffcb-3a99-4356-96d1-981499139ffb.json
+++ b/services/Sql/servers/templates/policy/databases-connectionfailedusererror_d528ffcb-3a99-4356-96d1-981499139ffb.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale","DataWarehouse"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-connectionsuccessful_460b6b29-a602-4409-b748-6b47b232a984.json
+++ b/services/Sql/servers/templates/policy/databases-connectionsuccessful_460b6b29-a602-4409-b748-6b47b232a984.json
@@ -141,6 +141,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale","DataWarehouse"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-cpuused_3ddd3f95-989c-4777-b6b8-728439aae1df.json
+++ b/services/Sql/servers/templates/policy/databases-cpuused_3ddd3f95-989c-4777-b6b8-728439aae1df.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-deadlock_ce44fc81-3610-4165-a107-9dd4b8ab3972.json
+++ b/services/Sql/servers/templates/policy/databases-deadlock_ce44fc81-3610-4165-a107-9dd4b8ab3972.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-dtulimit_50124594-a291-4183-a8e3-195f5e6f5204.json
+++ b/services/Sql/servers/templates/policy/databases-dtulimit_50124594-a291-4183-a8e3-195f5e6f5204.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["Basic","Standard","Premium"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-dtuused_d26f4c8b-0461-4c57-b230-cbd1a5424db1.json
+++ b/services/Sql/servers/templates/policy/databases-dtuused_d26f4c8b-0461-4c57-b230-cbd1a5424db1.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["Basic","Standard","Premium"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-dwuconsumptionpercent_70f88865-7a8b-4e03-9252-a9369df503ef.json
+++ b/services/Sql/servers/templates/policy/databases-dwuconsumptionpercent_70f88865-7a8b-4e03-9252-a9369df503ef.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["DataWarehouse"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-memoryusagepercent_f5c13b49-8528-457d-9d7d-083b8433bf96.json
+++ b/services/Sql/servers/templates/policy/databases-memoryusagepercent_f5c13b49-8528-457d-9d7d-083b8433bf96.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["DataWarehouse"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-sessionscount_07eeae07-010e-47ca-ad90-fa7adb5a6c52.json
+++ b/services/Sql/servers/templates/policy/databases-sessionscount_07eeae07-010e-47ca-ad90-fa7adb5a6c52.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-sqlinstancecpupercent_1a8132b9-fbd2-4ac5-9e08-96358e16b7f7.json
+++ b/services/Sql/servers/templates/policy/databases-sqlinstancecpupercent_1a8132b9-fbd2-4ac5-9e08-96358e16b7f7.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-sqlinstancememorypercent_f44a3cb0-6e99-4a5e-a691-c5d7d5bf7e64.json
+++ b/services/Sql/servers/templates/policy/databases-sqlinstancememorypercent_f44a3cb0-6e99-4a5e-a691-c5d7d5bf7e64.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-storage_86922a27-41bb-4834-bc54-0b602b275597.json
+++ b/services/Sql/servers/templates/policy/databases-storage_86922a27-41bb-4834-bc54-0b602b275597.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/databases-tempdbdatasize_0fe27fd1-e4f7-48c1-bbd2-a6953755d5e8.json
+++ b/services/Sql/servers/templates/policy/databases-tempdbdatasize_0fe27fd1-e4f7-48c1-bbd2-a6953755d5e8.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "Microsoft.Sql/servers/databases/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/elasticpools-allocateddatastorage_3743016a-a056-43fe-b53a-36dd9a17626d.json
+++ b/services/Sql/servers/templates/policy/elasticpools-allocateddatastorage_3743016a-a056-43fe-b53a-36dd9a17626d.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/elasticpools"
           },
           {
+            "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/elasticpools-allocateddatastoragepercent_7e9d0710-3243-4cf2-8b73-6be1539b8545.json
+++ b/services/Sql/servers/templates/policy/elasticpools-allocateddatastoragepercent_7e9d0710-3243-4cf2-8b73-6be1539b8545.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/elasticpools"
           },
           {
+            "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/elasticpools-cpupercent_805c4ae5-a852-43bd-ad1c-0f7f381d8f32.json
+++ b/services/Sql/servers/templates/policy/elasticpools-cpupercent_805c4ae5-a852-43bd-ad1c-0f7f381d8f32.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/elasticpools"
           },
           {
+            "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/elasticpools-dtuconsumptionpercent_5d9075b5-3c19-4cf6-9c2e-50ba4c175691.json
+++ b/services/Sql/servers/templates/policy/elasticpools-dtuconsumptionpercent_5d9075b5-3c19-4cf6-9c2e-50ba4c175691.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/elasticpools"
           },
           {
+            "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+            "in": ["Basic","Standard","Premium"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/elasticpools-eDTUused_16a64053-1905-4d8e-8198-810584cad108.json
+++ b/services/Sql/servers/templates/policy/elasticpools-eDTUused_16a64053-1905-4d8e-8198-810584cad108.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/elasticpools"
           },
           {
+            "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+            "in": ["Basic","Standard","Premium"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/elasticpools-logwritepercent_47cd814e-1991-437e-8feb-e589a250d2a3.json
+++ b/services/Sql/servers/templates/policy/elasticpools-logwritepercent_47cd814e-1991-437e-8feb-e589a250d2a3.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/elasticpools"
           },
           {
+            "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/elasticpools-physicaldatareadpercent_92efc2ea-b6ed-41aa-921c-6d40e7b58c27.json
+++ b/services/Sql/servers/templates/policy/elasticpools-physicaldatareadpercent_92efc2ea-b6ed-41aa-921c-6d40e7b58c27.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/elasticpools"
           },
           {
+            "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/elasticpools-sessionspercent_6b2e0ce9-d1b8-4061-b3ce-c39f9c5c1763.json
+++ b/services/Sql/servers/templates/policy/elasticpools-sessionspercent_6b2e0ce9-d1b8-4061-b3ce-c39f9c5c1763.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/elasticpools"
           },
           {
+            "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/elasticpools-sqlserverprocesscorepercent_73ec4301-872a-4bea-928e-420255aae8cb.json
+++ b/services/Sql/servers/templates/policy/elasticpools-sqlserverprocesscorepercent_73ec4301-872a-4bea-928e-420255aae8cb.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/elasticpools"
           },
           {
+            "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/elasticpools-sqlserverprocessmemorypercent_fa056aaf-57c4-4abe-9bc5-23ba413a1f5b.json
+++ b/services/Sql/servers/templates/policy/elasticpools-sqlserverprocessmemorypercent_fa056aaf-57c4-4abe-9bc5-23ba413a1f5b.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/elasticpools"
           },
           {
+            "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/elasticpools-storagepercent_88f3cbc0-bcfb-482f-b6f4-709a335afcad.json
+++ b/services/Sql/servers/templates/policy/elasticpools-storagepercent_88f3cbc0-bcfb-482f-b6f4-709a335afcad.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/elasticpools"
           },
           {
+            "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/elasticpools-tempdblogusedpercent_af66de51-079c-4d34-af92-f52f887642dc.json
+++ b/services/Sql/servers/templates/policy/elasticpools-tempdblogusedpercent_af66de51-079c-4d34-af92-f52f887642dc.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/elasticpools"
           },
           {
+            "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/elasticpools-workerspercent_1b37038e-6e5c-4463-97d4-8a632251d70e.json
+++ b/services/Sql/servers/templates/policy/elasticpools-workerspercent_1b37038e-6e5c-4463-97d4-8a632251d70e.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/elasticpools"
           },
           {
+            "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Sql/servers/templates/policy/elasticpools-xtpstoragepercent_db517009-30ad-4cbc-b282-7f212052c3b4.json
+++ b/services/Sql/servers/templates/policy/elasticpools-xtpstoragepercent_db517009-30ad-4cbc-b282-7f212052c3b4.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/elasticpools"
           },
           {
+            "field": "Microsoft.Sql/servers/elasticpools/sku.tier",
+            "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/tooling/generate-templates/generate-policies-full-arm.ps1
+++ b/tooling/generate-templates/generate-policies-full-arm.ps1
@@ -67,6 +67,18 @@ process {
                 } else {
                     $alertTemplate = $alertTemplate -replace "##POLICY_KIND##", ""
                 }
+                if ($alert.PSObject.Properties.Name -contains "tier") {
+                    $tierString = [Environment]::NewLine + '              ' + '{' +
+                                  [Environment]::NewLine + '              ' + '  "field": "' + $alert.properties.metricNamespace + '/sku.tier",' +
+                                  [Environment]::NewLine + '              ' + '  "in": ['
+                    foreach ($tier in $alert.tier) {
+                        $tierString += '"' + $tier + '",'
+                    }
+                    $tierString = $tierString.TrimEnd(',') + ']' + [Environment]::NewLine+ '              },'
+                    $alertTemplate = $alertTemplate -replace "##POLICY_TIER##", $tierString
+                } else {
+                    $alertTemplate = $alertTemplate -replace "##POLICY_TIER##", ""
+                }
                 $category = $alert.properties.metricNamespace -replace "Microsoft.", ""
                 $category = $category -replace "/.+", ""
                 $alertTemplate = $alertTemplate -replace "##POLICY_CATEGORY##", $category

--- a/tooling/generate-templates/generate-policies.ps1
+++ b/tooling/generate-templates/generate-policies.ps1
@@ -67,6 +67,18 @@ process {
                 } else {
                     $alertTemplate = $alertTemplate -replace "##POLICY_KIND##", ""
                 }
+                if ($alert.PSObject.Properties.Name -contains "tier") {
+                    $tierString = [Environment]::NewLine + '          ' + '{' +
+                                  [Environment]::NewLine + '          ' + '  "field": "' + $alert.properties.metricNamespace + '/sku.tier",' +
+                                  [Environment]::NewLine + '          ' + '  "in": ['
+                    foreach ($tier in $alert.tier) {
+                        $tierString += '"' + $tier + '",'
+                    }
+                    $tierString = $tierString.TrimEnd(',') + ']' + [Environment]::NewLine+ '          },'
+                    $alertTemplate = $alertTemplate -replace "##POLICY_TIER##", $tierString
+                } else {
+                    $alertTemplate = $alertTemplate -replace "##POLICY_TIER##", ""
+                }
                 $category = $alert.properties.metricNamespace -replace "Microsoft.", ""
                 $category = $category -replace "/.+", ""
                 $alertTemplate = $alertTemplate -replace "##POLICY_CATEGORY##", $category

--- a/tooling/generate-templates/policy/metric-dynamic-full-arm.json
+++ b/tooling/generate-templates/policy/metric-dynamic-full-arm.json
@@ -178,7 +178,7 @@
               {
                 "field": "type",
                 "equals": "##METRIC_NAMESPACE##"
-              },##POLICY_KIND##
+              },##POLICY_KIND####POLICY_TIER##
               {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"

--- a/tooling/generate-templates/policy/metric-dynamic.json
+++ b/tooling/generate-templates/policy/metric-dynamic.json
@@ -139,7 +139,7 @@
           {
             "field": "type",
             "equals": "##METRIC_NAMESPACE##"
-          },##POLICY_KIND##
+          },##POLICY_KIND####POLICY_TIER##
           {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"

--- a/tooling/generate-templates/policy/metric-static-full-arm.json
+++ b/tooling/generate-templates/policy/metric-static-full-arm.json
@@ -177,7 +177,7 @@
               {
                 "field": "type",
                 "equals": "##METRIC_NAMESPACE##"
-              },##POLICY_KIND##
+              },##POLICY_KIND####POLICY_TIER##
               {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"

--- a/tooling/generate-templates/policy/metric-static.json
+++ b/tooling/generate-templates/policy/metric-static.json
@@ -138,7 +138,7 @@
           {
             "field": "type",
             "equals": "##METRIC_NAMESPACE##"
-          },##POLICY_KIND##
+          },##POLICY_KIND####POLICY_TIER##
           {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Policies for type Microsoft.Sql/servers/databases need to be able to distinguish between different sku tiers and kinds of databases. For example, Basic, Standard, Premium, GeneralPurpose, Hyperscale, BusinessCritical and DataWarehouse are all of type Microsoft.Sql/servers/databases but support different sets of metrics. When doing compliance with Azure Policy a check needed to be in place to determine the sku tier and kind field values so that compliance did not fail for those resources that do not support a specific metric. Tier and kind fields were added to the alert YAML and the code generation and policy templates were updated to support the tier and kind fields.  This was done for elastic pools as well.

## This PR fixes/adds/changes/removes

1. Partially fixes Issue #599 
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

### Testing evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

<img width="512" alt="image" src="https://github.com/user-attachments/assets/beef64e8-0056-461f-a4e1-ed706c4170b2" />


## As part of this Pull Request I have

- [ ] Read the Contribution Guide and ensured this PR is compliant with the guide
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
