### PR TITLE
Update AMBA_VERSION to 2025-10-01

### DIFF
--- a/patterns/alz/examples/sample-workflow-whatif.yml
+++ b/patterns/alz/examples/sample-workflow-whatif.yml
@@ -45,7 +45,7 @@ jobs:
             --template-uri https://raw.githubusercontent.com/Azure/azure-monitor-baseline-alerts/${{ env.AMBA_VERSION }}/patterns/alz/alzArm.json \
             --location ${{ env.Location }} \
             --management-group-id ${{ env.ManagementGroupPrefix }} \
-            --parameters ./azure_monitor_baseline_alerts/alzArm.param.json | tee amba-what-if-output.txt
+            --parameters ./azure_monitor_baseline_alerts/alzArm.param.json managementSubscriptionId=${{ env.ARM_SUBSCRIPTION_ID }} | tee amba-what-if-output.txt
 
       - name: Parse What-If Output for Changes
         id: amba_changes


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary
Current version does not contain parameter _policyAssignmentParametersConnectivity_2_. 
As policyAssignmentParametersConnectivity_2 is referenced in the latest _alzArm.json_ file this created a error

## This PR fixes/adds/changes/removes

1. move to the latest version of AMBA
2. Adds ID for Management subscription



### Testing evidence

<img width="1430" height="788" alt="Screenshot 2026-01-11 at 00 00 02" src="https://github.com/user-attachments/assets/dfbe7880-8dae-429c-aea9-90f14998796f" />

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
