### PR TITLE
Updated windowsize on heartbeat alerts (VM and HybridVM) to match docs

### DIFF
--- a/patterns/alz/alzArm.param.json
+++ b/patterns/alz/alzArm.param.json
@@ -1429,7 +1429,7 @@
           "value": "1"
         },
         "HybridVMHeartBeatRGWindowSize": {
-          "value": "PT6H"
+          "value": "PT15M"
         },
         "HybridVMHeartBeatRGEvaluationFrequency": {
           "value": "PT5M"
@@ -2645,7 +2645,7 @@
           "value": "1"
         },
         "VMHeartBeatRGWindowSize": {
-          "value": "PT6H"
+          "value": "PT15M"
         },
         "VMHeartBeatRGEvaluationFrequency": {
           "value": "PT5M"

--- a/patterns/alz/eslzArm.terraform-sync.param.json
+++ b/patterns/alz/eslzArm.terraform-sync.param.json
@@ -1431,7 +1431,7 @@
           "value": "1"
         },
         "HybridVMHeartBeatRGWindowSize": {
-          "value": "PT6H"
+          "value": "PT15M"
         },
         "HybridVMHeartBeatRGEvaluationFrequency": {
           "value": "PT5M"
@@ -2647,7 +2647,7 @@
           "value": "1"
         },
         "VMHeartBeatRGWindowSize": {
-          "value": "PT6H"
+          "value": "PT15M"
         },
         "VMHeartBeatRGEvaluationFrequency": {
           "value": "PT5M"

--- a/patterns/alz/policyDefinitions/policySets.json
+++ b/patterns/alz/policyDefinitions/policySets.json
@@ -219,7 +219,7 @@
           },
           "VMHeartBeatRGWindowSize": {
             "type": "string",
-            "defaultValue": "PT6H",
+            "defaultValue": "PT15M",
             "allowedValues": [
               "PT1M",
               "PT5M",
@@ -8345,7 +8345,7 @@
           },
           "VMHeartBeatRGWindowSize": {
             "type": "string",
-            "defaultValue": "PT6H",
+            "defaultValue": "PT15M",
             "allowedValues": [
               "PT1M",
               "PT5M",

--- a/patterns/alz/policySetDefinitions/Deploy-LandingZone-Alerts.json
+++ b/patterns/alz/policySetDefinitions/Deploy-LandingZone-Alerts.json
@@ -869,7 +869,7 @@
       },
       "VMHeartBeatRGWindowSize": {
         "type": "string",
-        "defaultValue": "PT6H",
+        "defaultValue": "PT15M",
         "allowedValues": [
           "PT1M",
           "PT5M",

--- a/patterns/alz/policySetDefinitions/Deploy-VM-Alerts.json
+++ b/patterns/alz/policySetDefinitions/Deploy-VM-Alerts.json
@@ -102,7 +102,7 @@
       },
       "VMHeartBeatRGWindowSize": {
         "type": "string",
-        "defaultValue": "PT6H",
+        "defaultValue": "PT15M",
         "allowedValues": [
           "PT1M",
           "PT5M",

--- a/patterns/alz4Subs/alzArm4Subs.param.json
+++ b/patterns/alz4Subs/alzArm4Subs.param.json
@@ -1411,7 +1411,7 @@
           "value": "1"
         },
         "HybridVMHeartBeatRGWindowSize": {
-          "value": "PT6H"
+          "value": "PT15M"
         },
         "HybridVMHeartBeatRGEvaluationFrequency": {
           "value": "PT5M"
@@ -2627,7 +2627,7 @@
           "value": "1"
         },
         "VMHeartBeatRGWindowSize": {
-          "value": "PT6H"
+          "value": "PT15M"
         },
         "VMHeartBeatRGEvaluationFrequency": {
           "value": "PT5M"

--- a/patterns/alz4Subs/policyDefinitions/policySets.json
+++ b/patterns/alz4Subs/policyDefinitions/policySets.json
@@ -219,7 +219,7 @@
           },
           "VMHeartBeatRGWindowSize": {
             "type": "string",
-            "defaultValue": "PT6H",
+            "defaultValue": "PT15M",
             "allowedValues": [
               "PT1M",
               "PT5M",
@@ -8345,7 +8345,7 @@
           },
           "VMHeartBeatRGWindowSize": {
             "type": "string",
-            "defaultValue": "PT6H",
+            "defaultValue": "PT15M",
             "allowedValues": [
               "PT1M",
               "PT5M",

--- a/patterns/alz4Subs/policySetDefinitions/Deploy-LandingZone-Alerts.json
+++ b/patterns/alz4Subs/policySetDefinitions/Deploy-LandingZone-Alerts.json
@@ -869,7 +869,7 @@
       },
       "VMHeartBeatRGWindowSize": {
         "type": "string",
-        "defaultValue": "PT6H",
+        "defaultValue": "PT15M",
         "allowedValues": [
           "PT1M",
           "PT5M",

--- a/patterns/alz4Subs/policySetDefinitions/Deploy-VM-Alerts.json
+++ b/patterns/alz4Subs/policySetDefinitions/Deploy-VM-Alerts.json
@@ -102,7 +102,7 @@
       },
       "VMHeartBeatRGWindowSize": {
         "type": "string",
-        "defaultValue": "PT6H",
+        "defaultValue": "PT15M",
         "allowedValues": [
           "PT1M",
           "PT5M",


### PR DESCRIPTION
# Overview/Summary

VMHeartBeat and HybridVMHeartBeat both have documentation stating WindowSize should be PT15M, but actual code is PT6H.
As described in issue #896 

This PR corrects the mismatch and sets values to be compliant to documentation again.

## This PR fixes

#896 

1. `VMHeartBeatRGWindowSize` from `PT6H` to `PT15M`
2. `HybridVMHeartBeatRGWindowSize` from `PT6H` to `PT15M`

### Breaking Changes

None

### Testing evidence

None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
