### PR TITLE
Fix loop condition for management group batching

### DIFF
--- a/patterns/alz/scripts/Start-AMBA-ALZ-Maintenance.ps1
+++ b/patterns/alz/scripts/Start-AMBA-ALZ-Maintenance.ps1
@@ -115,7 +115,7 @@ Function Search-AzGraphRecursive {
   If ($managementGroupNames.count -gt 10) {
     $managementGroupBatches = @()
 
-    For ($i = 0; $i -le $managementGroupNames.count; $i = $i + 10) {
+    For ($i = 0; $i -lt $managementGroupNames.count; $i = $i + 10) {
       $batchGroups = $managementGroupNames[$i..($i + 9)]
       $managementGroupBatches += , @($batchGroups)
 


### PR DESCRIPTION


<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

It's an off-by-one bug in the batching loop that triggers exactly when MG count is a multiple of 10. Trace with count = 50:

i = 0,10,20,30,40 → five batches of 10 ✓
i = 50: condition -le is still true. $managementGroupNames[50..59] is fully out-of-bounds → $batchGroups is empty → an empty array gets appended to $managementGroupBatches Changing line 118 from:
`For ($i = 0; $i -le $managementGroupNames.count; $i = $i + 10) {`

to:
`For ($i = 0; $i -lt $managementGroupNames.count; $i = $i + 10) {`

## This PR fixes/adds/changes/removes

1. #907 

### Breaking Changes

none

### Testing evidence

it didn't work before on exactly 50 management groups, now it does...

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
