### PR TITLE
Update policies to distinguish between ExpressRoute and VPN 

### DIFF
--- a/.github/yml-schemas/defaultDynamicMetric.json
+++ b/.github/yml-schemas/defaultDynamicMetric.json
@@ -33,6 +33,12 @@
                         "type": "string"
                     }
                 },
+                "gatewayType": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "tags": {
                     "type": "array",
                     "items": {

--- a/.github/yml-schemas/defaultStaticMetric.json
+++ b/.github/yml-schemas/defaultStaticMetric.json
@@ -33,6 +33,12 @@
                         "type": "string"
                     }
                 },
+                "gatewayType": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "tags": {
                     "type": "array",
                     "items": {

--- a/services/Network/expressRouteGateways/alerts.yaml
+++ b/services/Network/expressRouteGateways/alerts.yaml
@@ -1,5 +1,5 @@
 - name: ERGatewayConnectionBitsInPerSecond
-  description: ERGatewayConnectionBitsInPerSecond
+  description: Bits per second ingressing Azure via ExpressRoute Gateway.  Applies to VWAN ExpressRoute Gateways.
   type: Metric
   verified: false
   visible: true
@@ -19,7 +19,7 @@
     enabled: true
   references:
   - name: ExpressRoute Monitoring Metrics Alerts for ExpressRoute Gateways
-    url: https://learn.microsoft.com/en-us/azure/expressroute/expressroute-monitoring-metrics-alerts#expressroute-gateways
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-network-expressroutegateways-metrics
   deployments:
   - name: Deploy ERG ExpressRoute Bits In Alert
     template: Deploy-ERG-BitsInPerSecond-Alert.json
@@ -31,7 +31,7 @@
       multiResource: false
   guid: ff147700-c9e6-4063-bb23-45500c00067a
 - name: ERGatewayConnectionBitsOutPerSecond
-  description: Metric Alert for ER Gateway Connection BitsOutPerSecond
+  description: Bits per second egressing Azure via ExpressRoute Gateway.  Applies to VWAN ExpressRoute Gateways.
   type: Metric
   verified: false
   visible: true
@@ -51,7 +51,7 @@
     enabled: true
   references:
   - name: ExpressRoute Monitoring Metrics Alerts for ExpressRoute Gateways
-    url: https://learn.microsoft.com/en-us/azure/expressroute/expressroute-monitoring-metrics-alerts#expressroute-gateways
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-network-expressroutegateways-metrics
   deployments:
   - name: Deploy ERG ExpressRoute Bits Out Alert
     template: Deploy-ERG-BitsOutPerSecond-Alert.json
@@ -63,7 +63,7 @@
       multiResource: false
   guid: 4d5c7854-e044-4dd6-971b-df433fa3ad37
 - name: ExpressRouteGatewayCpuUtilization
-  description: Metric Alert for ER Gateway Express Route CPU Utilization
+  description: CPU Utilization of the ExpressRoute Gateway.  Applies to VWAN ExpressRoute Gateways.
   type: Metric
   verified: true
   visible: true
@@ -83,7 +83,7 @@
     enabled: true
   references:
   - name: ExpressRoute Monitoring Metrics Alerts for ExpressRoute Gateways
-    url: https://learn.microsoft.com/en-us/azure/expressroute/expressroute-monitoring-metrics-alerts#expressroute-gateways
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-network-expressroutegateways-metrics
   deployments:
   - name: Deploy ERG ExpressRoute CPU Utilization Alert
     template: Deploy-ERG-CPUUtilization-Alert.json

--- a/services/Network/virtualNetworkGateways/alerts.yaml
+++ b/services/Network/virtualNetworkGateways/alerts.yaml
@@ -3,6 +3,8 @@
   type: Metric
   verified: false
   visible: true
+  gatewayType:
+  - Vpn
   tags:
   - alz
   properties:
@@ -35,6 +37,8 @@
   type: Metric
   verified: false
   visible: true
+  gatewayType:
+  - Vpn
   tags:
   - alz
   properties:
@@ -67,6 +71,8 @@
   type: Metric
   verified: false
   visible: true
+  gatewayType:
+  - Vpn
   tags:
   - alz
   properties:
@@ -102,6 +108,8 @@
   type: Metric
   verified: false
   visible: true
+  gatewayType:
+  - Vpn
   tags:
   - alz
   properties:
@@ -137,6 +145,8 @@
   type: Metric
   verified: false
   visible: true
+  gatewayType:
+  - ExpressRoute
   tags:
   - alz
   properties:
@@ -169,6 +179,8 @@
   type: Metric
   verified: false
   visible: true
+  gatewayType:
+  - ExpressRoute
   tags:
   - alz
   properties:
@@ -201,6 +213,8 @@
   type: Metric
   verified: false
   visible: true
+  gatewayType:
+  - Vpn
   tags:
   - alz
   properties:
@@ -233,6 +247,8 @@
   type: Metric
   verified: false
   visible: true
+  gatewayType:
+  - Vpn
   tags:
   - alz
   properties:
@@ -268,6 +284,8 @@
   type: Metric
   verified: false
   visible: true
+  gatewayType:
+  - Vpn
   tags:
   - alz
   properties:
@@ -303,6 +321,8 @@
   type: Metric
   verified: false
   visible: true
+  gatewayType:
+  - Vpn
   tags:
   - auto-generated
   - agc-342

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/AverageBandwidth_88642ff7-6c08-486a-9bf2-37764d5bf6a3.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/AverageBandwidth_88642ff7-6c08-486a-9bf2-37764d5bf6a3.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Network/virtualNetworkGateways"
               },
               {
+                "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+                "in": ["Vpn"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/ExpressRouteGatewayBitsPerSecond_4c3c25d2-7473-4d0c-9174-609162571859.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/ExpressRouteGatewayBitsPerSecond_4c3c25d2-7473-4d0c-9174-609162571859.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Network/virtualNetworkGateways"
               },
               {
+                "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+                "in": ["ExpressRoute"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/ExpressRouteGatewayCpuUtilization_56491bc7-1267-42a2-92c6-fe9efe822ff1.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/ExpressRouteGatewayCpuUtilization_56491bc7-1267-42a2-92c6-fe9efe822ff1.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Network/virtualNetworkGateways"
               },
               {
+                "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+                "in": ["ExpressRoute"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelAverageBandwidth_09bb7f01-a715-437d-b692-325f89e1869e.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelAverageBandwidth_09bb7f01-a715-437d-b692-325f89e1869e.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Network/virtualNetworkGateways"
               },
               {
+                "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+                "in": ["Vpn"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelEgressBytes_092f6e09-1eb5-436d-b7c2-eadb70318920.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelEgressBytes_092f6e09-1eb5-436d-b7c2-eadb70318920.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Network/virtualNetworkGateways"
               },
               {
+                "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+                "in": ["Vpn"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelEgressPacketDropCount_6f02e3e8-9bfa-4312-a352-6506139e3dba.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelEgressPacketDropCount_6f02e3e8-9bfa-4312-a352-6506139e3dba.json
@@ -180,6 +180,10 @@
                 "equals": "Microsoft.Network/virtualNetworkGateways"
               },
               {
+                "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+                "in": ["Vpn"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelEgressPacketDropTSMismatch_ca909c09-89c4-467e-bdca-9140e72d6c82.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelEgressPacketDropTSMismatch_ca909c09-89c4-467e-bdca-9140e72d6c82.json
@@ -180,6 +180,10 @@
                 "equals": "Microsoft.Network/virtualNetworkGateways"
               },
               {
+                "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+                "in": ["Vpn"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelIngressBytes_a34fa329-da3e-4947-8d06-9bd2bee6c8a7.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelIngressBytes_a34fa329-da3e-4947-8d06-9bd2bee6c8a7.json
@@ -179,6 +179,10 @@
                 "equals": "Microsoft.Network/virtualNetworkGateways"
               },
               {
+                "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+                "in": ["Vpn"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelIngressPacketDropCount_b511650f-535c-45d1-a089-0ea402245deb.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelIngressPacketDropCount_b511650f-535c-45d1-a089-0ea402245deb.json
@@ -180,6 +180,10 @@
                 "equals": "Microsoft.Network/virtualNetworkGateways"
               },
               {
+                "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+                "in": ["Vpn"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelIngressPacketDropTSMismatch_1cc4a539-e4bf-40e8-a280-f4e9e178fb51.json
+++ b/services/Network/virtualNetworkGateways/templates/policy-arm/TunnelIngressPacketDropTSMismatch_1cc4a539-e4bf-40e8-a280-f4e9e178fb51.json
@@ -180,6 +180,10 @@
                 "equals": "Microsoft.Network/virtualNetworkGateways"
               },
               {
+                "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+                "in": ["Vpn"]
+              },
+              {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"
               }

--- a/services/Network/virtualNetworkGateways/templates/policy/AverageBandwidth_88642ff7-6c08-486a-9bf2-37764d5bf6a3.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/AverageBandwidth_88642ff7-6c08-486a-9bf2-37764d5bf6a3.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Network/virtualNetworkGateways"
           },
           {
+            "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+            "in": ["Vpn"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Network/virtualNetworkGateways/templates/policy/ExpressRouteGatewayBitsPerSecond_4c3c25d2-7473-4d0c-9174-609162571859.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/ExpressRouteGatewayBitsPerSecond_4c3c25d2-7473-4d0c-9174-609162571859.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Network/virtualNetworkGateways"
           },
           {
+            "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+            "in": ["ExpressRoute"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Network/virtualNetworkGateways/templates/policy/ExpressRouteGatewayCpuUtilization_56491bc7-1267-42a2-92c6-fe9efe822ff1.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/ExpressRouteGatewayCpuUtilization_56491bc7-1267-42a2-92c6-fe9efe822ff1.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Network/virtualNetworkGateways"
           },
           {
+            "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+            "in": ["ExpressRoute"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Network/virtualNetworkGateways/templates/policy/TunnelAverageBandwidth_09bb7f01-a715-437d-b692-325f89e1869e.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/TunnelAverageBandwidth_09bb7f01-a715-437d-b692-325f89e1869e.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Network/virtualNetworkGateways"
           },
           {
+            "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+            "in": ["Vpn"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Network/virtualNetworkGateways/templates/policy/TunnelEgressBytes_092f6e09-1eb5-436d-b7c2-eadb70318920.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/TunnelEgressBytes_092f6e09-1eb5-436d-b7c2-eadb70318920.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Network/virtualNetworkGateways"
           },
           {
+            "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+            "in": ["Vpn"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Network/virtualNetworkGateways/templates/policy/TunnelEgressPacketDropCount_6f02e3e8-9bfa-4312-a352-6506139e3dba.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/TunnelEgressPacketDropCount_6f02e3e8-9bfa-4312-a352-6506139e3dba.json
@@ -141,6 +141,10 @@
             "equals": "Microsoft.Network/virtualNetworkGateways"
           },
           {
+            "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+            "in": ["Vpn"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Network/virtualNetworkGateways/templates/policy/TunnelEgressPacketDropTSMismatch_ca909c09-89c4-467e-bdca-9140e72d6c82.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/TunnelEgressPacketDropTSMismatch_ca909c09-89c4-467e-bdca-9140e72d6c82.json
@@ -141,6 +141,10 @@
             "equals": "Microsoft.Network/virtualNetworkGateways"
           },
           {
+            "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+            "in": ["Vpn"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Network/virtualNetworkGateways/templates/policy/TunnelIngressBytes_a34fa329-da3e-4947-8d06-9bd2bee6c8a7.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/TunnelIngressBytes_a34fa329-da3e-4947-8d06-9bd2bee6c8a7.json
@@ -140,6 +140,10 @@
             "equals": "Microsoft.Network/virtualNetworkGateways"
           },
           {
+            "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+            "in": ["Vpn"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Network/virtualNetworkGateways/templates/policy/TunnelIngressPacketDropCount_b511650f-535c-45d1-a089-0ea402245deb.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/TunnelIngressPacketDropCount_b511650f-535c-45d1-a089-0ea402245deb.json
@@ -141,6 +141,10 @@
             "equals": "Microsoft.Network/virtualNetworkGateways"
           },
           {
+            "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+            "in": ["Vpn"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/services/Network/virtualNetworkGateways/templates/policy/TunnelIngressPacketDropTSMismatch_1cc4a539-e4bf-40e8-a280-f4e9e178fb51.json
+++ b/services/Network/virtualNetworkGateways/templates/policy/TunnelIngressPacketDropTSMismatch_1cc4a539-e4bf-40e8-a280-f4e9e178fb51.json
@@ -141,6 +141,10 @@
             "equals": "Microsoft.Network/virtualNetworkGateways"
           },
           {
+            "field": "Microsoft.Network/virtualNetworkGateways/gatewayType",
+            "in": ["Vpn"]
+          },
+          {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"
           }

--- a/tooling/generate-templates/generate-policies-full-arm.ps1
+++ b/tooling/generate-templates/generate-policies-full-arm.ps1
@@ -79,6 +79,18 @@ process {
                 } else {
                     $alertTemplate = $alertTemplate -replace "##POLICY_TIER##", ""
                 }
+                if ($alert.PSObject.Properties.Name -contains "gatewayType") {
+                    $gatewayTypeString = [Environment]::NewLine + '              ' + '{' +
+                                  [Environment]::NewLine + '              ' + '  "field": "' + $alert.properties.metricNamespace + '/gatewayType",' +
+                                  [Environment]::NewLine + '              ' + '  "in": ['
+                    foreach ($gatewayType in $alert.gatewayType) {
+                        $gatewayTypeString += '"' + $gatewayType + '",'
+                    }
+                    $gatewayTypeString = $gatewayTypeString.TrimEnd(',') + ']' + [Environment]::NewLine+ '              },'
+                    $alertTemplate = $alertTemplate -replace "##POLICY_GWTYPE##", $gatewayTypeString
+                } else {
+                    $alertTemplate = $alertTemplate -replace "##POLICY_GWTYPE##", ""
+                }
                 if ($alert.properties.dimensions -ne $null) {
                   $dimensionRuleString = $dimensionRuleString + [Environment]::NewLine + '                  ' + '{' +
                        [Environment]::NewLine + '                  ' + '  "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].dimensions[*].name",' +

--- a/tooling/generate-templates/generate-policies.ps1
+++ b/tooling/generate-templates/generate-policies.ps1
@@ -79,6 +79,18 @@ process {
                 } else {
                     $alertTemplate = $alertTemplate -replace "##POLICY_TIER##", ""
                 }
+                if ($alert.PSObject.Properties.Name -contains "gatewayType") {
+                    $gatewayTypeString = [Environment]::NewLine + '          ' + '{' +
+                                  [Environment]::NewLine + '          ' + '  "field": "' + $alert.properties.metricNamespace + '/gatewayType",' +
+                                  [Environment]::NewLine + '          ' + '  "in": ['
+                    foreach ($gatewayType in $alert.gatewayType) {
+                        $gatewayTypeString += '"' + $gatewayType + '",'
+                    }
+                    $gatewayTypeString = $gatewayTypeString.TrimEnd(',') + ']' + [Environment]::NewLine+ '          },'
+                    $alertTemplate = $alertTemplate -replace "##POLICY_GWTYPE##", $gatewayTypeString
+                } else {
+                    $alertTemplate = $alertTemplate -replace "##POLICY_GWTYPE##", ""
+                }
                 if ($alert.properties.dimensions -ne $null) {
                   $dimensionRuleString = $dimensionRuleString + [Environment]::NewLine + '              ' + '{' +
                        [Environment]::NewLine + '              ' + '  "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].dimensions[*].name",' +

--- a/tooling/generate-templates/policy/metric-dynamic-full-arm.json
+++ b/tooling/generate-templates/policy/metric-dynamic-full-arm.json
@@ -178,7 +178,7 @@
               {
                 "field": "type",
                 "equals": "##METRIC_NAMESPACE##"
-              },##POLICY_KIND####POLICY_TIER##
+              },##POLICY_KIND####POLICY_TIER####POLICY_GWTYPE##
               {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"

--- a/tooling/generate-templates/policy/metric-dynamic.json
+++ b/tooling/generate-templates/policy/metric-dynamic.json
@@ -139,7 +139,7 @@
           {
             "field": "type",
             "equals": "##METRIC_NAMESPACE##"
-          },##POLICY_KIND####POLICY_TIER##
+          },##POLICY_KIND####POLICY_TIER####POLICY_GWTYPE##
           {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"

--- a/tooling/generate-templates/policy/metric-static-full-arm.json
+++ b/tooling/generate-templates/policy/metric-static-full-arm.json
@@ -177,7 +177,7 @@
               {
                 "field": "type",
                 "equals": "##METRIC_NAMESPACE##"
-              },##POLICY_KIND####POLICY_TIER##
+              },##POLICY_KIND####POLICY_TIER####POLICY_GWTYPE##
               {
                 "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
                 "notIn": "[[parameters('MonitorDisableTagValues')]"

--- a/tooling/generate-templates/policy/metric-static.json
+++ b/tooling/generate-templates/policy/metric-static.json
@@ -138,7 +138,7 @@
           {
             "field": "type",
             "equals": "##METRIC_NAMESPACE##"
-          },##POLICY_KIND####POLICY_TIER##
+          },##POLICY_KIND####POLICY_TIER####POLICY_GWTYPE##
           {
             "field": "[[concat('tags[', parameters('MonitorDisableTagName'), ']')]",
             "notIn": "[[parameters('MonitorDisableTagValues')]"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Updated policies for type Microsoft.Network/virtualNetworkGateways to distinguish between ExpressRoute and VPN Gateway resources using the "gatewayType" property.  Also updated the descriptions for Microsoft.Network/expressRouteGateways alerts with information that those alerts apply to VWAN ExR GWs.

## This PR fixes/adds/changes/removes

1. *Replace me*
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

### Testing evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).
<img width="542" alt="image" src="https://github.com/user-attachments/assets/f2b90a33-217d-4675-9fff-d1240d96ce95" />
<img width="543" alt="image" src="https://github.com/user-attachments/assets/ef26706d-acfa-44b6-9f79-4c8d285eb5c2" />

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
