### PR TITLE
Fix non-unique HTML IDs in Alert Deployment Tabs

### DIFF
--- a/docs/layouts/partials/templates/template-tabs.html
+++ b/docs/layouts/partials/templates/template-tabs.html
@@ -17,10 +17,10 @@
   <input
     type="radio"
     class="gdoc-tabs__control hidden"
-    name="parentTab"
-    id="tab-mg"
+    name="parentTab-{{ $alert_name}}"
+    id="tab-mg-{{ $alert_name}}"
   />
-  <label for="tab-mg" class="gdoc-tabs__label"><strong>Management Group templates</strong></label>
+  <label for="tab-mg-{{ $alert_name}}" class="gdoc-tabs__label"><strong>Management Group templates</strong></label>
 
   <div class="gdoc-tabs__content">
     <!-- Child tabset: Management Group items -->
@@ -29,10 +29,10 @@
       <input
         type="radio"
         class="nested gdoc-tabs__control hidden"
-        name="parentNestedTab-mg"
-        id="mg-policy"
+        name="parentNestedTab-mg-{{ $alert_name}}"
+        id="mg-policy-{{ $alert_name}}"
       />
-      <label for="mg-policy" class="nested gdoc-tabs__label">Deploy Alert Policy</label>
+      <label for="mg-policy-{{ $alert_name}}" class="nested gdoc-tabs__label">Deploy Alert Policy</label>
 
       <div class="gdoc-markdown--nested gdoc-tabs__content">
         <p>
@@ -51,10 +51,10 @@
   <input
     type="radio"
     class="gdoc-tabs__control hidden"
-    name="parentTab"
-    id="tab-sub"
+    name="parentTab-{{ $alert_name}}"
+    id="tab-sub-{{ $alert_name}}"
   />
-  <label for="tab-sub" class="gdoc-tabs__label"><strong>Subscription templates</strong></label>
+  <label for="tab-sub-{{ $alert_name}}" class="gdoc-tabs__label"><strong>Subscription templates</strong></label>
 
   <div class="gdoc-tabs__content">
     <!-- Child tabset: Subscription items -->
@@ -63,10 +63,10 @@
       <input
         type="radio"
         class="nested gdoc-tabs__control hidden"
-        name="parentNestedTab-sub"
-        id="sub-policy"
+        name="parentNestedTab-sub-{{ $alert_name}}"
+        id="sub-policy-{{ $alert_name}}"
       />
-      <label for="sub-policy" class="nested gdoc-tabs__label">Deploy Alert Policy</label>
+      <label for="sub-policy-{{ $alert_name}}" class="nested gdoc-tabs__label">Deploy Alert Policy</label>
 
       <div class="gdoc-markdown--nested gdoc-tabs__content">
         <p>
@@ -83,10 +83,10 @@
       <input
         type="radio"
         class="nested gdoc-tabs__control hidden"
-        name="parentNestedTab-sub"
-        id="sub-alert"
+        name="parentNestedTab-sub-{{ $alert_name}}"
+        id="sub-alert-{{ $alert_name}}"
       />
-      <label for="sub-alert" class="nested gdoc-tabs__label">Deploy Alert</label>
+      <label for="sub-alert-{{ $alert_name}}" class="nested gdoc-tabs__label">Deploy Alert</label>
 
       <div class="gdoc-markdown--nested gdoc-tabs__content">
         <p>
@@ -103,10 +103,10 @@
       <input
         type="radio"
         class="nested gdoc-tabs__control hidden"
-        name="parentNestedTab-sub"
-        id="sub-policyArm"
+        name="parentNestedTab-sub-{{ $alert_name}}"
+        id="sub-policyArm-{{ $alert_name}}"
       />
-      <label for="sub-policyArm" class="nested gdoc-tabs__label">Alert Policy template - ARM</label>
+      <label for="sub-policyArm-{{ $alert_name}}" class="nested gdoc-tabs__label">Alert Policy template - ARM</label>
 
       <div class="gdoc-markdown--nested gdoc-tabs__content">
         {{ $filename := printf "%s.json" $alert_name | printf "%s"}}
@@ -136,10 +136,10 @@
       <input
         type="radio"
         class="nested gdoc-tabs__control hidden"
-        name="parentNestedTab-sub"
-        id="sub-alertArm"
+        name="parentNestedTab-sub-{{ $alert_name}}"
+        id="sub-alertArm-{{ $alert_name}}"
       />
-      <label for="sub-alertArm" class="nested gdoc-tabs__label">Alert template - ARM</label>
+      <label for="sub-alertArm-{{ $alert_name}}" class="nested gdoc-tabs__label">Alert template - ARM</label>
 
       <div class="gdoc-markdown--nested gdoc-tabs__content">
         {{ $file := path.Join "services" $category $type "templates/arm" $filename }}
@@ -151,10 +151,10 @@
       <input
         type="radio"
         class="nested gdoc-tabs__control hidden"
-        name="parentNestedTab-sub"
-        id="sub-alertBicep"
+        name="parentNestedTab-sub-{{ $alert_name}}"
+        id="sub-alertBicep-{{ $alert_name}}"
       />
-      <label for="sub-alertBicep" class="nested gdoc-tabs__label">Alert template - Bicep</label>
+      <label for="sub-alertBicep-{{ $alert_name}}" class="nested gdoc-tabs__label">Alert template - Bicep</label>
 
       <div class="gdoc-markdown--nested gdoc-tabs__content">
         {{ $filename := printf "%s.bicep" $alert_name | printf "%s"}}


### PR DESCRIPTION
This Pull Request addresses a critical UI bug in the Azure Monitor Baseline Alerts (AMBA) documentation site where deployment buttons and tabs for multiple alerts on the same page were conflicting, causing all clicks to default to the first alert (typically "Availability" in storage accounts).

The current template used hardcoded IDs (e.g., id="tab-mg", id="sub-policy") and names for radio-button-controlled tabs. When multiple alerts are listed on a single service page (like Storage Accounts), the browser identifies duplicate IDs and always triggers the first instance found in the DOM.
This change introduces dynamic IDs and Name scoping by appending the alert_name to all interactive elements, ensuring each alert's deployment section operates independently.
Key Changes
Unique Scoping: Appended {{ aalert_name }} to all id, name, and for attributes within the tab system.

