### PR TITLE
Add kind field to a few SQL alerts to ignore elastic pool DBs

### DIFF
--- a/services/Sql/servers/alerts.yaml
+++ b/services/Sql/servers/alerts.yaml
@@ -228,10 +228,16 @@
   guid: d26f4c8b-0461-4c57-b230-cbd1a5424db1
 - name: databases - sql_instance_memory_percent
   description: Memory usage by the database engine instance. Not applicable to data
-    warehouses.
+    warehouses and elastic pool databases.
   type: Metric
   verified: false
   visible: true
+  kind:
+  - v12.0,user
+  - v12.0,user,vcore
+  - v12.0,user,vcore,hyperscale
+  - v12.0,user,vcore,serverless
+  - v12.0,user,vcore,hyperscale,serverless
   tier:
   - Basic
   - Standard
@@ -307,10 +313,16 @@
   guid: 50124594-a291-4183-a8e3-195f5e6f5204
 - name: databases - sql_instance_cpu_percent
   description: CPU usage by all user and system workloads. Not applicable to data
-    warehouses.
+    warehouses and elastic pool databases.
   type: Metric
   verified: false
   visible: true
+  kind:
+  - v12.0,user
+  - v12.0,user,vcore
+  - v12.0,user,vcore,hyperscale
+  - v12.0,user,vcore,serverless
+  - v12.0,user,vcore,hyperscale,serverless
   tier:
   - Basic
   - Standard
@@ -433,10 +445,16 @@
   guid: f5c13b49-8528-457d-9d7d-083b8433bf96
 - name: databases - tempdb_data_size
   description: Space used in tempdb data files in kilobytes. Not applicable to data
-    warehouses.
+    warehouses and elastic pool databases.
   type: Metric
   verified: false
   visible: true
+  kind:
+  - v12.0,user
+  - v12.0,user,vcore
+  - v12.0,user,vcore,hyperscale
+  - v12.0,user,vcore,serverless
+  - v12.0,user,vcore,hyperscale,serverless
   tier:
   - Basic
   - Standard

--- a/services/Sql/servers/templates/policy-arm/databases-sqlinstancecpupercent_1a8132b9-fbd2-4ac5-9e08-96358e16b7f7.json
+++ b/services/Sql/servers/templates/policy-arm/databases-sqlinstancecpupercent_1a8132b9-fbd2-4ac5-9e08-96358e16b7f7.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "kind",
+                "in": ["v12.0,user","v12.0,user,vcore","v12.0,user,vcore,hyperscale","v12.0,user,vcore,serverless","v12.0,user,vcore,hyperscale,serverless"]
+              },
+              {
                 "field": "Microsoft.Sql/servers/databases/sku.tier",
                 "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
               },

--- a/services/Sql/servers/templates/policy-arm/databases-sqlinstancememorypercent_f44a3cb0-6e99-4a5e-a691-c5d7d5bf7e64.json
+++ b/services/Sql/servers/templates/policy-arm/databases-sqlinstancememorypercent_f44a3cb0-6e99-4a5e-a691-c5d7d5bf7e64.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "kind",
+                "in": ["v12.0,user","v12.0,user,vcore","v12.0,user,vcore,hyperscale","v12.0,user,vcore,serverless","v12.0,user,vcore,hyperscale,serverless"]
+              },
+              {
                 "field": "Microsoft.Sql/servers/databases/sku.tier",
                 "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
               },

--- a/services/Sql/servers/templates/policy-arm/databases-tempdbdatasize_0fe27fd1-e4f7-48c1-bbd2-a6953755d5e8.json
+++ b/services/Sql/servers/templates/policy-arm/databases-tempdbdatasize_0fe27fd1-e4f7-48c1-bbd2-a6953755d5e8.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Sql/servers/databases"
               },
               {
+                "field": "kind",
+                "in": ["v12.0,user","v12.0,user,vcore","v12.0,user,vcore,hyperscale","v12.0,user,vcore,serverless","v12.0,user,vcore,hyperscale,serverless"]
+              },
+              {
                 "field": "Microsoft.Sql/servers/databases/sku.tier",
                 "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
               },

--- a/services/Sql/servers/templates/policy/databases-sqlinstancecpupercent_1a8132b9-fbd2-4ac5-9e08-96358e16b7f7.json
+++ b/services/Sql/servers/templates/policy/databases-sqlinstancecpupercent_1a8132b9-fbd2-4ac5-9e08-96358e16b7f7.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "kind",
+            "in": ["v12.0,user","v12.0,user,vcore","v12.0,user,vcore,hyperscale","v12.0,user,vcore,serverless","v12.0,user,vcore,hyperscale,serverless"]
+          },
+          {
             "field": "Microsoft.Sql/servers/databases/sku.tier",
             "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
           },

--- a/services/Sql/servers/templates/policy/databases-sqlinstancememorypercent_f44a3cb0-6e99-4a5e-a691-c5d7d5bf7e64.json
+++ b/services/Sql/servers/templates/policy/databases-sqlinstancememorypercent_f44a3cb0-6e99-4a5e-a691-c5d7d5bf7e64.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "kind",
+            "in": ["v12.0,user","v12.0,user,vcore","v12.0,user,vcore,hyperscale","v12.0,user,vcore,serverless","v12.0,user,vcore,hyperscale,serverless"]
+          },
+          {
             "field": "Microsoft.Sql/servers/databases/sku.tier",
             "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
           },

--- a/services/Sql/servers/templates/policy/databases-tempdbdatasize_0fe27fd1-e4f7-48c1-bbd2-a6953755d5e8.json
+++ b/services/Sql/servers/templates/policy/databases-tempdbdatasize_0fe27fd1-e4f7-48c1-bbd2-a6953755d5e8.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Sql/servers/databases"
           },
           {
+            "field": "kind",
+            "in": ["v12.0,user","v12.0,user,vcore","v12.0,user,vcore,hyperscale","v12.0,user,vcore,serverless","v12.0,user,vcore,hyperscale,serverless"]
+          },
+          {
             "field": "Microsoft.Sql/servers/databases/sku.tier",
             "in": ["Basic","Standard","Premium","GeneralPurpose","BusinessCritical","Hyperscale"]
           },

--- a/services/Storage/storageAccounts/templates/policy-arm/Availability_b1a4849b-78a8-437f-8113-7c6f2dc34927.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/Availability_b1a4849b-78a8-437f-8113-7c6f2dc34927.json
@@ -88,7 +88,7 @@
               "PT12H",
               "P1D"
             ],
-            "defaultValue": "PT5M"
+            "defaultValue": "PT1M"
           },
           "evaluationFrequency": {
             "type": "String",
@@ -103,7 +103,7 @@
               "PT30M",
               "PT1H"
             ],
-            "defaultValue": "PT5M"
+            "defaultValue": "PT1M"
           },
           "autoMitigate": {
             "type": "String",

--- a/services/Storage/storageAccounts/templates/policy-arm/UsedCapacity_b663a689-6db8-467d-8b5d-8cd34afe4b0e.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/UsedCapacity_b663a689-6db8-467d-8b5d-8cd34afe4b0e.json
@@ -135,7 +135,7 @@
               "displayName": "Threshold",
               "description": "Threshold for the alert"
             },
-            "defaultValue": "2251800000000000"
+            "defaultValue": "500000000000000"
           },
           "effect": {
             "type": "String",

--- a/services/Storage/storageAccounts/templates/policy-arm/blobServices-BlobCapacity_8c0aaea9-bcce-4c27-a090-ffe54b7e1d1c.json
+++ b/services/Storage/storageAccounts/templates/policy-arm/blobServices-BlobCapacity_8c0aaea9-bcce-4c27-a090-ffe54b7e1d1c.json
@@ -88,7 +88,7 @@
               "PT12H",
               "P1D"
             ],
-            "defaultValue": "P1D"
+            "defaultValue": "PT1H"
           },
           "evaluationFrequency": {
             "type": "String",
@@ -103,7 +103,7 @@
               "PT30M",
               "PT1H"
             ],
-            "defaultValue": "PT5M"
+            "defaultValue": "PT1H"
           },
           "autoMitigate": {
             "type": "String",
@@ -135,7 +135,7 @@
               "displayName": "Threshold",
               "description": "Threshold for the alert"
             },
-            "defaultValue": "107374182400"
+            "defaultValue": "500000000000000"
           },
           "effect": {
             "type": "String",

--- a/services/Storage/storageAccounts/templates/policy/Availability_b1a4849b-78a8-437f-8113-7c6f2dc34927.json
+++ b/services/Storage/storageAccounts/templates/policy/Availability_b1a4849b-78a8-437f-8113-7c6f2dc34927.json
@@ -49,7 +49,7 @@
           "PT12H",
           "P1D"
         ],
-        "defaultValue": "PT5M"
+        "defaultValue": "PT1M"
       },
       "evaluationFrequency": {
         "type": "String",
@@ -64,7 +64,7 @@
           "PT30M",
           "PT1H"
         ],
-        "defaultValue": "PT5M"
+        "defaultValue": "PT1M"
       },
       "autoMitigate": {
         "type": "String",

--- a/services/Storage/storageAccounts/templates/policy/UsedCapacity_b663a689-6db8-467d-8b5d-8cd34afe4b0e.json
+++ b/services/Storage/storageAccounts/templates/policy/UsedCapacity_b663a689-6db8-467d-8b5d-8cd34afe4b0e.json
@@ -96,7 +96,7 @@
           "displayName": "Threshold",
           "description": "Threshold for the alert"
         },
-        "defaultValue": "2251800000000000"
+        "defaultValue": "500000000000000"
       },
       "effect": {
         "type": "String",

--- a/services/Storage/storageAccounts/templates/policy/blobServices-BlobCapacity_8c0aaea9-bcce-4c27-a090-ffe54b7e1d1c.json
+++ b/services/Storage/storageAccounts/templates/policy/blobServices-BlobCapacity_8c0aaea9-bcce-4c27-a090-ffe54b7e1d1c.json
@@ -49,7 +49,7 @@
           "PT12H",
           "P1D"
         ],
-        "defaultValue": "P1D"
+        "defaultValue": "PT1H"
       },
       "evaluationFrequency": {
         "type": "String",
@@ -64,7 +64,7 @@
           "PT30M",
           "PT1H"
         ],
-        "defaultValue": "PT5M"
+        "defaultValue": "PT1H"
       },
       "autoMitigate": {
         "type": "String",
@@ -96,7 +96,7 @@
           "displayName": "Threshold",
           "description": "Threshold for the alert"
         },
-        "defaultValue": "107374182400"
+        "defaultValue": "500000000000000"
       },
       "effect": {
         "type": "String",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Add kind field to a few SQL alerts to ignore elastic pool DBs

## This PR fixes/adds/changes/removes

1. *Replace me*
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

### Testing evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
