### PR TITLE
Update bastion hosts memory threshold

### DIFF
--- a/services/Network/bastionHosts/alerts.yaml
+++ b/services/Network/bastionHosts/alerts.yaml
@@ -52,7 +52,7 @@
     evaluationFrequency: PT5M
     timeAggregation: Average
     operator: GreaterThan
-    threshold: 85
+    threshold: 7089000000
     criterionType: StaticThresholdCriterion
     enabled: true
   references:

--- a/services/Network/bastionHosts/templates/arm/MemoryUsage_2c288e52-422b-4f7e-85cf-feb3d08a1602.json
+++ b/services/Network/bastionHosts/templates/arm/MemoryUsage_2c288e52-422b-4f7e-85cf-feb3d08a1602.json
@@ -73,7 +73,7 @@
     },
     "threshold": {
       "type": "string",
-      "defaultValue": "85",
+      "defaultValue": "7089000000",
       "metadata": {
         "description": "The threshold value at which the alert is activated."
       }

--- a/services/Network/bastionHosts/templates/bicep/MemoryUsage_2c288e52-422b-4f7e-85cf-feb3d08a1602.bicep
+++ b/services/Network/bastionHosts/templates/bicep/MemoryUsage_2c288e52-422b-4f7e-85cf-feb3d08a1602.bicep
@@ -40,7 +40,7 @@ param alertSeverity int = 3
 param operator string = 'GreaterThan'
 
 @description('The threshold value at which the alert is activated.')
-param threshold int = 85
+param threshold int = 7089000000
 
 @description('How the data that is collected should be combined over time.')
 @allowed([

--- a/services/Network/bastionHosts/templates/policy-arm-subscription/MemoryUsage_2c288e52-422b-4f7e-85cf-feb3d08a1602.json
+++ b/services/Network/bastionHosts/templates/policy-arm-subscription/MemoryUsage_2c288e52-422b-4f7e-85cf-feb3d08a1602.json
@@ -135,7 +135,7 @@
               "displayName": "Threshold",
               "description": "Threshold for the alert"
             },
-            "defaultValue": "85"
+            "defaultValue": "7089000000"
           },
           "effect": {
             "type": "String",

--- a/services/Network/bastionHosts/templates/policy-arm/MemoryUsage_2c288e52-422b-4f7e-85cf-feb3d08a1602.json
+++ b/services/Network/bastionHosts/templates/policy-arm/MemoryUsage_2c288e52-422b-4f7e-85cf-feb3d08a1602.json
@@ -135,7 +135,7 @@
               "displayName": "Threshold",
               "description": "Threshold for the alert"
             },
-            "defaultValue": "85"
+            "defaultValue": "7089000000"
           },
           "effect": {
             "type": "String",

--- a/services/Network/bastionHosts/templates/policy/MemoryUsage_2c288e52-422b-4f7e-85cf-feb3d08a1602.json
+++ b/services/Network/bastionHosts/templates/policy/MemoryUsage_2c288e52-422b-4f7e-85cf-feb3d08a1602.json
@@ -96,7 +96,7 @@
           "displayName": "Threshold",
           "description": "Threshold for the alert"
         },
-        "defaultValue": "85"
+        "defaultValue": "7089000000"
       },
       "effect": {
         "type": "String",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary
#909 

Currently the Networks >> bastionHosts >> Memory Usage Threshold is incorrectly set to a percentage value of 85, while it is actually measured in bytes per million (M) or billion (B).

Currently the deployment includes the standard SKU for bastion, this means that 85% of the Total Memory of the standard SKU is equal to 7089000000

So the new Memory Usage Threshold should be 7089000000 instead of 85

## This PR fixes/adds/changes/removes

1. Changes the value of the parameter from a percentage (threshold: 85) to the 85% of the standard SKU Total Memory (threshold: 7089000000)

### Breaking Changes

1. Not applicable

### Testing evidence

https://docs.azure.cn/en-us/bastion/monitor-bastion-reference#memory-usage

**Memory Usage Graphs:**
<img width="1635" height="680" alt="image" src="https://github.com/user-attachments/assets/9f0f84d2-f243-485c-aac0-c403df1f1191" />

## As part of this Pull Request I have 

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azure-monitor-baseline-alerts/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/azure-monitor-baseline-alerts/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azure-monitor-baseline-alerts/)
- [x] Ensured PR tests are passing
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)