### PR TITLE
chore: Adjust width to full page

### DIFF
--- a/docs/layouts/partials/head/custom.html
+++ b/docs/layouts/partials/head/custom.html
@@ -5,3 +5,37 @@
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
     })(window, document, "clarity", "script", "jg5llkd8j6");
 </script>
+<link rel="stylesheet" href="{{ " custom.css" | relURL }}">
+<style>
+  /* Override GeekDoc theme for full-width layout */
+  .gdoc-page,
+  .gdoc-page__inner,
+  .gdoc-page__header,
+  .gdoc-page__content,
+  .gdoc-markdown,
+  .gdoc-markdown__inner,
+  .container,
+  .gdoc-container,
+  .gdoc-main {
+    max-width: 100% !important;
+    width: 100% !important;
+  }
+
+  .container,
+  .gdoc-container,
+  .gdoc-page__content {
+    padding-left: 2rem;
+    padding-right: 2rem;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+  }
+
+  .gdoc-markdown table {
+    width: 100%;
+    display: table;
+  }
+
+  .gdoc-markdown pre {
+    max-width: 100%;
+  }
+</style>

--- a/docs/static/custom.css
+++ b/docs/static/custom.css
@@ -1,0 +1,31 @@
+/* Override GeekDoc theme for full-width layout */
+.gdoc-page,
+.gdoc-page__inner,
+.gdoc-page__header,
+.gdoc-page__content,
+.gdoc-markdown,
+.gdoc-markdown__inner,
+.container,
+.gdoc-container,
+.gdoc-main {
+  max-width: 100% !important;
+  width: 100% !important;
+}
+
+.container,
+.gdoc-container,
+.gdoc-page__content {
+  padding-left: 2rem;
+  padding-right: 2rem;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.gdoc-markdown table {
+  width: 100%;
+  display: table;
+}
+
+.gdoc-markdown pre {
+  max-width: 100%;
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

## This PR fixes/adds/changes/removes

This pull request updates the documentation site's layout to use a full-width design by overriding the default GeekDoc theme styles. The changes ensure that all main content areas, tables, and code blocks span the full width of the page, improving the visual presentation and readability.

Layout and style updates:

* Added a new `custom.css` stylesheet and linked it in the site head to override GeekDoc theme styles for a full-width layout across all main content containers and markdown elements. [[1]](diffhunk://#diff-17fb34e088a1cbb7826f9179ffaf7471b88ad26b475808f64e284d60a0431555R8-R41) [[2]](diffhunk://#diff-e9407bb1943fad406fb077f70eaffb27342e58a4bd318eed60a20218177e5c29R1-R31)
* Applied additional inline CSS in `custom.html` to guarantee the full-width layout and consistent padding/margins for containers, tables, and code blocks.

### Breaking Changes

None

### Testing evidence

<img width="2513" height="1285" alt="image" src="https://github.com/user-attachments/assets/69e9fc41-b6a5-4cef-ae92-70e69975985f" />

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
